### PR TITLE
update filter titles to match v2

### DIFF
--- a/docs/graphql-api/postgresql-queries/filters/boolean-operators.mdx
+++ b/docs/graphql-api/postgresql-queries/filters/boolean-operators.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import GraphiQLIDE from "@site/src/components/GraphiQLIDE";
 
-# PostgreSQL: Filter Boolean operators
+# PostgreSQL: Filter by Boolean Expressions
 
 ## Filter based on failure of some criteria (\_not)
 

--- a/docs/graphql-api/postgresql-queries/filters/comparison-operators.mdx
+++ b/docs/graphql-api/postgresql-queries/filters/comparison-operators.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import GraphiQLIDE from "@site/src/components/GraphiQLIDE";
 
-# PostgreSQL: Filter Simple Comparison operators
+# PostgreSQL: Filter by Comparing Values
 
 ## Introduction
 

--- a/docs/graphql-api/postgresql-queries/filters/nested-objects.mdx
+++ b/docs/graphql-api/postgresql-queries/filters/nested-objects.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import GraphiQLIDE from "@site/src/components/GraphiQLIDE";
 
-# PostgreSQL: Filter based on Nested objects' fields
+# PostgreSQL: Filter Based on Fields of Nested Objects
 
 ## Introduction
 

--- a/docs/graphql-api/postgresql-queries/filters/text-search-operators.mdx
+++ b/docs/graphql-api/postgresql-queries/filters/text-search-operators.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import GraphiQLIDE from "@site/src/components/GraphiQLIDE";
 
-# PostgreSQL: Filter Text search operators
+# PostgreSQL: Filter by Text
 
 ## Introduction
 


### PR DESCRIPTION
## Description

This PR creates parity between title pages in v2 and v3 for query filters.

## Quick Links 🚀
- [Boolean](https://rob-docs-update-filter-title.v3-docs-eny.pages.dev/latest/graphql-api/postgresql-queries/filters/boolean-operators/)
- [Comparison](https://rob-docs-update-filter-title.v3-docs-eny.pages.dev/latest/graphql-api/postgresql-queries/filters/comparison-operators/)
- [Nested](https://rob-docs-update-filter-title.v3-docs-eny.pages.dev/latest/graphql-api/postgresql-queries/filters/nested-objects/)
- [Text search](https://rob-docs-update-filter-title.v3-docs-eny.pages.dev/latest/graphql-api/postgresql-queries/filters/text-search-operators/)
