### PR TITLE
Install node.js and Yarn via Nix if present.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if command -v nix >& /dev/null; then
+  use nix
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 .env.test.local
 .env.production.local
 
+.direnv
+
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,29 @@
+# This sets up node.js and Yarn.
+#
+# To use, either:
+#   * install Nix and enter a shell by typing `nix-shell`, or
+#   * install Nix and direnv, and type `direnv allow`
+
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
+let
+  nodejs-corepack = stdenv.mkDerivation {
+    name = "nodejs-corepack";
+    buildInputs = [
+      nodejs
+    ];
+    phases = "installPhase";
+    installPhase = ''
+      mkdir -p $out/bin
+      corepack enable --install-directory $out/bin
+    '';
+  };
+in
+mkShell {
+  name = "v3-docs";
+
+  buildInputs = [
+    nodejs
+    nodejs-corepack
+  ];
+}


### PR DESCRIPTION
## Description

I personally use Nix to manage dependencies across projects.

This sets up Nix to install node.js and Yarn (via corepack) whenever I `cd` into this directory.

It can be enabled by installing Nix and direnv, and typing `direnv allow`.

## Quick Links 🚀

 <!-- Add links to the affected pages / sections here for quick review. We'll generate a comment for you after you open the PR with a link to your preview site, which will need to build. -->

## Release

_(Select only one: this is either good-to-go as soon as it's merged, or is tagged to go with a feature in release
`v3.x`)_

<!-- You'll have to choose one of these, otherwise GitHub (and we) will be angry with you 👇 -->

- [x] SHIP IT, YOU FOOLS! 🚢
- [ ] Hold until next release 🛑
<!-- release : end : DO NOT REMOVE -->

### Kodiak commit message

Information used by [Kodiak bot](https://kodiakhq.com/) while merging this PR.

#### Commit title

Same as the title of this pull request

#### Commit body

(Append below if you want to add something to the commit body)

<!-- kodiak-commit-message-body-start: do not remove/edit this line -->
