### PR TITLE
CI: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -6,7 +6,7 @@ labels:
   - enhancement
 
 body:
-  - type: input
+  - type: textarea
     id: describe-issue
     attributes:
       label: 'Describe the improvement'
@@ -29,45 +29,13 @@ body:
       required: true
 
   - type: textarea
-    id: steps-to-reproduce
-    attributes:
-      label: 'To Reproduce (if applicable)'
-      description:
-        "Steps to reproduce the behavior (if it's an issue). Pretend we're five years old and need everything spelled
-        out."
-      placeholder: "1. Go to '...'\n2. Read '....'\n3. Notice the problem"
-    validations:
-      required: false
-
-  - type: input
-    id: expected-behavior
-    attributes:
-      label: 'Expected behavior or improvement'
-      description:
-        'A clear and concise description of what you expected to see or how you think it can be improved. Because
-        reality is often disappointing.'
-      placeholder: 'I expected to see...'
-    validations:
-      required: true
-
-  - type: input
-    id: screenshots
-    attributes:
-      label: 'Screenshots or Relevant Links'
-      description:
-        'If applicable, add screenshots or links to help explain what we can improve. Because a picture is worth a
-        thousand facepalms.'
-      placeholder: 'Add screenshots or links...'
-    validations:
-      required: false
-
-  - type: textarea
     id: additional-context
     attributes:
-      label: 'Additional context'
+      label: 'Additional context (optional)'
       description:
-        'Add any other context about the problem or suggestion here. The more you tell us, the less we have to guess.
-        And, so you know, we are TERRIBLE guessers.'
+        'Add any other context about the problem or suggestion here. Feel free to add screenshots, recordings, your
+        favorite recipe for flan, etc. The more you tell us, the less we have to guess. And, so you know, we are
+        TERRIBLE guessers.'
       placeholder: 'Additional context...'
     validations:
       required: false


### PR DESCRIPTION
## Description

This PR adds issue templates. Why are we adding these? Primarily, there's two reasons:
- First, with Linear's integrations, any new issues are automatically added as items to be triaged by the docs team.
- Second, and perhaps more important, with the build-in-public campaign we've undertaken with DDN, I feel it's time to make the docs public (after a thorough check over API keys, etc.).

Yes, I channeled my inner @samirtalwar and @seanparkross when writing these. And, no: I've never used the YAML-formatted issue forms, but let's see what happens 🎲

NB: This utilizes the [issue template forms beta](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms), which _should_ result in higher-quality submissions.