### PR TITLE
mention command palette shortcut

### DIFF
--- a/docs/getting-started/local-dev.mdx
+++ b/docs/getting-started/local-dev.mdx
@@ -222,8 +222,9 @@ Open the new `hml` file that was created at `subgraphs/default/dataconnectors/pg
 automatically introspected your data source and created your schema for you.
 
 From here, you can immediately track all tables, views, relationships, and quickly scaffold out your metadata by using
-the Hasura VS Code extension. **From this file**, bring up the command palette (Ctrl+Shift+P), type `hasura track all`
-and choose the option from the dropdown. Then, select your data source's name (e.g., `pg_db`) from the dropdown.
+the Hasura VS Code extension. **From this file**, bring up the command palette (Ctrl+Shift+P or Cmd+Shift+P), type
+`hasura track all` and choose the option from the dropdown. Then, select your data source's name (e.g., `pg_db`) from
+the dropdown.
 
 <Thumbnail src="/img/get-started/0.0.1_vscode-track-table.png" alt="VSCode data connector" width="1000px" />
 


### PR DESCRIPTION
<!-- 🚧 IMPORTANT: PLEASE READ 🚧 -->
<!-- Thank you for submitting this docs PR! 🤙 -->
<!-- You'll need to complete the two sections below (Description and Quick Links) but please also select `Enable auto-merge` after opening your PR 🙏 -->
<!-- Any merged docs PR will be picked up by our CI/CD pipeline and — if there are no merge conflicts — automatically be deployed to production 🎉 -->

## Description

In the getting started using cli section, there's a mention of the command palette. Having never used VSCode before I had to google how to open it. Would be nice if the shortcut was in the tutorial (like we mention Ctrl+P in the same doc).

## Quick Links 🚀

 <!-- Add links to the affected pages / sections here for quick review. We'll generate a comment for you after you open the PR with a link to your preview site, which will need to build. -->
