### PR TITLE
docs: fix console url that was for staging

### DIFF
--- a/docs/getting-started/local-dev.mdx
+++ b/docs/getting-started/local-dev.mdx
@@ -322,7 +322,7 @@ The CLI will return:
  Build Version         <BUILD_VERSION>
  Project ID            <PROJECT_ID>
  GraphQL API Endpoint  https://<PROJECT_NAME>-<BUILD_VERSION>.ddn.hasura.me/graphql
- Console URL           https://console.arusah.com/project/<PROJECT_ID>/graphql
+ Console URL           https://console.hasura.com/project/<PROJECT_ID>/graphql
  FQDN                  <PROJECT_NAME>-<BUILD_VERSION>.ddn.hasura.me
  Environment           default
  Description           Connect Datasource and track entities


### PR DESCRIPTION
## Description

As titled: noticed during a walkthrough.