### PR TITLE
fix sed in postgres docs

### DIFF
--- a/docs/getting-started/build/_databaseDocs/_postgreSQL/_08-mutate-data.mdx
+++ b/docs/getting-started/build/_databaseDocs/_postgreSQL/_08-mutate-data.mdx
@@ -33,7 +33,7 @@ models.
 This can be done with the following sed script:
 
 ```bash title="Run the following command, updating the referenced paths to match your directory structure:"
-sed -i 's/"mutationsVersion" = null/"mutationsVersion" = "v2"/' app/connector/my_pg/configuration.json
+sed -i 's/"mutationsVersion": null/"mutationsVersion": "v2"/' app/connector/my_pg/configuration.json
 ```
 
 #### Step 2. Introspect the connector and add resources


### PR DESCRIPTION
<!-- 🚧 IMPORTANT: PLEASE READ 🚧 -->
<!-- Thank you for submitting this docs PR! 🤙 -->
<!-- You'll need to complete the two sections below (Description and Quick Links) but please also select `Enable auto-merge` after opening your PR 🙏 -->
<!-- Any merged docs PR will be picked up by our CI/CD pipeline and — if there are no merge conflicts — automatically be deployed to production 🎉 -->

## Description

<!-- 1. Give us a tl;dr of what this docs contribution is / does -->
<!-- 2. If you're submitting docs that are part of the beta release, please add the `hold-for-beta` label -->
I made a mistake with the sed command in https://github.com/hasura/v3-docs/pull/550. This fixes it.

## Quick Links 🚀

 <!-- Add links to the affected pages / sections here for quick review. We'll generate a comment for you after you open the PR with a link to your preview site, which will need to build. -->

## 🤖 DX: Assertion Tests

<!-- Between the comments below, you can add assertions to test your docs contribution! E.g., A user should be able to easily add a comment to their PR's description.  -->
<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->
<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->
