### PR TITLE
docs: port the CLI docs

### DIFF
--- a/docs/ci-cd/cli/_category_.json
+++ b/docs/ci-cd/cli/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Hasura CLI",
+  "position": 1
+}

--- a/docs/ci-cd/cli/commands/_category_.json
+++ b/docs/ci-cd/cli/commands/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Commands",
+  "position": 2
+}
+

--- a/docs/ci-cd/cli/commands/cloud-build-apply.mdx
+++ b/docs/ci-cd/cli/commands/cloud-build-apply.mdx
@@ -1,0 +1,27 @@
+---
+title: hasura3 cloud build apply
+sidebar_position: 13
+sidebar_label: hasura3 cloud build apply
+description: Using the hasura3 cloud build apply command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud build apply 
+
+## Synopsis
+Apply metadata to a Hasura Project.
+
+```bash
+$ hasura3 cloud build apply --help
+Apply metadata to a Hasura Project
+
+Usage: hasura3 cloud build apply [OPTIONS] --project-id <project-id> --build-id <build-id>
+
+Options:
+  -p, --project-id <project-id>  Your Hasura Cloud Project ID
+  -b, --build-id <build-id>      ID of the Build you want to apply to your Project
+      --log-level <log-level>    The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                                 [possible values: error, warn, info, debug, trace, error-all,
+                                 warn-all, info-all, debug-all, trace-all]
+  -h, --help                     Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-build-create.mdx
+++ b/docs/ci-cd/cli/commands/cloud-build-create.mdx
@@ -1,0 +1,30 @@
+---
+title: hasura3 cloud build create
+sidebar_position: 14
+sidebar_label: hasura3 cloud build create
+description: Using the hasura3 cloud build create command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud build create 
+
+## Synopsis
+Create a build.
+
+```bash
+$ hasura3 cloud build create --help
+Create a build
+
+Usage: hasura3 cloud build create [OPTIONS] --metadata-file <metadata_file> <--project-id <project_id>|--dry-run>
+
+Options:
+  -p, --project-id <project_id>        Your Hasura Cloud Project ID
+  -m, --metadata-file <metadata_file>  Path to your Hasura Metadata file
+      --dry-run                        Dry run the command, and output the metadata. This does not
+                                       require you to be logged in, and project id is not verified
+      --log-level <log-level>          The log level to be printed in stdout [env:
+                                       HASURA_CLI_LOG_LEVEL=] [possible values: error, warn, info,
+                                       debug, trace, error-all, warn-all, info-all, debug-all,
+                                       trace-all]
+  -h, --help                           Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-build-list.mdx
+++ b/docs/ci-cd/cli/commands/cloud-build-list.mdx
@@ -1,0 +1,26 @@
+---
+title: hasura3 cloud build list
+sidebar_position: 15
+sidebar_label: hasura3 cloud build list
+description: Using the hasura3 cloud build list command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud build list 
+
+## Synopsis
+List all builds of Hasura Project.
+
+```bash
+$ hasura3 cloud build list --help
+List all builds of Hasura Project
+
+Usage: hasura3 cloud build list [OPTIONS] --project-id <project_id>
+
+Options:
+  -p, --project-id <project_id>  Your Hasura Cloud Project ID
+      --log-level <log-level>    The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                                 [possible values: error, warn, info, debug, trace, error-all,
+                                 warn-all, info-all, debug-all, trace-all]
+  -h, --help                     Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-build-remove.mdx
+++ b/docs/ci-cd/cli/commands/cloud-build-remove.mdx
@@ -1,0 +1,28 @@
+---
+title: hasura3 cloud build remove
+sidebar_position: 16
+sidebar_label: hasura3 cloud build remove
+description: Using the hasura3 cloud build remove command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud build remove 
+
+## Synopsis
+Remove a project from Hasura Cloud.
+
+```bash
+$ hasura3 cloud build remove --help
+Remove a project from Hasura Cloud
+
+Usage: hasura3 cloud build remove [OPTIONS] --project-id <project id> --build-version <build version>
+
+Options:
+  -p, --project-id <project id>        
+  -v, --build-version <build version>  
+      --log-level <log-level>          The log level to be printed in stdout [env:
+                                       HASURA_CLI_LOG_LEVEL=] [possible values: error, warn, info,
+                                       debug, trace, error-all, warn-all, info-all, debug-all,
+                                       trace-all]
+  -h, --help                           Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-build.mdx
+++ b/docs/ci-cd/cli/commands/cloud-build.mdx
@@ -1,0 +1,32 @@
+---
+title: hasura3 cloud build
+sidebar_position: 12
+sidebar_label: hasura3 cloud build
+description: Using the hasura3 cloud build command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud build 
+
+## Synopsis
+Build a Hasura Project.
+
+```bash
+$ hasura3 cloud build --help
+Build a Hasura Project
+
+Usage: hasura3 cloud build [OPTIONS] [COMMAND]
+
+Commands:
+  apply   Apply metadata to a Hasura Project
+  create  Create a build
+  list    List all builds of Hasura Project [aliases: ls]
+  remove  Remove a project from Hasura Cloud [aliases: delete, rm]
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-login.mdx
+++ b/docs/ci-cd/cli/commands/cloud-login.mdx
@@ -1,0 +1,28 @@
+---
+title: hasura3 cloud login
+sidebar_position: 27
+sidebar_label: hasura3 cloud login
+description: Using the hasura3 cloud login command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud login 
+
+## Synopsis
+Login into Hasura Cloud using a Personal Access Token.
+
+```bash
+$ hasura3 cloud login --help
+Login into Hasura Cloud using a Personal Access Token
+
+Usage: hasura3 cloud login [OPTIONS] --pat <personal-access-token>
+
+Options:
+      --pat <personal-access-token>  Your Hasura Cloud login token [env:
+                                     HASURA_DDN_PERSONAL_ACCESS_TOKEN=]
+      --log-level <log-level>        The log level to be printed in stdout [env:
+                                     HASURA_CLI_LOG_LEVEL=] [possible values: error, warn, info,
+                                     debug, trace, error-all, warn-all, info-all, debug-all,
+                                     trace-all]
+  -h, --help                         Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-logout.mdx
+++ b/docs/ci-cd/cli/commands/cloud-logout.mdx
@@ -1,0 +1,25 @@
+---
+title: hasura3 cloud logout
+sidebar_position: 28
+sidebar_label: hasura3 cloud logout
+description: Using the hasura3 cloud logout command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud logout 
+
+## Synopsis
+Logout from Hasura Cloud.
+
+```bash
+$ hasura3 cloud logout --help
+Logout from Hasura Cloud
+
+Usage: hasura3 cloud logout [OPTIONS]
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-project-create.mdx
+++ b/docs/ci-cd/cli/commands/cloud-project-create.mdx
@@ -1,0 +1,25 @@
+---
+title: hasura3 cloud project create
+sidebar_position: 9
+sidebar_label: hasura3 cloud project create
+description: Using the hasura3 cloud project create command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud project create 
+
+## Synopsis
+Create a new project in Hasura Cloud.
+
+```bash
+$ hasura3 cloud project create --help
+Create a new project in Hasura Cloud
+
+Usage: hasura3 cloud project create [OPTIONS]
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-project-details.mdx
+++ b/docs/ci-cd/cli/commands/cloud-project-details.mdx
@@ -1,0 +1,26 @@
+---
+title: hasura3 cloud project details
+sidebar_position: 10
+sidebar_label: hasura3 cloud project details
+description: Using the hasura3 cloud project details command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud project details 
+
+## Synopsis
+View project details.
+
+```bash
+$ hasura3 cloud project details --help
+View project details
+
+Usage: hasura3 cloud project details [OPTIONS] --project-id <project id>
+
+Options:
+  -p, --project-id <project id>  
+      --log-level <log-level>    The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                                 [possible values: error, warn, info, debug, trace, error-all,
+                                 warn-all, info-all, debug-all, trace-all]
+  -h, --help                     Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-project-list.mdx
+++ b/docs/ci-cd/cli/commands/cloud-project-list.mdx
@@ -1,0 +1,25 @@
+---
+title: hasura3 cloud project list
+sidebar_position: 8
+sidebar_label: hasura3 cloud project list
+description: Using the hasura3 cloud project list command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud project list 
+
+## Synopsis
+View a list of your projects on Hasura Cloud.
+
+```bash
+$ hasura3 cloud project list --help
+View a list of your projects on Hasura Cloud
+
+Usage: hasura3 cloud project list [OPTIONS]
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-project-remove.mdx
+++ b/docs/ci-cd/cli/commands/cloud-project-remove.mdx
@@ -1,0 +1,26 @@
+---
+title: hasura3 cloud project remove
+sidebar_position: 11
+sidebar_label: hasura3 cloud project remove
+description: Using the hasura3 cloud project remove command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud project remove 
+
+## Synopsis
+Delete a project from Hasura Cloud.
+
+```bash
+$ hasura3 cloud project remove --help
+Delete a project from Hasura Cloud
+
+Usage: hasura3 cloud project remove [OPTIONS] --project-id <project id>
+
+Options:
+  -p, --project-id <project id>  
+      --log-level <log-level>    The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                                 [possible values: error, warn, info, debug, trace, error-all,
+                                 warn-all, info-all, debug-all, trace-all]
+  -h, --help                     Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-project.mdx
+++ b/docs/ci-cd/cli/commands/cloud-project.mdx
@@ -1,0 +1,32 @@
+---
+title: hasura3 cloud project
+sidebar_position: 7
+sidebar_label: hasura3 cloud project
+description: Using the hasura3 cloud project command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud project 
+
+## Synopsis
+Projects Ops.
+
+```bash
+$ hasura3 cloud project --help
+Projects Ops
+
+Usage: hasura3 cloud project [OPTIONS] [COMMAND]
+
+Commands:
+  list     View a list of your projects on Hasura Cloud [aliases: ls]
+  create   Create a new project in Hasura Cloud
+  details  View project details
+  remove   Delete a project from Hasura Cloud [aliases: delete, rm]
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-secret-delete.mdx
+++ b/docs/ci-cd/cli/commands/cloud-secret-delete.mdx
@@ -1,0 +1,29 @@
+---
+title: hasura3 cloud secret delete
+sidebar_position: 26
+sidebar_label: hasura3 cloud secret delete
+description: Using the hasura3 cloud secret delete command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud secret delete 
+
+## Synopsis
+Delete a secret.
+
+```bash
+$ hasura3 cloud secret delete --help
+Delete a secret
+
+Usage: hasura3 cloud secret delete [OPTIONS] --project-id <project-id> <secret key>
+
+Arguments:
+  <secret key>  Key of secret to be deleted
+
+Options:
+  -p, --project-id <project-id>  Your Hasura Cloud Project ID
+      --log-level <log-level>    The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                                 [possible values: error, warn, info, debug, trace, error-all,
+                                 warn-all, info-all, debug-all, trace-all]
+  -h, --help                     Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-secret-list.mdx
+++ b/docs/ci-cd/cli/commands/cloud-secret-list.mdx
@@ -1,0 +1,26 @@
+---
+title: hasura3 cloud secret list
+sidebar_position: 24
+sidebar_label: hasura3 cloud secret list
+description: Using the hasura3 cloud secret list command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud secret list 
+
+## Synopsis
+List all secrets.
+
+```bash
+$ hasura3 cloud secret list --help
+List all secrets
+
+Usage: hasura3 cloud secret list [OPTIONS] --project-id <project-id>
+
+Options:
+  -p, --project-id <project-id>  Your Hasura Cloud Project ID
+      --log-level <log-level>    The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                                 [possible values: error, warn, info, debug, trace, error-all,
+                                 warn-all, info-all, debug-all, trace-all]
+  -h, --help                     Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-secret-set.mdx
+++ b/docs/ci-cd/cli/commands/cloud-secret-set.mdx
@@ -1,0 +1,29 @@
+---
+title: hasura3 cloud secret set
+sidebar_position: 25
+sidebar_label: hasura3 cloud secret set
+description: Using the hasura3 cloud secret set command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud secret set 
+
+## Synopsis
+Set a secret. Pass the secret in the format KEY=VALUE.
+
+```bash
+$ hasura3 cloud secret set --help
+Set a secret. Pass the secret in the format KEY=VALUE
+
+Usage: hasura3 cloud secret set [OPTIONS] --project-id <project-id> <secret>
+
+Arguments:
+  <secret>  Secret you wnat to set. Use the format KEY=VALUE
+
+Options:
+  -p, --project-id <project-id>  Your Hasura Cloud Project ID
+      --log-level <log-level>    The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                                 [possible values: error, warn, info, debug, trace, error-all,
+                                 warn-all, info-all, debug-all, trace-all]
+  -h, --help                     Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-secret.mdx
+++ b/docs/ci-cd/cli/commands/cloud-secret.mdx
@@ -1,0 +1,31 @@
+---
+title: hasura3 cloud secret
+sidebar_position: 23
+sidebar_label: hasura3 cloud secret
+description: Using the hasura3 cloud secret command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud secret 
+
+## Synopsis
+Commands related to Hasura Cloud Secret Ops.
+
+```bash
+$ hasura3 cloud secret --help
+Commands related to Hasura Cloud Secret Ops
+
+Usage: hasura3 cloud secret [OPTIONS] [COMMAND]
+
+Commands:
+  list    List all secrets [aliases: ls]
+  set     Set a secret. Pass the secret in the format KEY=VALUE
+  delete  Delete a secret
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-tunnel-activate.mdx
+++ b/docs/ci-cd/cli/commands/cloud-tunnel-activate.mdx
@@ -1,0 +1,28 @@
+---
+title: hasura3 cloud tunnel activate
+sidebar_position: 20
+sidebar_label: hasura3 cloud tunnel activate
+description: Using the hasura3 cloud tunnel activate command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud tunnel activate 
+
+## Synopsis
+Restart a paused tunnel.
+
+```bash
+$ hasura3 cloud tunnel activate --help
+Restart a paused tunnel
+
+Usage: hasura3 cloud tunnel activate [OPTIONS] <socket>
+
+Arguments:
+  <socket>  
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-tunnel-create.mdx
+++ b/docs/ci-cd/cli/commands/cloud-tunnel-create.mdx
@@ -1,0 +1,28 @@
+---
+title: hasura3 cloud tunnel create
+sidebar_position: 19
+sidebar_label: hasura3 cloud tunnel create
+description: Using the hasura3 cloud tunnel create command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud tunnel create 
+
+## Synopsis
+Create a new tunnel.
+
+```bash
+$ hasura3 cloud tunnel create --help
+Create a new tunnel
+
+Usage: hasura3 cloud tunnel create [OPTIONS] <socket>
+
+Arguments:
+  <socket>  
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-tunnel-delete.mdx
+++ b/docs/ci-cd/cli/commands/cloud-tunnel-delete.mdx
@@ -1,0 +1,28 @@
+---
+title: hasura3 cloud tunnel delete
+sidebar_position: 22
+sidebar_label: hasura3 cloud tunnel delete
+description: Using the hasura3 cloud tunnel delete command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud tunnel delete 
+
+## Synopsis
+Delete/remove a tunnel.
+
+```bash
+$ hasura3 cloud tunnel delete --help
+Delete/remove a tunnel
+
+Usage: hasura3 cloud tunnel delete [OPTIONS] <socket>
+
+Arguments:
+  <socket>  
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-tunnel-list.mdx
+++ b/docs/ci-cd/cli/commands/cloud-tunnel-list.mdx
@@ -1,0 +1,25 @@
+---
+title: hasura3 cloud tunnel list
+sidebar_position: 18
+sidebar_label: hasura3 cloud tunnel list
+description: Using the hasura3 cloud tunnel list command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud tunnel list 
+
+## Synopsis
+List tunnels.
+
+```bash
+$ hasura3 cloud tunnel list --help
+List tunnels
+
+Usage: hasura3 cloud tunnel list [OPTIONS]
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-tunnel-pause.mdx
+++ b/docs/ci-cd/cli/commands/cloud-tunnel-pause.mdx
@@ -1,0 +1,28 @@
+---
+title: hasura3 cloud tunnel pause
+sidebar_position: 21
+sidebar_label: hasura3 cloud tunnel pause
+description: Using the hasura3 cloud tunnel pause command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud tunnel pause 
+
+## Synopsis
+Pause an active tunnel.
+
+```bash
+$ hasura3 cloud tunnel pause --help
+Pause an active tunnel
+
+Usage: hasura3 cloud tunnel pause [OPTIONS] <socket>
+
+Arguments:
+  <socket>  
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud-tunnel.mdx
+++ b/docs/ci-cd/cli/commands/cloud-tunnel.mdx
@@ -1,0 +1,33 @@
+---
+title: hasura3 cloud tunnel
+sidebar_position: 17
+sidebar_label: hasura3 cloud tunnel
+description: Using the hasura3 cloud tunnel command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud tunnel 
+
+## Synopsis
+Hasura Secure Connect service.
+
+```bash
+$ hasura3 cloud tunnel --help
+Hasura Secure Connect service
+
+Usage: hasura3 cloud tunnel [OPTIONS] <COMMAND>
+
+Commands:
+  list      List tunnels [aliases: ls]
+  create    Create a new tunnel
+  activate  Restart a paused tunnel
+  pause     Pause an active tunnel
+  delete    Delete/remove a tunnel
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/cloud.mdx
+++ b/docs/ci-cd/cli/commands/cloud.mdx
@@ -1,0 +1,34 @@
+---
+title: hasura3 cloud
+sidebar_position: 6
+sidebar_label: hasura3 cloud
+description: Using the hasura3 cloud command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 cloud 
+
+## Synopsis
+Commands related to Hasura Cloud Ops.
+
+```bash
+$ hasura3 cloud --help
+Commands related to Hasura Cloud Ops
+
+Usage: hasura3 cloud [OPTIONS] [COMMAND]
+
+Commands:
+  project  Projects Ops [aliases: projects]
+  build    Build a Hasura Project [aliases: builds]
+  tunnel   Hasura Secure Connect service [aliases: tunnels]
+  secret   Commands related to Hasura Cloud Secret Ops [aliases: secrets]
+  login    Login into Hasura Cloud using a Personal Access Token
+  logout   Logout from Hasura Cloud
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/index.mdx
+++ b/docs/ci-cd/cli/commands/index.mdx
@@ -1,0 +1,31 @@
+---
+title: hasura3
+sidebar_position: 1
+sidebar_label: hasura3
+description: Using the hasura3  command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3
+
+## Synopsis
+
+Usage: hasura3 [OPTIONS] [COMMAND].
+
+```bash
+$ hasura3  --help
+Usage: hasura3 [OPTIONS] [COMMAND]
+
+Commands:
+  local   Commands related to local Hasura Ops
+  cloud   Commands related to Hasura Cloud Ops
+  cli     Hasura CLI ops
+  plugin  Commands related to CLI Plugins [aliases: plugins]
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+  -V, --version                Print version
+```

--- a/docs/ci-cd/cli/commands/local-daemon-start.mdx
+++ b/docs/ci-cd/cli/commands/local-daemon-start.mdx
@@ -1,0 +1,26 @@
+---
+title: hasura3 local daemon start
+sidebar_position: 5
+sidebar_label: hasura3 local daemon start
+description: Using the hasura3 local daemon start command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 local daemon start 
+
+## Synopsis
+Start Hasura Secure Connect Daemon.
+
+```bash
+$ hasura3 local daemon start --help
+Start Hasura Secure Connect Daemon
+
+Usage: hasura3 local daemon start [OPTIONS]
+
+Options:
+      --port <TCP Port>        The TCP Port on which the Secure Connect Tunnel Daemon will run
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/local-daemon.mdx
+++ b/docs/ci-cd/cli/commands/local-daemon.mdx
@@ -1,0 +1,29 @@
+---
+title: hasura3 local daemon
+sidebar_position: 4
+sidebar_label: hasura3 local daemon
+description: Using the hasura3 local daemon command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 local daemon 
+
+## Synopsis
+Commands related to Hasura Secure Connect Tunnel Daemon.
+
+```bash
+$ hasura3 local daemon --help
+Commands related to Hasura Secure Connect Tunnel Daemon
+
+Usage: hasura3 local daemon [OPTIONS] [COMMAND]
+
+Commands:
+  start  Start Hasura Secure Connect Daemon
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/local-init.mdx
+++ b/docs/ci-cd/cli/commands/local-init.mdx
@@ -1,0 +1,27 @@
+---
+title: hasura3 local init
+sidebar_position: 3
+sidebar_label: hasura3 local init
+description: Using the hasura3 local init command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 local init 
+
+## Synopsis
+Create a new Hasura Project and initialise with a Metadata file..
+
+```bash
+$ hasura3 local init --help
+Create a new Hasura Project and initialise with a Metadata file.
+
+Usage: hasura3 local init [OPTIONS] --dir <Project Directory>
+
+Options:
+  -d, --dir <Project Directory>  Directory where the project should be created
+      --json                     Create a JSON file for metadata instead of a YAML file
+      --log-level <log-level>    The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                                 [possible values: error, warn, info, debug, trace, error-all,
+                                 warn-all, info-all, debug-all, trace-all]
+  -h, --help                     Print help
+```
+

--- a/docs/ci-cd/cli/commands/local.mdx
+++ b/docs/ci-cd/cli/commands/local.mdx
@@ -1,0 +1,30 @@
+---
+title: hasura3 local
+sidebar_position: 2
+sidebar_label: hasura3 local
+description: Using the hasura3 local command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 local 
+
+## Synopsis
+Commands related to local Hasura Ops.
+
+```bash
+$ hasura3 local --help
+Commands related to local Hasura Ops
+
+Usage: hasura3 local [OPTIONS] [COMMAND]
+
+Commands:
+  init    Create a new Hasura Project and initialise with a Metadata file.
+  daemon  Commands related to Hasura Secure Connect Tunnel Daemon
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/commands/plugin.mdx
+++ b/docs/ci-cd/cli/commands/plugin.mdx
@@ -1,0 +1,28 @@
+---
+title: hasura3 plugin
+sidebar_position: 29
+sidebar_label: hasura3 plugin
+description: Using the hasura3 plugin command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 plugin 
+
+## Synopsis
+Commands related to CLI Plugins.
+
+```bash
+$ hasura3 plugin --help
+Commands related to CLI Plugins
+
+Usage: hasura3 plugin [OPTIONS] [command]...
+
+Arguments:
+  [command]...  
+
+Options:
+      --log-level <log-level>  The log level to be printed in stdout [env: HASURA_CLI_LOG_LEVEL=]
+                               [possible values: error, warn, info, debug, trace, error-all,
+                               warn-all, info-all, debug-all, trace-all]
+  -h, --help                   Print help
+```
+

--- a/docs/ci-cd/cli/index.mdx
+++ b/docs/ci-cd/cli/index.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_position: 1
+sidebar_label: Introduction
+description: Hasura CLI
+keywords:
+  - hasura
+  - graphql
+  - CI/CD
+  - CLI
+---
+
+# Introduction
+
+This directory contains information on the new Hasura CLI. The new CLI has been re-written from the ground up to be more
+intuitive and easier to use. It allows you to completely manage your Hasura projects from the command line.
+
+## Next steps
+
+- [Install the CLI](/ci-cd/cli/installation.mdx)
+- [See the commands](/ci-cd/cli/commands/index.mdx)
+- [Quickstart using the CLI](/getting-started/local-dev.mdx)

--- a/docs/ci-cd/cli/installation.mdx
+++ b/docs/ci-cd/cli/installation.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-sidebar_label: Hasura CLI
+sidebar_label: Installation
 description: Hasura Command Line Interface (CLI)
 keywords:
   - hasura
@@ -11,13 +11,11 @@ keywords:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# Hasura CLI
-
-## Installation
+# Installation
 
 You can download the CLI binaries below and start using it immediately. Please follow the instructions for your system.
 
-### Install instructions for Linux/Macs
+## Install instructions for Linux/Macs
 
 <Tabs groupId="os-preference" className="api-tabs">
 
@@ -90,7 +88,7 @@ wget https://graphql-engine-cdn.hasura.io/ddn/cli/v2023.08.10-internal/hasura3_x
 </TabItem>
 </Tabs>
 
-### Install instructions for Windows:
+## Install instructions for Windows
 
 1. Download
    [`hasura3_x86_64-pc-windows-gnu.exe` binary](https://graphql-engine-cdn.hasura.io/ddn/cli/v2023.08.10-internal/hasura3_x86_64-pc-windows-gnu.exe)
@@ -110,7 +108,7 @@ In Windows, if you get an "Unrecognized application" warning, click "Run anyway"
 
 :::
 
-### Verify Installation
+## Verify Installation
 
 Running `hasura3` should print the following message:
 

--- a/docs/ci-cd/overview.mdx
+++ b/docs/ci-cd/overview.mdx
@@ -42,19 +42,19 @@ import VersionedLink from "@site/src/components/VersionedLink";
 </div>
 
 <div className="overview-gallery">
-  <VersionedLink to="/ci-cd/hasura-cli/#install-instructions-for-linuxmacs">
+  <VersionedLink to="/ci-cd/cli/installation/#install-instructions-for-linuxmacs">
     <div className="card">
       <h3>Install the CLI for macOS</h3>
       <p>Click here to learn how to install the CLI.</p>
     </div>
   </VersionedLink>
-  <VersionedLink to="/ci-cd/hasura-cli/#install-instructions-for-linuxmacs">
+  <VersionedLink to="/ci-cd/cli/installation/#install-instructions-for-linuxmacs">
     <div className="card">
       <h3>Install the CLI for Linux</h3>
       <p>Click here to learn how to install the CLI.</p>
     </div>
   </VersionedLink>
-  <VersionedLink to="/ci-cd/hasura-cli/#install-instructions-for-windows">
+  <VersionedLink to="/ci-cd/cli/installation/#install-instructions-for-windows">
     <div className="card">
       <h3>Install the CLI for Windows</h3>
       <p>Click here to learn how to install the CLI.</p>

--- a/docs/getting-started/local-dev.mdx
+++ b/docs/getting-started/local-dev.mdx
@@ -24,7 +24,7 @@ guide, you'll be introduced to new Hasura concepts, like builds, our new metadat
 
 :::tip Prerequisites
 
-1. The [new Hasura CLI](/ci-cd/hasura-cli.mdx)
+1. The [new Hasura CLI](/ci-cd/cli/index.mdx)
 2. The [Hasura VS Code extension](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura)
 3. A PostgreSQL database
 
@@ -105,13 +105,13 @@ connectorConfiguration:
   connection_uris:
 ```
 
-| Field                    | Description                                                                             |
-| ------------------------ | --------------------------------------------------------------------------------------- |
-| `name`                   | The name of your data source. Put `default` for now.                                    |
-| `connectorId`            | The ID of the connector you want to use. In this example, we'll use `hasura/postgres`.  |
-| `connectorConfiguration` | The configuration for your connector, made up of `version` and `connection_uris`. |
-| `version`                | The version of your connector. Put `1` for now.                                         |
-| `connection_uris`        | The connection string for your database. Add your database's connection string.         |
+| Field                    | Description                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------- |
+| `name`                   | The name of your data source. Put `default` for now.                                   |
+| `connectorId`            | The ID of the connector you want to use. In this example, we'll use `hasura/postgres`. |
+| `connectorConfiguration` | The configuration for your connector, made up of `version` and `connection_uris`.      |
+| `version`                | The version of your connector. Put `1` for now.                                        |
+| `connection_uris`        | The connection string for your database. Add your database's connection string.        |
 
 ## Step 4: Scaffold your metadata
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
     "lint": "prettier --check docs",
-    "format": "prettier --write docs"
+    "format": "prettier --write docs",
+    "write-cli-docs": "cd utilities/auto-cli && ./scaffold.sh"
   },
   "dependencies": {
     "@docusaurus/core": "2.4.1",

--- a/utilities/auto-cli/scaffold.sh
+++ b/utilities/auto-cli/scaffold.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Directory to store generated MDX files
+MDX_DIR="../../docs/ci-cd/cli/commands"
+
+# Get rid of the old directory if it exists
+rm -rf "$MDX_DIR"
+
+# Create the directory if it doesn't exist
+mkdir -p "$MDX_DIR"
+
+# Create the _category_.json file
+echo -e '{
+  "label": "Commands",
+  "position": 2
+}
+' > "$MDX_DIR/_category_.json"
+
+# List of CLI commands
+COMMANDS=("" "local" "local init" "local daemon" "local daemon start" "cloud" "cloud project" "cloud project list" "cloud project create" "cloud project details" "cloud project remove" "cloud build" "cloud build apply" "cloud build create" "cloud build list" "cloud build remove" "cloud tunnel" "cloud tunnel list" "cloud tunnel create" "cloud tunnel activate" "cloud tunnel pause" "cloud tunnel delete" "cloud secret" "cloud secret list" "cloud secret set" "cloud secret delete" "cloud login" "cloud logout" "plugin")
+
+# Position counter
+position=1
+
+# Loop through each command
+for cmd in "${COMMANDS[@]}"; do
+  # Create a kabob-case file name
+  cmd_slug=$(echo "$cmd" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+
+  # Capture the help text for the command
+  help_text=$(hasura3 $cmd --help)
+
+  # parse the first line of the help text
+    synopsis=$(echo "$help_text" | head -n 1)
+
+  # Create the MDX file with frontmatter and help text
+  mdx_content="---
+title: hasura3 $cmd
+sidebar_position: $position
+sidebar_label: hasura3 $cmd
+description: Using the hasura3 $cmd command with the Hasura CLI
+---
+
+# Hasura3 CLI: hasura3 $cmd 
+
+## Synopsis
+$synopsis.
+
+\`\`\`bash
+$ hasura3 $cmd --help
+$help_text
+\`\`\`
+"
+
+# if the file is "" then it is the root command and should be index.mdx
+if [ "$cmd_slug" == "" ]; then
+    cmd_slug="index"
+fi
+
+  # Save the MDX content to a file
+  echo -e "$mdx_content" > "$MDX_DIR/$cmd_slug.mdx"
+  ((position++))
+  echo "Generated $cmd_slug.mdx"
+done


### PR DESCRIPTION
## Description

This PR adds "auto-documenting" CLI docs and proves my laziness knows no bounds. It also adds a barebones directory for the CLI itself, which will need to be improved upon — along with the CI/CD `overview` — before the first release. However, that's outside the scope of this PR.

**NB: Currently, it's dependent on the array in `utilities/auto-cli/scaffold.sh`**


https://github.com/hasura/v3-docs/assets/24390149/5d9bdf7b-2884-4369-a0b1-4d5cdb7fcdd3

[DOCS-1409](https://hasurahq.atlassian.net/browse/DOCS-1409)

## Quick Links 🚀

- [New CLI directory](https://rob-docs-port-the-cli-docs.v3-docs-eny.pages.dev/latest/ci-cd/cli/)

## To generate CLI docs

1. Move into `utilities/auto-cli`

```bash
cd utilities/auto-cli
```

2. Make the `scaffold.sh` file executable

```bash
chmod +x scaffold.sh
```

3. Run it 🍿 

```bash
./scaffold.sh
```



[DOCS-1409]: https://hasurahq.atlassian.net/browse/DOCS-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ