### PR TITLE
docs: add note for watch mode

### DIFF
--- a/docs/getting-started/local-dev.mdx
+++ b/docs/getting-started/local-dev.mdx
@@ -171,8 +171,18 @@ update automatically:
 hasura3 watch --dir .
 ```
 
-This command will take over the current terminal tab and watch for changes to the folder. This will keep creating new
-**builds** — that represent a new version of the GraphQL API — as you make changes.
+The CLI will respond with the following warning to ensure you don't accidentally apply a build to your production
+environment:
+
+```text
+This command will create new builds in the selected environment "default" and change the current applied build.
+We recommend using a test environment so that there is no disruption to existing work.
+Do you want to continue?
+```
+
+This command will take over the current terminal tab and watch for changes to the folder. This will keep creating and
+applying new **builds** — that represent a new version of the GraphQL API — as you make changes. If you'd like to learn
+more about watch mode and what flags you can pass, check out the [CLI docs on watch mode](/cli/commands/watch.mdx).
 
 If you are using a local Postgres database, this command also creates a tunnel to your local machine to make the
 database available to Hasura DDN.


### PR DESCRIPTION
## Description

As titled. Adds clarification to the getting started for warning users what watch mode does.

## Quick Links 🚀

[Watch mode section in quickstart](https://rob-docs-add-note-for-watch.v3-docs-eny.pages.dev/getting-started/local-dev/#step-4-start-watch-mode)

## Assertion testing
<!-- DX:Assertion-start -->
Understand that when using watch mode, builds are created and applied to their environment.
<!-- DX:Assertion-end -->