### PR TITLE
Fix the CI cache by checking out first.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,14 @@
 name: lint the documentation
 on:
+  push:
   pull_request:
 
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: enable corepack
         run: corepack enable yarn
 
@@ -20,8 +23,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - uses: actions/checkout@v3
 
       - name: install dependencies
         run: yarn install


### PR DESCRIPTION
## Description

This speeds up the lint job by fixing the cache.

`yarn config get cacheFolder` doesn't work unless we have checked out the repository and its configuration.

## Quick Links 🚀

 <!-- Add links to the affected pages / sections here for quick review. We'll generate a comment for you after you open the PR with a link to your preview site, which will need to build. -->

## Release

_(Select only one: this is either good-to-go as soon as it's merged, or is tagged to go with a feature in release
`v3.x`)_

<!-- You'll have to choose one of these, otherwise GitHub (and we) will be angry with you 👇 -->

- [x] SHIP IT, YOU FOOLS! 🚢
- [ ] Hold until next release 🛑
<!-- release : end : DO NOT REMOVE -->

### Kodiak commit message

Information used by [Kodiak bot](https://kodiakhq.com/) while merging this PR.

#### Commit title

Same as the title of this pull request

#### Commit body

(Append below if you want to add something to the commit body)

<!-- kodiak-commit-message-body-start: do not remove/edit this line -->
