### PR TITLE
Docs: Add note for for local dev

### DIFF
--- a/docs/getting-started/01-init-supergraph.mdx
+++ b/docs/getting-started/01-init-supergraph.mdx
@@ -51,8 +51,8 @@ ddn context set supergraph ./supergraph.local.yaml
 
 ### Step 3. Build your supergraph
 
-You now have all the scaffolding necessary to start developing your Hasura supergraph. In fact, we can create a build
-by running the following command.
+You now have all the scaffolding necessary to start developing your Hasura supergraph. In fact, we can create a build by
+running the following command.
 
 ```bash title="From the project's root, run:"
 ddn supergraph build local --output-dir ./engine
@@ -87,10 +87,18 @@ blank slate, allowing you to iteratively and collaboratively build it out. Hasur
 [immutable builds](/project-configuration/builds.mdx) which provide a stable snapshot of your API at any point in the
 development process.
 
+:::tip Privacy settings in some browsers
+
+Your browser settings or privacy tools may prevent the Console from accessing your local Hasura instance. This could be
+due to features designed to protect your privacy and security. Should you encounter one of these issues, we recommend
+disabling these settings for the `console.hasura.io` domain.
+
+:::
+
 ## What did this do?
 
-The CLI created all the files needed for local and cloud development in your local directory, including a
-docker compose file for local development and helper files for VS Code.
+The CLI created all the files needed for local and cloud development in your local directory, including a docker compose
+file for local development and helper files for VS Code.
 
 <details>
   <summary>Click here to see an expanded directory structure.</summary>

--- a/docs/getting-started/03-build-your-api.mdx
+++ b/docs/getting-started/03-build-your-api.mdx
@@ -65,6 +65,14 @@ You can now navigate to
 [`https://console.hasura.io/local/graphql?url=http://localhost:3000`](https://console.hasura.io/local/graphql?url=http://localhost:3000)
 and interact with your API using the Hasura Console.
 
+:::tip Privacy settings in some browsers
+
+Your browser settings or privacy tools may prevent the Console from accessing your local Hasura instance. This could be
+due to features designed to protect your privacy and security. Should you encounter one of these issues, we recommend
+disabling these settings for the `console.hasura.io` domain.
+
+:::
+
 ### Step 2. Write your first query
 
 Use the GraphiQL explorer to either write a query or construct it using the menu on the left-hand side of the console.

--- a/docs/getting-started/07-integrate-business-logic.mdx
+++ b/docs/getting-started/07-integrate-business-logic.mdx
@@ -18,12 +18,11 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 With Hasura, you can integrate — and even host — this business logic directly with Hasura DDN and your API.
 
-You can handle custom business logic using the Node.js Lambda data connector. Using this connector, you can
-transform or enrich data before it reaches your consumers, or perform any other app business logic you may need.
+You can handle custom business logic using the Node.js Lambda data connector. Using this connector, you can transform or
+enrich data before it reaches your consumers, or perform any other app business logic you may need.
 
-You can then integrate these functions as individual [**commands**](/supergraph-modeling/commands.mdx) in your
-metadata and resulting API. This process enables you to simplify client applications and speed up your backend
-development.
+You can then integrate these functions as individual [**commands**](/supergraph-modeling/commands.mdx) in your metadata
+and resulting API. This process enables you to simplify client applications and speed up your backend development.
 
 ## Steps
 
@@ -85,17 +84,16 @@ together.
 Importantly, a data connector can only connect to one data source.
 
 The project will be kept organized with each data connector's configuration located in a relevant subgraph directory. In
-this example the CLI will create a `my_subgraph/connector/my_ts` directory if it doesn't exist. You can also change
-this directory by passing a `--dir` flag to the CLI.
+this example the CLI will create a `my_subgraph/connector/my_ts` directory if it doesn't exist. You can also change this
+directory by passing a `--dir` flag to the CLI.
 
-The name of the connector and the directory in which the configuration is stored, `my_ts` in this example, should
-match for convenience and clarity sake.
+The name of the connector and the directory in which the configuration is stored, `my_ts` in this example, should match
+for convenience and clarity sake.
 
 In subsequent steps, when running your connector locally, it's critical to ensure the port value matches the connection
 string you provide in your subgraph's `.env.my_subgraph` file.
 
 :::
-
 
 ### What did this do?
 
@@ -127,8 +125,8 @@ ddn connector-link add my_ts \
   --subgraph my_subgraph \
 ```
 
-The `--configure-host` convenience flag added the read and write URL for the connect to the `.env.my_subgraph` file
-for us.
+The `--configure-host` convenience flag added the read and write URL for the connect to the `.env.my_subgraph` file for
+us.
 
 ```env title="Example .env.my_subgraph file"
 MY_SUBGRAPH_MY_TS_READ_URL="http://local.hasura.dev:8083"
@@ -226,8 +224,8 @@ Want to test your supergraph? Don't forget to start your GraphQL engine using th
 HASURA_DDN_PAT=$(ddn auth print-pat) docker compose -f docker-compose.hasura.yaml watch
 ```
 
-This starts our Hasura Engine and observability tools. `HASURA_DDN_PAT=$(ddn auth print-pat)` gives the Hasura
-Engine access to the DDN CLI's authentication token.
+This starts our Hasura Engine and observability tools. `HASURA_DDN_PAT=$(ddn auth print-pat)` gives the Hasura Engine
+access to the DDN CLI's authentication token.
 
 :::
 
@@ -241,11 +239,19 @@ with a string such as: `"2024-03-14T08:00:00Z"`.
   width="1000px"
 />
 
+:::tip Privacy settings in some browsers
+
+Your browser settings or privacy tools may prevent the Console from accessing your local Hasura instance. This could be
+due to features designed to protect your privacy and security. Should you encounter one of these issues, we recommend
+disabling these settings for the `console.hasura.io` domain.
+
+:::
+
 ## What did this do?
 
 The commands above initialized a new Node.js Lambda connector, installed dependencies, and created a new function to
-format a timestamp with timezone into a human-readable format. We then added this function to our metadata as a
-command, and created a new build of our supergraph.
+format a timestamp with timezone into a human-readable format. We then added this function to our metadata as a command,
+and created a new build of our supergraph.
 
 ## Next Steps
 


### PR DESCRIPTION
## Description

Some browsers — notably Brave — have privacy settings which block the console from accessing the engine instance on a user's machine. This just alerts them to the fact that it's like an issue on their end and to allowlist console.hasura.io in whatever fashion makes the most sense for them.

## 🤖 DX: Assertion Tests

<!-- Between the comments below, you can add assertions to test your docs contribution! E.g., A user should be able to easily add a comment to their PR's description.  -->
<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->
<!-- DX:Assertion-start -->
A user should understand that their privacy settings may cause issues with local development.
<!-- DX:Assertion-end -->
