### PR TITLE
UI: Fix TOC scroll

### DIFF
--- a/src/theme/TOC/styles.module.css
+++ b/src/theme/TOC/styles.module.css
@@ -1,9 +1,10 @@
 .tableOfContents {
-  max-height: calc(100vh - (var(--ifm-navbar-height) - 20px));
+  max-height: calc(100vh - (var(--ifm-navbar-height) - 80px));
   position: sticky;
   top: calc(var(--ifm-navbar-height));
   top: 92px;
   border-left: 1px solid var(--primary-neutral-200);
+  overflow-y: auto;
 }
 
 @media (max-width: 996px) {
@@ -19,3 +20,4 @@
 [data-theme='dark'] .tableOfContents {
   border-left: 1px solid var(--header-border-bottom);
 }
+


### PR DESCRIPTION
## Description

This adds the `overflow-y` property to the TOC. Easy peasy.

### Before

https://github.com/hasura/v3-docs/assets/24390149/047fc03d-0671-479a-aba5-bf2b6c17ee73


### After

https://github.com/hasura/v3-docs/assets/24390149/15fa5bd2-31b4-4643-aae9-d177b4916949

[DOCS-1938](https://hasurahq.atlassian.net/browse/DOCS-1938)

## Quick Links 🚀

- [Relationships provides a good example](https://rob-docs-fix-toc-scrolling.v3-docs-eny.pages.dev/supergraph-modeling/relationships)

[DOCS-1938]: https://hasurahq.atlassian.net/browse/DOCS-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ