### PR TITLE
Chore: Update <port> placeholders

### DIFF
--- a/docs/getting-started/07-integrate-business-logic.mdx
+++ b/docs/getting-started/07-integrate-business-logic.mdx
@@ -93,9 +93,16 @@ ddn connector-link add my_ts
 Then, update the values in your subgraph's `.env.my_subgraph` file to include this connector.
 
 ```env
-MY_SUBGRAPH_MY_TS_READ_URL=http://local.hasura.dev:<port>
-MY_SUBGRAPH_MY_TS_WRITE_URL=http://local.hasura.dev:<port>
+MY_SUBGRAPH_MY_TS_READ_URL=http://local.hasura.dev:8083
+MY_SUBGRAPH_MY_TS_WRITE_URL=http://local.hasura.dev:8083
 ```
+
+:::tip Don't forget to modify the port number
+
+To avoid port conflicts, you should modify the port number in the `.env.my_subgraph` file to match the port number you
+set in the `.env.local` file.
+
+:::
 
 These values are already referenced in `my_subgraph/metadata/my_ts/my_ts.hml`.
 

--- a/src/_databaseDocs/_mongoDB/_02-create-source-metadata.mdx
+++ b/src/_databaseDocs/_mongoDB/_02-create-source-metadata.mdx
@@ -24,8 +24,6 @@ configuration JSON files for a data connector and transform them into an `hml` (
 
 Basically, metadata objects in `hml` files define our API.
 
-[//]: # 'TODO links'
-
 First we need to create this `hml` file with the `connector-link add` command and then convert our configuration files
 into `hml` syntax and add it to this file with the `connector-link update` command.
 
@@ -75,9 +73,19 @@ subgraph's `.env.my_subgraph` file. Each key is prefixed by the subgraph name, a
 connector. Ensure the port value matches what is published in your connector's docker compose file.
 
 ```env
-MY_SUBGRAPH_MY_MONGO_READ_URL=http://local.hasura.dev:<port>
-MY_SUBGRAPH_MY_MONGO_WRITE_URL=http://local.hasura.dev:<port>
+MY_SUBGRAPH_MY_MONGO_READ_URL=http://local.hasura.dev:8082
+MY_SUBGRAPH_MY_MONGO_WRITE_URL=http://local.hasura.dev:8082
 ```
+
+These values are for the MongoDB connector itself and utilize `local.hasura.dev` to ensure proper resolution within the
+docker container.
+
+:::tip Don't forget to modify the port number
+
+To avoid port conflicts, you should modify the port number in the `.env.my_subgraph` file to match the port number you
+set in the Docker Compose for the connector.
+
+:::
 
 ## Step 2. Start the connector's docker compose
 
@@ -92,7 +100,7 @@ This starts our MongoDB connector on the specified port. We can navigate to the 
 modified, to see the schema of our MongoDB database:
 
 ```bash
-http://localhost:<PORT>/schema
+http://localhost:8082/schema
 ```
 
 :::tip Prefer to start all your services together?

--- a/src/_databaseDocs/_postgreSQL/_02-create-source-metadata.mdx
+++ b/src/_databaseDocs/_postgreSQL/_02-create-source-metadata.mdx
@@ -70,12 +70,19 @@ subgraph's `.env.my_subgraph` file. Each key is prefixed by the subgraph name, a
 connector. Ensure the port value matches what is published in your connector's docker compose file.
 
 ```env title="my_subgraph/.env.my_subgraph"
-MY_SUBGRAPH_MY_PG_READ_URL=http://local.hasura.dev:<port>
-MY_SUBGRAPH_MY_PG_WRITE_URL=http://local.hasura.dev:<port>
+MY_SUBGRAPH_MY_PG_READ_URL=http://local.hasura.dev:8082
+MY_SUBGRAPH_MY_PG_WRITE_URL=http://local.hasura.dev:8082
 ```
 
 These values are for the PostgreSQL connector itself and utilize `local.hasura.dev` to ensure proper resolution within
 the docker container.
+
+:::tip Don't forget to modify the port number
+
+To avoid port conflicts, you should modify the port number in the `.env.my_subgraph` file to match the port number you
+set in the Docker Compose for the connector.
+
+:::
 
 ## Step 2. Start the connector's docker compose
 
@@ -89,7 +96,7 @@ This starts our PostgreSQL connector on the specified port. We can navigate to t
 modified, to see the schema of our PostgreSQL database:
 
 ```bash
-http://localhost:<PORT>/schema
+http://localhost:8082/schema
 ```
 
 ## Step 3. Include the connector in your docker compose


### PR DESCRIPTION
## Description

This PR removes abstracted `<port>` references to commands and copy-paste sections wherein users may get confused. The goal here is to give users as much copy-paste as possible while balancing out the teaching aspect of these docs.

[DOCS-2100](https://hasurahq.atlassian.net/browse/DOCS-2100)

## 🤖 DX: Assertion Tests

<!-- Between the comments below, you can add assertions to test your docs contribution! E.g., A user should be able to easily add a comment to their PR's description.  -->
<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->
<!-- DX:Assertion-start -->
A user should understand that their port number may be different from what's listed in the copy-paste command.
<!-- DX:Assertion-end -->


[DOCS-2100]: https://hasurahq.atlassian.net/browse/DOCS-2100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ