### PR TITLE
Bug Bash: Update GrpahiQLIDE query names

### DIFF
--- a/docs/graphql-api/queries/filters/boolean-operators.mdx
+++ b/docs/graphql-api/queries/filters/boolean-operators.mdx
@@ -97,7 +97,7 @@ expressions involving multiple filtering criteria.
 Fetch a list of articles published in a specific time-frame (for example: in year 2017):
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesPublishedInCertainYear {
   articles (
     where: {
       _and: [
@@ -153,7 +153,7 @@ Certain `_and` expressions can be expressed in a simpler format using some synta
 Fetch a list of articles rated more than 4 or published after "01/01/2018":
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesPublishedAfterCertainDateAndRatedMoreThanFour {
   articles (
     where: {
       _or: [

--- a/docs/graphql-api/queries/filters/comparison-operators.mdx
+++ b/docs/graphql-api/queries/filters/comparison-operators.mdx
@@ -43,7 +43,7 @@ The following are examples of using the equality operators on different types.
 Fetch data about an author whose `id` _(an integer field)_ is equal to 3:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorById {
   authors(
     where: {id: {_eq: 3}}
   ) {
@@ -68,7 +68,7 @@ Fetch data about an author whose `id` _(an integer field)_ is equal to 3:
 Fetch a list of authors with `name` _(a text field)_ as "Sidney":
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorByName {
   authors(
     where: {name: {_eq: "Sidney"}}
   ) {
@@ -93,7 +93,7 @@ Fetch a list of authors with `name` _(a text field)_ as "Sidney":
 Fetch a list of articles that have not been published (`is_published` is a boolean field):
 
 <GraphiQLIDE
-  query={`query {
+  query={`query UnpublishedArticles {
   articles(
     where: {is_published: {_eq: false}}
   ) {
@@ -135,7 +135,7 @@ Fetch a list of articles that have not been published (`is_published` is a boole
 Fetch a list of articles that were published on a certain date (`published_on` is a Date field):
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesByDate {
   articles(
     where: {published_on: {_eq: "2017-05-26"}}
   ) {
@@ -162,7 +162,7 @@ Fetch a list of articles that were published on a certain date (`published_on` i
 Fetch a list of users whose age is _not_ 30 (`age` is an Integer field):
 
 <GraphiQLIDE
-  query={`query {
+  query={`query UsersNotAge30 {
   users(where: { age: { _neq: 30 } }) {
     id
     name
@@ -201,7 +201,7 @@ operator.
 For example, to fetch a list of articles where the `is_published` column is either `false` or `null`:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query UnpublishedArticles {
   articles (
     where: {
       _or: [
@@ -258,7 +258,7 @@ This query retrieves all users whose age is less than 30. The `_lt` operator is 
 than". It is used to filter records based on a specified value.
 
 <GraphiQLIDE
-  query={`query {
+  query={`query UsersAgeLessThan30 {
   users(where: { age: { _lt: 30 }}) {
     id
     name
@@ -289,7 +289,7 @@ Fetch a list of authors whose names begin with M or any letter that follows M _(
 dictionary sort)_:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsNameGreaterThanM {
   authors(
     where: {name: {_gt: "M"}}
   ) {
@@ -318,7 +318,7 @@ dictionary sort)_:
 Fetch a list of all products with a price less than or equal to 10.
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ProductsPriceLessThanOrEqualTo10 {
   products(where: { price: { _lte: 10 } }) {
     name
     price
@@ -349,7 +349,7 @@ Fetch a list of all products with a price less than or equal to 10.
 Fetch a list of articles rated 4 or more (`rating` is an integer field):
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesRatingGTE4 {
   articles(
     where: {rating: {_gte: 4}}
   ) {
@@ -386,7 +386,7 @@ Fetch a list of articles rated 4 or more (`rating` is an integer field):
 Fetch a list of articles that were published on or after date "01/01/2018":
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesPublishedAfterDate {
   articles(
     where: {published_on: {_gte: "2018-01-01"}}
   ) {
@@ -435,7 +435,7 @@ The following are examples of using these operators on different types:
 Fetch a list of articles rated 1, 3 or 5:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesRating1or3or5 {
   articles(
     where: {rating: {_in: [1,3,5]}}
   ) {
@@ -481,7 +481,7 @@ Checking for null values can be achieved using the `_is_null` operator.
 Fetch a list of articles that have a value in the `published_on` field:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query PublishedArticles {
   articles(
     where: {published_on: {_is_null: false}}
   ) {

--- a/docs/graphql-api/queries/filters/text-search-operators.mdx
+++ b/docs/graphql-api/queries/filters/text-search-operators.mdx
@@ -36,7 +36,7 @@ operators are used for pattern matching on string/text fields.
 Fetch a list of articles whose titles contain the word “amet”:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesWithAmetInTitle {
   articles(
     where: {title: {_like: "%amet%"}}
   ) {
@@ -69,7 +69,7 @@ Fetch a list of articles whose titles contain the word “amet”:
 This query will return all users whose name contains the string "john", regardless of case.
 
 <GraphiQLIDE
-  query={`query {
+  query={`query UsersWithNameLike {
   users(where: { name: { _ilike: "%john%" } }) {
     id
     name
@@ -98,7 +98,7 @@ This query will return all users whose name contains the string "john", regardle
 This query would return all users whose name does not contain the string "John".
 
 <GraphiQLIDE
-  query={`query {
+  query={`query UsersWithNameNotLike {
   users(where: { name: { _nilike: "%John%" } }) {
     name
   }
@@ -130,7 +130,7 @@ This query would return all users whose name does not contain the string "John".
 Fetch a list of authors whose names begin with A or C:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsWithAorC {
   authors(
     where: {name: {_similar: "(A|C)%"}}
   ) {
@@ -167,7 +167,7 @@ Fetch a list of authors whose names begin with A or C:
 Fetch a list of authors whose names do not begin with A or C:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsNotWithAorC {
   authors(
     where: {name: {_nsimilar: "(A|C)%"}}
   ) {
@@ -212,7 +212,7 @@ Fetch a list of authors whose names do not begin with A or C:
 Fetch a list of articles whose titles match the regex `[ae]met`:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesWithRegex {
   articles(
     where: {title: {_regex: "[ae]met"}}
   ) {
@@ -245,7 +245,7 @@ Fetch a list of articles whose titles match the regex `[ae]met`:
 This query will return all users whose name matches the regular expression `/^joh?n$/i`, which matches "John" and "Jon".
 
 <GraphiQLIDE
-  query={`query {
+  query={`query UsersWithRegex {
   users(where: { name: { _iregex: "/^joh?n$/i" } }) {
     id
     name
@@ -272,7 +272,7 @@ The \_nregex operator in this GraphQL query is a negated regular expression filt
 not start with the letter "J".
 
 <GraphiQLIDE
-  query={`query {
+  query={`query UsersWithNRegex {
   users(where: { name: { _nregex: "/^J/" } }) {
     id
     name

--- a/docs/graphql-api/queries/multiple-arguments.mdx
+++ b/docs/graphql-api/queries/multiple-arguments.mdx
@@ -30,7 +30,7 @@ For example, you can use the `where` argument to filter the results and then use
 \*publication:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsAndArticles {
   authors {
     id
     name

--- a/docs/graphql-api/queries/multiple-queries.mdx
+++ b/docs/graphql-api/queries/multiple-queries.mdx
@@ -31,7 +31,7 @@ You can fetch objects of different unrelated types in the same query.
 **For example**, fetch a list of `authors` and a list of `articles`:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsAndArticles {
   authors(limit: 2) {
     id
     name

--- a/docs/graphql-api/queries/nested-queries.mdx
+++ b/docs/graphql-api/queries/nested-queries.mdx
@@ -34,7 +34,7 @@ The following is an example of a nested object query using the **object relation
 **Example:** Fetch a list of articles and the name of each article’s author:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesAndAuthors {
   articles {
     id
     title
@@ -79,7 +79,7 @@ The following is an example of a nested object query using the **array relations
 **Example:** Fetch a list of authors and a related, nested list of each author’s articles:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsAndArticles {
   authors {
     id
     name

--- a/docs/graphql-api/queries/pagination.mdx
+++ b/docs/graphql-api/queries/pagination.mdx
@@ -40,7 +40,7 @@ The following are examples of different pagination scenarios:
 **Example:** Fetch the first 5 authors from the list of all authors:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query FirstFiveAuthors {
   authors(
     limit: 5
   ) {
@@ -81,7 +81,7 @@ The following are examples of different pagination scenarios:
 **Example:** Fetch 5 authors from the list of all authors, starting with the 6th one:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsFromSixth {
   authors(
     limit: 5,
     offset:5
@@ -123,7 +123,7 @@ The following are examples of different pagination scenarios:
 **Example:** Fetch a list of authors and a list of their first 2 articles:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsAndArticles {
   authors {
     id
     name
@@ -213,7 +213,7 @@ position of the row in the dataset as done by `offset`, and that duplicate recor
 `offset`:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsGreaterThanFive {
   authors(
     limit: 5,
     where: { id: {_gt: 5} }

--- a/docs/graphql-api/queries/simple-queries.mdx
+++ b/docs/graphql-api/queries/simple-queries.mdx
@@ -32,7 +32,7 @@ You can fetch a single node or multiple nodes of the same type using a simple ob
 **Example:** Fetch a list of authors:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query Authors {
   authors {
     id
     name
@@ -67,7 +67,7 @@ You can fetch a single node or multiple nodes of the same type using a simple ob
 **Example:** Fetch an author using their primary key:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorById {
   authors_by_pk(id: 1) {
     id
     name
@@ -88,7 +88,7 @@ You can fetch a single node or multiple nodes of the same type using a simple ob
 **Example:** Fetch 2 articles after removing the 1st article from the result set.
 
 <GraphiQLIDE
-  query={`query {
+  query={`query TwoArticlesAfterFirst {
   ArticleMany(limit: 2, offset: 1) {
     title
     article_id
@@ -121,7 +121,7 @@ Without an `order_by` in `limit` queries, the results may be unpredictable.
 **Example:** Fetch a list of articles whose title contains the word "The":
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesWithTitleThe {
   ArticleMany(where: {title: {_like: "The"}}) {
     title
     article_id
@@ -148,7 +148,7 @@ Without an `order_by` in `limit` queries, the results may be unpredictable.
 **Example:** Fetch a list of articles with `article_id` in descending order:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesSorted {
   ArticleMany(order_by: {article_id: Desc}) {
     title
     article_id
@@ -179,7 +179,7 @@ Without an `order_by` in `limit` queries, the results may be unpredictable.
 **Example:** Fetch the articles for the given `author_id`:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesByAuthor {
   ArticlesByAuthorMany(args: {author_id: 2}) {
       article_id
       title

--- a/docs/graphql-api/queries/sorting.mdx
+++ b/docs/graphql-api/queries/sorting.mdx
@@ -45,7 +45,7 @@ The following are example queries for different sorting use cases:
 **Example:** Fetch a list of authors sorted by their names in ascending order:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsSorted {
   authors (
     order_by: {name: Asc}
   ) {
@@ -90,7 +90,7 @@ The following are example queries for different sorting use cases:
 **Example:** Fetch a list of authors sorted by their names with a list of their articles that is sorted by their rating:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorsAndArticlesSorted {
   authors (order_by: {name: Asc}) {
     id
     name
@@ -184,7 +184,7 @@ For object relationships only columns can be used for sorting.
 **Example:** Fetch a list of articles that are sorted by their author's ids in descending order:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query ArticlesSortedByAuthor {
   articles (
     order_by: {author: {id: Desc}}
   ) {

--- a/docs/supergraph-modeling/relationships.mdx
+++ b/docs/supergraph-modeling/relationships.mdx
@@ -74,7 +74,7 @@ type** and you want to relate that to a `customers` **model** and whatever objec
 **Example:** Fetch a list of orders along with the customer details for each order:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query OrdersAndCustomers {
   orders {
     orderId
     orderDate
@@ -151,7 +151,7 @@ data and their current session information.
 **Example:** fetch a list of users and the current session information of each user:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query UsersAndCurrentSession {
   users {
     id
     username
@@ -218,7 +218,7 @@ Hasura DDN also allows you to link commands together from a source type to query
 **Example:** fetch the result of one command and use it as input for another command:
 
 <GraphiQLIDE
-  query={`query {
+  query={`query TrackOrder {
     trackOrder(orderId: "ORD12345") {
       trackingNumber
       shippingDetails {

--- a/wiki/docusaurus-mdx-guide/graphiql-ide.mdx
+++ b/wiki/docusaurus-mdx-guide/graphiql-ide.mdx
@@ -24,7 +24,7 @@ Use it as follows:
 import GraphiQLIDE from '@site/src/components/GraphiQLIDE';
 
 <GraphiQLIDE
-  query={`query {
+  query={`query AuthorById {
   author_by_pk(id: 1) {
     id
     name

--- a/wiki/kitchen-sink.mdx
+++ b/wiki/kitchen-sink.mdx
@@ -3,15 +3,16 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GraphiQLIDE from '@site/src/components/GraphiQLIDE';
 import Thumbnail from '@site/src/components/Thumbnail';
-import Introduction from "@site/static/icons/award-02.svg";
-import { OverviewIconCard } from "@site/src/components/OverviewIconCard";
+import Introduction from '@site/static/icons/award-02.svg';
+import { OverviewIconCard } from '@site/src/components/OverviewIconCard';
 
 # The Kitchen Sink
 
-As we bring over components from the old site, we're using this page as a UI playground to make sure everything looks as expected.
-<hr/>
-###### Styles
-## Typography - Headings & Body Copy
+As we bring over components from the old site, we're using this page as a UI playground to make sure everything looks as
+expected.
+
+<hr />
+###### Styles ## Typography - Headings & Body Copy
 
 # Heading level 1
 
@@ -25,9 +26,10 @@ As we bring over components from the old site, we're using this page as a UI pla
 
 ###### Heading level 6
 
-<hr/>
+<hr />
 
 ###### Styles
+
 ## Paragraph text and inline formatting
 
 Some text in a paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet
@@ -50,18 +52,20 @@ This is strikethrough with two tildes: ~~strikethrough~~.
 
 This is inline code with backticks: `inline code`.
 
-<hr/>
+<hr />
 
 ###### Styles
+
 ## Blockquote
 
 ```
 This is a blockquote.
 ```
 
-<hr/>
+<hr />
 
 ###### Styles
+
 ## Lists
 
 ### Unordered List
@@ -76,7 +80,7 @@ This is a blockquote.
 2. Item 2
 3. Item 3
 
-<hr/>
+<hr />
 
 ###### Styles
 
@@ -92,14 +96,9 @@ const quux = 'quuz';
 
 This is just to see what happens 😘
 
-<CodeStep
-  language={`javascript`}
-  code={`console.log("Hey, this works 🤙");`}
-  output={`Hey, this works 🤙`}
->
-</CodeStep>
+<CodeStep language={`javascript`} code={`console.log("Hey, this works 🤙");`} output={`Hey, this works 🤙`}></CodeStep>
 
-<hr/>
+<hr />
 
 ###### Styles
 
@@ -123,7 +122,7 @@ Some API stuff.
   </TabItem>
 </Tabs>
 
-<hr/>
+<hr />
 
 ###### Styles
 
@@ -179,7 +178,7 @@ Deep child content
 
 :::::
 
-<hr/>
+<hr />
 
 ###### Styles
 
@@ -189,7 +188,7 @@ Deep child content
 
 [This is a link with title](https://www.hasura.io 'Hasura')
 
-<hr/>
+<hr />
 
 ###### Styles
 
@@ -199,7 +198,7 @@ Deep child content
 | -------- | -------- |
 | Cell 1   | Cell 2   |
 
-<hr/>
+<hr />
 
 ###### Styles
 
@@ -211,7 +210,7 @@ Deep child content
   <div>
     Some text in a paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue.
 
-    Some text in a paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. 
+    Some text in a paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.
 
   </div>
   <div className="kitchen-image-container heightAuto">
@@ -219,17 +218,19 @@ Deep child content
   </div>
 </div>
 
-<hr/>
+<hr />
 
 ### The full-width
 
-Some text in a paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue.
+Some text in a paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet
+ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et
+diam eget libero egestas mattis sit amet vitae augue.
 
 <div className="kitchen-image-container">
   <p>Img or video container</p>
 </div>
 
-<hr/>
+<hr />
 
 ###### Styles
 
@@ -239,7 +240,7 @@ Here's a sentence with a footnote.[^1]
 
 [^1]: This is the footnote.
 
-<hr/>
+<hr />
 
 ###### Styles
 
@@ -252,14 +253,17 @@ This is a hidden section.
 
 </details>
 
-<hr/>
+<hr />
 
 ###### Styles
 
 ## GraphiQL IDE
 
+**NB: Do note that a name for the query is required, otherwise it will break upon rendering whenever a user attempts to
+"prettify" the query.**
+
 <GraphiQLIDE
-  query={`query {
+  query={`query Users {
   users {
     id
     name
@@ -288,4 +292,3 @@ This is a hidden section.
   }
  }`}
 />
-


### PR DESCRIPTION
## Description

Turns out, whenever we include a query in the <GraphiQLIDE /> component, we must include a name for the query. Otherwise, the component will remove the word "query" from the beginning. This closes hasura/graphql-engine#10384.

[DOCS-2213](https://hasurahq.atlassian.net/browse/DOCS-2213)


[DOCS-2213]: https://hasurahq.atlassian.net/browse/DOCS-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ