### PR TITLE
docs: add 'Default Deprecation Reason' section in GraphQL API versioning

### DIFF
--- a/docs/graphql-api/versioning.mdx
+++ b/docs/graphql-api/versioning.mdx
@@ -62,16 +62,16 @@ definition:
   orderableFields:
   - Id
   graphql:
-	selectUniques:
-	- queryRootField: selectCar
-  	  uniqueIdentifier:
-  	  - make
-  	  - model
-  	  deprecated:
-    	    reason: Use selectCarById instead
-	- queryRootField: selectCarById
-  	  uniqueIdentifier:
-  	  - Id
+    selectUniques:
+    - queryRootField: selectCar
+      uniqueIdentifier:
+      - make
+      - model
+      deprecated:
+        reason: Use selectCarById instead
+    - queryRootField: selectCarById
+      uniqueIdentifier:
+      - Id
 ```
 
 And the resulting schema:
@@ -94,10 +94,10 @@ definition:
   name: GetEngineSpec
   outputType: Engine
   graphql:
-	rootFieldName: getEngineSpec
-	rootFieldKind: Query
-	deprecated:
-  	  reason: "Fuel Engines are no longer supported from Jan 01 2035"
+    rootFieldName: getEngineSpec
+    rootFieldKind: Query
+    deprecated:
+      reason: "Fuel Engines are no longer supported from Jan 01 2035"
 ```
 
 And the resulting schema:
@@ -120,17 +120,17 @@ definition:
   name: Car
   fields:
   - name: Id
-	type: String
+    type: String
   - name: make
-	type: String
+    type: String
   - name: model
-	type: String
+    type: String
   - name: engine
-	type: String
-	deprecated:
-  	  reason: Use motor field instead
+    type: String
+    deprecated:
+      reason: Use motor field instead
   - name: motor
-	type: String
+    type: String
   graphql:
       typeName: Car
 ```
@@ -158,17 +158,17 @@ definition:
   name: engineSpec
   source: Car
   target:
-	command:
-  	name: GetEngineSpec
+    command:
+    name: GetEngineSpec
   mapping:
   - source:
-  	fieldPath:
-  	- fieldName: engine
-	target:
-  	argument:
-    	argumentName: name
+      fieldPath:
+      - fieldName: engine
+    target:
+      argument:
+        argumentName: name
   deprecated:
-	reason: Engines on cars are no longer supported from Jan 01 2035
+    reason: Engines on cars are no longer supported from Jan 01 2035
 ```
 
 And the resulting schema:
@@ -182,5 +182,45 @@ type Car {
   motor: String
   engineSpec: Engine @deprecated(reason: "Engines on cars are no longer supported from Jan 01 2035")
   motorSpec: Motor
+}
+```
+
+## Default Deprecation Reason
+
+In cases where no deprecation reason is explicitly provided, the `@deprecated` directive defaults to `No longer supported` as the reason.
+
+The following example from [ObjectType](/supergraph-modeling/types.mdx#objecttype-objecttype) metadata illustrates deprecating a field without specifying a reason.
+
+```yaml
+kind: ObjectType
+version: V1
+definition:
+  name: Car
+  fields:
+  - name: Id
+    type: String
+  - name: make
+    type: String
+  - name: model
+    type: String
+  - name: engine
+    type: String
+    deprecated:
+      reason: null
+  - name: motor
+    type: String
+  graphql:
+      typeName: Car
+```
+
+And the resulting schema:
+
+```graphql
+type Car {
+  Id: String
+
+  model: String
+  engine: String @deprecated(reason: "No longer supported")
+  motor: String
 }
 ```


### PR DESCRIPTION
<!-- 🚧 IMPORTANT: PLEASE READ 🚧 -->
<!-- Thank you for submitting this docs PR! 🤙 -->
<!-- You'll need to complete the two sections below (Description and Quick Links) but please also select `Enable auto-merge` after opening your PR 🙏 -->
<!-- Any merged docs PR will be picked up by our CI/CD pipeline and — if there are no merge conflicts — automatically be deployed to production 🎉 -->

## Description

<!-- 1. Give us a tl;dr of what this docs contribution is / does -->
<!-- 2. If you're submitting docs that are part of the beta release, please add the `hold-for-beta` label -->

Now, when a deprecation reason is not specified, the generated schema defaults to `No longer supported` as the reason. Ref: https://github.com/hasura/v3-engine/pull/448. 

## Quick Links 🚀

 <!-- Add links to the affected pages / sections here for quick review. We'll generate a comment for you after you open the PR with a link to your preview site, which will need to build. -->

## 🤖 DX: Assertion Tests

<!-- Between the comments below, you can add assertions to test your docs contribution! E.g., A user should be able to easily add a comment to their PR's description.  -->
<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->
<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->
