### PR TITLE
Docs: Add admonition for console-first creation

### DIFF
--- a/docs/getting-started/1-create-a-project.mdx
+++ b/docs/getting-started/1-create-a-project.mdx
@@ -113,6 +113,14 @@ The CLI will respond with information about your new project, including the cons
 
 Additionally, it will log some information about the [project](/docs/project-configuration/projects.mdx).
 
+:::info I already created a project on Hasura DDN
+
+If you've landed here from Hasura DDN after creating a project via the Console (our GUI), you can replace the project
+name in the `hasura.yaml` at the root of your local project with the name of the project you created on Hasura DDN. From
+there, you can follow the rest of the steps below!
+
+:::
+
 ## Step 4: Add the Postgres Connector {#step-4-add-a-connector-manifest}
 
 A [**connector manifest**](/supergraph-modeling/build-manifests.mdx#connector-manifests) is the file which contains the


### PR DESCRIPTION
## Description

Manushi raised the issue that a user can still create projects via the Console. This admonition ensures users who land on docs from the Console have some kind of anchor to keep themselves going.

## Quick Links 🚀

Getting started step w/ new admonition

## 🤖 DX: Assertion Tests

<!-- Between the comments below, you can add assertions to test your docs contribution! E.g., A user should be able to easily add a comment to their PR's description.  -->
<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->
<!-- DX:Assertion-start -->
A user starting from the Console should understand how to proceed with their already-created project.
<!-- DX:Assertion-end -->
