### PR TITLE
update connection_uris field

### DIFF
--- a/docs/connectors/postgresql.mdx
+++ b/docs/connectors/postgresql.mdx
@@ -59,8 +59,8 @@ username, it will need to be written as `%40`.
 
 The `connection_uris` field can take on two formats:
 
-* A list of database uris, denoting a region-agnostic set read-only servers
-* An object with keys `reads`, and `writes`, each an object where each key maps
+- A list of database uris, denoting a region-agnostic set read-only servers
+- An object with keys `reads`, and `writes`, each an object where each key maps
   a region to a list of database servers.
 
 Example, region agnostic setup:


### PR DESCRIPTION
<!-- Thank you for submitting this docs PR! 🤙 -->

## Description

The format of the ndc-postgres metadata has changed.

The field `postgres_database_url` has been changed to `connection_uris`.

Also document the format of multi-region configuration.

## Quick Links 🚀

 <!-- Add links to the affected pages / sections here for quick review. We'll generate a comment for you after you open the PR with a link to your preview site, which will need to build. -->

## Release

_(Select only one: this is either good-to-go as soon as it's merged, or is tagged to go with a feature in release
`v3.x`)_

<!-- You'll have to choose one of these, otherwise GitHub (and we) will be angry with you 👇 -->

- [x] SHIP IT, YOU FOOLS! 🚢
- [ ] Hold until next release 🛑
<!-- release : end : DO NOT REMOVE -->

### Kodiak commit message

Information used by [Kodiak bot](https://kodiakhq.com/) while merging this PR.

#### Commit title

Same as the title of this pull request

#### Commit body

(Append below if you want to add something to the commit body)

<!-- kodiak-commit-message-body-start: do not remove/edit this line -->
