### PR TITLE
docs: fix yaml highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -122,7 +122,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ['rest', 'http', 'haskell', 'plsql', 'docker', 'nginx', 'markdown'],
+        additionalLanguages: ['rest', 'http', 'haskell', 'plsql', 'docker', 'nginx', 'markdown', 'yaml'],
       },
       algolia: {
         // If Algolia did not provide you any appId, use 'BH4D9OD16A'

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -84,4 +84,18 @@ html[data-theme='dark'] {
   .no-shadow {
     background-color: var(--color-gray-0);
   }
+
+  // dark theming for yaml 'plain' values
+  .language-yaml {
+    .plain {
+      color: rgb(255, 121, 198);
+    }
+  }
+}
+
+// theming for yaml 'plain' values
+.language-yaml {
+  .plain {
+    color: rgb(163, 21, 21);
+  }
 }


### PR DESCRIPTION
## Description

I'm not sure if this is the best implementation, however, it solves the problem.

Within each code block, prism adds a selector following this convention: `.language-{LANGUAGE_NAME}`. We can use `.language-yaml` to select only yaml code blocks and then target `plain` types — which are what any characters after a `:` not wrapped in quotation marks are rendered as — and provide two style rules; one set for light theme and another for dark.

An update is made to `docusaurus.config.js`, but I doubt it matters as yaml should be turned on by default.

If we like this, I can backport to v2 docs, too.

[DOCS-1478](https://hasurahq.atlassian.net/browse/DOCS-1478?atlOrigin=eyJpIjoiODRiZDhkZDE5Y2FhNDhlOThiOTEyZGQ0ODA5ZjM2MjEiLCJwIjoiaiJ9)

## Quick Links 🚀 

[Example](https://rob-docs-fix-yaml-highlighti.v3-docs-eny.pages.dev/latest/data-domain-modeling/types/#examples)

[DOCS-1478]: https://hasurahq.atlassian.net/browse/DOCS-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ