### PR TITLE
docs: add GCP connection information

### DIFF
--- a/docs/getting-started/console.mdx
+++ b/docs/getting-started/console.mdx
@@ -41,6 +41,17 @@ have a PostgreSQL database and prefer to connect to a cloud provider, check out 
 
 :::
 
+:::info Don't want to set up a database?
+
+We've provisioned a read-only database for you to use for this guide if you'd like. You can use the following connection
+string in Step 3:
+
+```text
+postgresql://read_only:kd4555jkfjfkdj39f8f8d9d@35.236.11.122:5432/v3-docs-sample-app
+```
+
+:::
+
 ## Step 1: Log into Hasura
 
 Go to the [Hasura Console](https://console.hasura.io) and sign into your account:
@@ -186,6 +197,30 @@ We're using the docs sample app's schema for this guide's visuals, but you can u
 query or write it manually:
 
 <Thumbnail src="/img/get-started/0.0.1_console-execute-query-on-build.png" alt="Execute a query" width="1000px" />
+
+<details>
+<summary>Using our sample db? You can use this query!</summary>
+
+```graphql
+query OrdersQuery {
+  orders {
+    id
+    status
+    delivery_date
+    user {
+      id
+      name
+      email
+    }
+    product {
+      id
+      name
+    }
+  }
+}
+```
+
+</details>
 
 ## Step 7: Apply your build
 

--- a/docs/getting-started/local-dev.mdx
+++ b/docs/getting-started/local-dev.mdx
@@ -43,6 +43,17 @@ have a PostgreSQL database and prefer to connect to a cloud provider, check out 
 
 :::
 
+:::info Don't want to set up a database?
+
+We've provisioned a read-only database for you to use for this guide if you'd like. You can use the following connection
+string in Step 3:
+
+```text
+postgresql://read_only:kd4555jkfjfkdj39f8f8d9d@35.236.11.122:5432/v3-docs-sample-app
+```
+
+:::
+
 ## Step 1: Log into Hasura
 
 To make a secure connection, you'll need a personal access token (PAT) from Hasura Cloud:
@@ -353,6 +364,30 @@ We're using the docs sample app's schema for this guide's visuals, but you can u
 query or write it manually:
 
 <Thumbnail src="/img/get-started/0.0.1_console-execute-query-on-build.png" alt="Execute a query" width="1000px" />
+
+<details>
+<summary>Using our sample db? You can use this query!</summary>
+
+```graphql
+query OrdersQuery {
+  orders {
+    id
+    status
+    delivery_date
+    user {
+      id
+      name
+      email
+    }
+    product {
+      id
+      name
+    }
+  }
+}
+```
+
+</details>
 
 ## Step 7: Apply your build
 


### PR DESCRIPTION
## Description

This adds information about connecting to a read-only GCP-hosted PostrgreSQL database. This is part of an effort to remove as much friction as possible for users to try out DDN.

TODO:
Resolution still needs to happen in [this thread](https://hasurahq.slack.com/archives/C05PBMG3GD9/p1699809816551469) for the configuration of the hosted database. While it's quite straightforward with the existing access allowed to Hasura Cloud, DDN and LSP are presumed to have static IP addresses that we'll need to allow access to via GCP.

[DOCS-1567](https://hasurahq.atlassian.net/browse/DOCS-1567)

## Quick Links 🚀

- VS Code
- Console


[DOCS-1567]: https://hasurahq.atlassian.net/browse/DOCS-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ