### PR TITLE
docs: add dynamic href to cta

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -215,7 +215,7 @@ const config = {
             className: 'nav-link_login',
           },
           {
-            to: 'https://console.hasura.io/?pg=products&plcmt=header&cta=try-hasura&tech=default',
+            to: 'https://console.hasura.io/?pg=docs_v3_page&plcmt=header&cta=get_started&tech=default',
             label: 'Get Started',
             position: 'right',
             className: 'nav-link_getting-started',

--- a/src/components/CustomDocItem/index.tsx
+++ b/src/components/CustomDocItem/index.tsx
@@ -24,6 +24,24 @@ const CustomDocItem = props => {
         });
       });
     });
+
+    // dynamically updating the pg prop for the getting started cta
+    function updateGettingStartedParam() {
+      const linkElement = document.querySelector('.navbar__link.nav-link_getting-started');
+
+      if (linkElement) {
+        let page = props.location.pathname;
+        page = page.slice(0, -1);
+        page = page.slice(1);
+        page = page.replace(/\//g, '_');
+
+        const href = linkElement.getAttribute('href');
+        const newHref = href.replace(/pg=docs_v3_[a-z_-]+/, `pg=docs_v3_${page}`);
+        linkElement.setAttribute('href', newHref);
+      }
+    }
+
+    updateGettingStartedParam();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This matches what we did with v2 docs for Kai: https://github.com/hasura/graphql-engine-mono/pull/10417.

