### PR TITLE
Docs: add troubleshooting template

### DIFF
--- a/docs/cli/troubleshooting.mdx
+++ b/docs/cli/troubleshooting.mdx
@@ -1,0 +1,32 @@
+---
+sidebar_position: 4
+sidebar_label: Troubleshooting
+description: "See common issues and how to troubleshoot them"
+keywords:
+  - hasura cli troubleshooting
+  - troubleshooting
+  - cli help
+  - errors
+---
+
+# Troubleshooting
+
+## Introduction
+
+At times, you may run into issues when using the CLI or LSP-assisted editing experiences in your IDE. Common issues and
+their solutions can be found below.
+
+### The CLI explodes
+
+This occasionally happens when the hamster running inside your machine refuses to keep that wheel spinning. The
+resolution is simple; kill the hamster and run `ddn dev` again:
+
+```bash
+kill <HAMSTER_PID>
+```
+
+Then, restart `dev` mode:
+
+```bash
+ddn dev
+```


### PR DESCRIPTION
## Description

This is meant to be a page that contains common issues when using the CLI or LSP. Each problem/solution should follow this template:

```text
### <TITLE OF PROBLEM>

<DESCRIPTION OF PROBLEM AND RESOLUTION>

<STEPS TO RESOLVE>
```

The example given in the initial commit is:

### The CLI explodes

This occasionally happens when the hamster running inside your machine refuses to keep that wheel spinning. The
resolution is simple; kill the hamster and run `ddn dev` again:

```bash
kill <HAMSTER_PID>
```

Then, restart `dev` mode:

```bash
ddn dev
```

## Quick Links 🚀

[Troubleshooting](https://rob-docs-add-troubleshooting.v3-docs-eny.pages.dev/cli/troubleshooting)