### PR TITLE
docs: update intro language to be more accessible

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -23,24 +23,28 @@ import GraphQL from "@site/static/icons/features/graphql.svg";
 import Beaker from "@site/static/icons/features/beaker-feature.svg";
 import Logo from "@site/static/img/logo.svg";
 
-# Hasura DDN Documentation
+# Hasura v3 Documentation
 
 <div className="gallery">
   <div className="sub-heading">
     <div className="front-matter">
       <p>
-        Welcome to the Hasura DDN Private Alpha Documentation.
+        Welcome to Hasura v3's public beta!
         <br />
         <br />
         We're happy to have you with us and are excited to share what we've been working on.
         <br />
         <br />
-        Hasura DDN is the evolution of Hasura, bringing you lighting-fast builds, a declarative metadata specification,
-        and a brand new set of developer tools to make you more productive than ever.
+        Hasura v3 is a Data Delivery Network (DDN) that provides instant GraphQL APIs on your data. It's a new way to
+        think about building applications and is the fastest way to generate an API on top of your data.
         <br />
         <br />
-        This documentation is a work in progress and we would love your feedback. If you have any suggestions or find any
-        bugs, please use our handy feedback component on each page and reach out.
+        Hasura brings you lighting-fast builds, a declarative metadata specification, and a set of developer tools to make
+        you and your teams more productive than ever.
+        <br />
+        <br />
+        This documentation is a work in progress and we would love your feedback. If you have any suggestions or find
+        any bugs, please use our handy feedback component on each page and reach out.
       </p>
       <div>
         <Logo />
@@ -56,7 +60,7 @@ import Logo from "@site/static/img/logo.svg";
       <h4>Basics</h4>
     </div>
     <p>
-      Here, you can get up and running with Hasura and our new concepts; we'll cover all the basics so you're ready to
+      Here, you can get up and running with Hasura and our core concepts; we'll cover all the basics so you're ready to
       start building.
     </p>
     <VersionedLink to="/basics/overview">
@@ -69,8 +73,8 @@ import Logo from "@site/static/img/logo.svg";
       <h4>Get Started</h4>
     </div>
     <p>
-      Whether you prefer the Console or the CLI, we've got you covered. Learn how to get started with Hasura DDN and
-      deploy a GraphQL API on your data in minutes.
+      Whether you prefer a GUI or the CLI, we've got you covered. Learn how to get started with Hasura and deploy a
+      GraphQL API on your data in minutes.
     </p>
     <VersionedLink to="/quickstart/">
       Deploy your first project <ArrowRight className="arrow" />


### PR DESCRIPTION
## Description

During our exploration of the language for the site, we determined the introductory text on the index was too referential to v2. This is because it _was_ focused on users in the private alpha; as the first release will be broader and more public, we've given the language a treatment that introduces Hasura to all users, not just those who know us.