### PR TITLE
Chore: Add ClickHouse

### DIFF
--- a/docs/connectors/overview.mdx
+++ b/docs/connectors/overview.mdx
@@ -176,12 +176,12 @@ what's coming up on the roadmap.
     </div>
   </Link> -->
   <!-- ClickHouse -->
-  <!-- <Link href={"/connectors/postgresql/"}>
+<Link href={"https://hasura.io/connectors/clickhouse"}>
     <div className="vendor-card-wrapper">
       <div className="vendor-card">
         <img src={ClickHouse} title="PostgreSQL" alt="Connect PostgreSQL to Hasura DDN" />
       </div>
       <h5>ClickHouse</h5>
     </div>
-  </Link> -->
+  </Link> 
 </div>


### PR DESCRIPTION
## Description

Until we've added ClickHouse docs internally, this is to direct users to the Connector Hub and advertise ClickHouse as a supported source.