### PR TITLE
docs: update connection string placeholders

### DIFF
--- a/docs/getting-started/local-dev.mdx
+++ b/docs/getting-started/local-dev.mdx
@@ -251,7 +251,7 @@ definition:
         # highlight-start
         connectionUri:
           uri:
-            value: <postgres://user:pass@host:port/db>
+            value: postgres://<YOUR_POSTGRESQL_USERNAME>:<YOUR_POSTGRESQL_PASSWORD>@<HOST_ADDRESS>:<PORT_NUMBER>/<DATABASE_NAME>
         # highlight-end
 ```
 


### PR DESCRIPTION
## Description

Based on feedback from Rahul during testing, this updates the placeholder syntax for the PostgreSQL connection string.