### PR TITLE
docs: change CLI ref from gh to docs

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -23,7 +23,7 @@ like Builds, our new Metadata structure, and more.
 ## Introduction
 
 This guide allows you to use the Console or the CLI. **If you're using the CLI, you'll need to first install it by
-following [these instructions](https://github.com/hasura/v3-cli#hasura-v3-cli).**
+following [these instructions](/ci-cd/hasura-cli.mdx).**
 
 :::info We're using seed data from the docs sample app
 


### PR DESCRIPTION
<!-- Thank you for submitting this docs PR! 🤙 -->

## Description

As titled; this ref was pointing at the private CLI repo. We now have this information in docs, so we should point to there instead.

## Quick Links 🚀

 <!-- Add links to the affected pages / sections here for quick review. We'll generate a comment for you after you open the PR with a link to your preview site, which will need to build. -->

## Release

_(Select only one: this is either good-to-go as soon as it's merged, or is tagged to go with a feature in release
`v3.x`)_

<!-- You'll have to choose one of these, otherwise GitHub (and we) will be angry with you 👇 -->

- [x] SHIP IT, YOU FOOLS! 🚢
- [ ] Hold until next release 🛑
<!-- release : end : DO NOT REMOVE -->

### Kodiak commit message

Information used by [Kodiak bot](https://kodiakhq.com/) while merging this PR.

#### Commit title

Same as the title of this pull request

#### Commit body

(Append below if you want to add something to the commit body)

<!-- kodiak-commit-message-body-start: do not remove/edit this line -->
