### PR TITLE
docs: refactor opendd types

### DIFF
--- a/docs/data-domain-modeling/types.mdx
+++ b/docs/data-domain-modeling/types.mdx
@@ -21,8 +21,6 @@ separately from the types in your data source.
 The specification employs a concrete type system that includes both primitive types and user-defined types. All
 subsequent layers, such as models, commands, and relationships are defined in terms of these types.
 
-[//]: # "Link out above para"
-
 The types can be one of the following:
 
 | OpenDD Type | Description                                                             |
@@ -49,6 +47,8 @@ primitive, container or custom types.
 Primitive types don't have any metadata structure and simply use the names `Int` / `Float` / `Boolean` / `String`
 directly.
 
+### Metadata structure
+
 Container types are defined as:
 
 ```json
@@ -66,6 +66,24 @@ Container types are defined as:
 | Value  | Description                                                                            |
 | ------ | -------------------------------------------------------------------------------------- |
 | `Type` | String in case of primitive or custom types. An object in the case of container types. |
+
+### Examples
+
+Examples of container types:
+
+```json
+{
+  "name": "category",
+  "type": { "Nullable": "ProductCategory" }
+}
+```
+
+```json
+{
+  "name": "tags",
+  "type": { "Array": "String" }
+}
+```
 
 ## Scalar types
 


### PR DESCRIPTION
## Description

This PR refactors the `Primitive and container types` section of the `Types` page to reflect the same structure as other types and other docs in this section. It adds  `Metadata structure` and `Examples` headings.

[DOCS-1395](https://hasurahq.atlassian.net/browse/DOCS-1395)

TODO:
- [x] Confirm the accuracy of the `Nullable` and `Array` examples as Container types

[DOCS-1395]: https://hasurahq.atlassian.net/browse/DOCS-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ