### PR TITLE
docs: refactor relationships

### DIFF
--- a/docs/data-domain-modeling/relationships.mdx
+++ b/docs/data-domain-modeling/relationships.mdx
@@ -26,7 +26,7 @@ type, a target model and the mapping between the two.
   "kind": "Relationship",
   "source": <String>,
   "name": <String>,
-  "target": <String>,
+  "target": <TargetConfiguration>,
   "mappings": <RelationshipMapping>
 }
 ```
@@ -34,8 +34,33 @@ type, a target model and the mapping between the two.
 | Field      | Type                                            | Required | Description                                                                                      |
 | ---------- | ----------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `source`   | `String`                                        | Yes      | The source [type](./types.mdx) of the relationship.                                              |
-| `target`   | `String`                                        | Yes      | The target of the relationship.                                                                  |
+| `target`   | [`TargetConfiguration`](#targetconfiguration)   | Yes      | The target of the relationship.                                                                  |
 | `mappings` | [`[RelationshipMapping]`](#relationshipmapping) | Yes      | Defines how the `Source` and `Target` should be connected. This field expects a list of objects. |
+
+#### TargetConfiguration:
+
+```json
+{
+  "modelName": <String>,
+  "relationshipType": <RelationshipType>
+}
+```
+
+| Field              | Type                                    | Required | Description                                               |
+| ------------------ | --------------------------------------- | -------- | --------------------------------------------------------- |
+| `modelName`        | `String`                                | Yes      | The target [model](./models.mdx) of the relationship.     |
+| `relationshipType` | [`RelationshipType`](#relationshiptype) | Yes      | The type of the relationship: either `Object` or `Array`. |
+
+#### RelationshipType:
+
+```json
+"Object" | "Array"
+```
+
+| Value    | Description                                     |
+| -------- | ----------------------------------------------- |
+| `Object` | The relationship is a one-to-one relationship.  |
+| `Array`  | The relationship is a one-to-many relationship. |
 
 #### RelationshipMapping:
 


### PR DESCRIPTION
## Description

This PR is an attempt to refactor the Relationships page of Data Domain Modeling to be more consistent with other pages in the section. Notably, it utilizes tables instead of ordered lists for describing the metadata structure and also attempts to create a breadcrumb as we move from broader concepts to more narrow and specific sets of nested metadata.

[DOCS-1394](https://hasurahq.atlassian.net/browse/DOCS-1394)

[DOCS-1394]: https://hasurahq.atlassian.net/browse/DOCS-1394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ