### PR TITLE
docs: remove latest from path

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,7 +54,6 @@ const config = {
             current: {
               label: 'v3.x alpha',
               badge: true,
-              path: 'latest',
             },
           },
         },

--- a/src/components/CustomDocItem/index.tsx
+++ b/src/components/CustomDocItem/index.tsx
@@ -47,13 +47,13 @@ const CustomDocItem = props => {
   // redirect them to the index if they attempt to directly navigate to a path with
   // _heading_ in it
   if (props.location.pathname.includes('_heading_')) {
-    return <Redirect to="/docs/latest/index/" />;
+    return <Redirect to="/docs/index/" />;
   }
 
   return (
     <div
       className={
-        props.location.pathname === `/latest/index/`
+        props.location.pathname === `/index/`
           ? `custom_doc_item_wrapper custom_doc_item_wrapper-x-wide`
           : `custom_doc_item_wrapper ${styles['custom_doc_item_wrapper']}`
       }
@@ -61,7 +61,7 @@ const CustomDocItem = props => {
       <ActualDocItem {...props} />
       <div
         className={
-          props.location.pathname === `/latest/index/` || props.location.pathname.includes('overview')
+          props.location.pathname === `/index/` || props.location.pathname.includes('overview')
             ? `custom_doc_item_footer-x-wide`
             : styles['custom_doc_item_footer']
         }

--- a/src/components/VersionedLink.tsx
+++ b/src/components/VersionedLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 
-const VersionedLink = ({ to, ...props }) => <Link to={`/latest${to}`} {...props} />;
+const VersionedLink = ({ to, ...props }) => <Link to={`${to}`} {...props} />;
 
 export default VersionedLink;

--- a/src/theme/DocSidebarItem/index.js
+++ b/src/theme/DocSidebarItem/index.js
@@ -8,12 +8,12 @@ export default function DocSidebarItem({ item, ...props }) {
     case 'category':
       if (item.customProps?.sidebar_pathname) {
         // if there is a custom sidebar_pathname, use it
-        item.href = `/latest/${item.customProps.sidebar_pathname}/overview/`;
+        item.href = `/${item.customProps.sidebar_pathname}/overview/`;
       } else if (item.href === undefined) {
         // if there is no custom sidebar_pathname, use the label with our regex
         // and apparently deal with the Wiki as a special case
         if (item.label != 'Docs Wiki') {
-          item.href = `/latest/${item.label.toLowerCase().replace(/\s/g, '-')}/overview/`;
+          item.href = `/${item.label.toLowerCase().replace(/\s/g, '-')}/overview/`;
         }
       } else {
         // if it already has a href (such as any category that has an index within the dir), use it


### PR DESCRIPTION
## Description

This removes `/latest` from the path and modifies the `versionedLink` component. This is so the URL structure for v3 docs will be this:

```https://hasura.io/docs/3.0/directory/page/```

Instead of this:

```https://hasura.io/docs/3.0/latest/directory/page/```

We can double-check this on `release-stage` after merging it and then we'll do our "final" test to things on `release-prod`.