### PR TITLE
docs: update links for v3 launch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -159,7 +159,7 @@ const config = {
         },
         items: [
           {
-            to: 'https://hasura.io/products/',
+            to: 'https://hasura.io/ddn/',
             label: 'Product',
             position: 'left',
           },
@@ -173,12 +173,12 @@ const config = {
             label: 'Tutorials',
             position: 'left',
           },
-          {
-            to: 'https://hasura.io/changelog',
-            label: "What's New",
-            id: 'whats-new-link',
-            position: 'left',
-          },
+          // {
+          //   to: 'https://hasura.io/changelog',
+          //   label: "What's New",
+          //   id: 'whats-new-link',
+          //   position: 'left',
+          // },
           {
             type: 'docsVersionDropdown',
             position: 'right',
@@ -199,7 +199,7 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://github.com/hasura/graphql-engine',
+            href: 'https://github.com/hasura/ndc-hub',
             position: 'right',
             className: 'header-github-link',
             'aria-label': 'GitHub repository',
@@ -210,13 +210,13 @@ const config = {
             position: 'right',
           },
           {
-            to: 'https://cloud.hasura.io/login?pg=docs&plcmt=header&cta=log-in&tech=default',
+            to: 'https://console.hasura.io/?pg=docs',
             label: 'Login',
             position: 'right',
             className: 'nav-link_login',
           },
           {
-            to: 'https://cloud.hasura.io/signup?pg=products&plcmt=header&cta=try-hasura&tech=default',
+            to: 'https://console.hasura.io/?pg=products&plcmt=header&cta=try-hasura&tech=default',
             label: 'Get Started',
             position: 'right',
             className: 'nav-link_getting-started',

--- a/src/components/CustomFooter/index.tsx
+++ b/src/components/CustomFooter/index.tsx
@@ -25,7 +25,7 @@ const CustomFooter = () => {
       <div className={styles['copyright']}>{`© ${new Date().getFullYear()} Hasura Inc. All rights reserved`}</div>
       <div className={styles['footerSocialIconsWrapper']}>
         <div className={styles['socialBrands']}>
-          <Link href={'https://github.com/hasura/graphql-engine'} rel="noopener noreferrer" aria-label={'Github'}>
+          <Link href={'https://github.com/hasura/ndc-hub'} rel="noopener noreferrer" aria-label={'Github'}>
             <GithubIcon />
           </Link>
         </div>


### PR DESCRIPTION
## Description

As titled and discussed during the grooming session today. Should probably update the GitHub repo we link to to something else if the engine(?) becomes OSS.

[DOCS-1492](https://hasurahq.atlassian.net/browse/DOCS-1492)

[DOCS-1492]: https://hasurahq.atlassian.net/browse/DOCS-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ