### PR TITLE
segregate data-connectors page into DataConnector and HasuraHubDataConnector

### DIFF
--- a/docs/data-domain-modeling/data-connectors.mdx
+++ b/docs/data-domain-modeling/data-connectors.mdx
@@ -20,17 +20,16 @@ seoFrontMatterUpdated: true
 
 ## Introduction
 
-A `DataConnector` is a way to specify where your data comes from and how it can be used. It can connect to various types
-of data, like SQL databases, NoSQL databases, REST APIs, GraphQL APIs, files, and more.
+A data connector is a way to specify where your data comes from and how it can be used. It can connect to various types
+of data sources, like SQL databases, NoSQL databases, REST APIs, GraphQL APIs, files, and more.
 
-In the Open Data Domain Specification (OpenDD spec), every data connector must have a connector URL and a schema. This
-schema defines how the data is structured and what operations can be performed on the data.
-
-Once you've declared a data connector, you can use it in your [model's](/data-domain-modeling/models.mdx) configuration
+You can declare a data connector and use it in your [model's](/data-domain-modeling/models.mdx) configuration
 by [referencing it with the `source`](/data-domain-modeling/models.mdx/#source) property, which connects that model to
 the respective data connector.
 
-## Description
+In the Open Data Domain Specification (OpenDD spec), you can connect to data sources through a `DataConnector` or a `HasuraHubDataConnector`.
+
+## DataConnector
 
 To create a data connector object, you will need to define an object with `kind: DataConnector` and `version: v1`.
 The object `definition` should include four fields: `name`, `url`, `headers` and `schema`.
@@ -110,7 +109,7 @@ schema:
 The structure and detailed documentation of these fields can be found
 [here](https://hasura.github.io/ndc-spec/specification/schema/index.html).
 
-## Example
+### Example
 
 In this example, we'll create a data connector for the Chinook data set. The Chinook data set is a sample database that
 represents a digital media store, including tables for artists, albums, tracks, and more. Each object we reference above


### PR DESCRIPTION
<!-- 🚧 IMPORTANT: PLEASE READ 🚧 -->
<!-- Thank you for submitting this docs PR! 🤙 -->
<!-- You'll need to complete the two sections below (Description and Quick Links) but please also select `Enable auto-merge` after opening your PR 🙏 -->
<!-- Any merged docs PR will be picked up by our CI/CD pipeline and — if there are no merge conflicts — automatically be deployed to production 🎉 -->

## Description

Improves hierarchy of the data connectors page, putting `DataConnector` and `HasuraHubDataConnector` as h2 headings.
Made minor changes to introduction to facilitate this -- happy to address any feedback.

## Quick Links 🚀

 <!-- Add links to the affected pages / sections here for quick review. We'll generate a comment for you after you open the PR with a link to your preview site, which will need to build. -->
