### PR TITLE
Docs: Add deployment guide

### DIFF
--- a/docs/ci-cd/deployment.mdx
+++ b/docs/ci-cd/deployment.mdx
@@ -127,9 +127,9 @@ are merged to the trunk of their repository.
 
 ### Staging
 
-With the changes present in the trunk of the repository, a [new build](/ci-cd/builds.mdx) in the team's staging
-environment can be created using the Hasura CLI, and passing `staging.supergraph.hml` to the `--supergraph-manifest`
-flag. Then, they can apply the build using the `build version` returned by the CLI:
+With the changes present in the trunk of the repository, a [new build](/ci-cd/builds.mdx) can be created in the team's staging
+environment using the Hasura CLI by passing `staging.supergraph.hml` to the `--supergraph-manifest`
+flag. Then, they can apply the build to that environment using the `build version` returned by the CLI:
 
 ```bash
 # create a new build which will return a build version


### PR DESCRIPTION
## Description

This PR adds a deployment guide for users. It walks through a common git workflow and references an Action that will be created in the next couple of days.

[DOCS-1782](https://hasurahq.atlassian.net/browse/DOCS-1782)

TODO: Replace `#` ref for Action with actual listing in the GitHub Marketplace.

## Quick Links 🚀

- [Deployment](https://rob-docs-add-deployment-guid.v3-docs-eny.pages.dev/ci-cd/deployment)

## 🤖 DX: Assertion Tests

<!-- Between the comments below, you can add assertions to test your docs contribution! E.g., A user should be able to easily add a comment to their PR's description.  -->
<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->
<!-- DX:Assertion-start -->
A user should understand how to collaborate with their teammates and move between environments.
<!-- DX:Assertion-end -->


[DOCS-1782]: https://hasurahq.atlassian.net/browse/DOCS-1782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ