### PR TITLE
add note for auth config requirements

### DIFF
--- a/docs/authentication/auth-config.mdx
+++ b/docs/authentication/auth-config.mdx
@@ -20,6 +20,8 @@ This document details the `AuthConfig` metadata object used to set up authentica
 
 ## Auth Config {#auth-config}
 
+Only a single `AuthConfig` object can be defined in the metadata. It has the following structure:
+
 | Field                   | Type   | Required | Description                                                                                                              |
 | ----------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `allowRoleEmulationFor` | String | false    | Name of the role which allows role emulation. Read more about role emulation [here](/authentication/role-emulation.mdx). |


### PR DESCRIPTION
## Description

This PR adds clarity that only a single `AuthConfig` object can be added in metadata.

## Quick Links 🚀
- [AuthConfig](https://rob-docs-add-note-for-auth-c.v3-docs-eny.pages.dev/latest/authentication/auth-config/)
