### PR TITLE
Remove default graphql root field and type name prefixes

### DIFF
--- a/docs/business-logic/python.mdx
+++ b/docs/business-logic/python.mdx
@@ -247,7 +247,7 @@ to access at
 
 ```graphql title=" You can then test your new command with the following query:"
 query MyQuery {
-  mySubgraph_formatTimezoneDate(dateString: "2024-03-14T08:00:00Z")
+  formatTimezoneDate(dateString: "2024-03-14T08:00:00Z")
 }
 ```
 

--- a/docs/business-logic/typescript.mdx
+++ b/docs/business-logic/typescript.mdx
@@ -199,7 +199,7 @@ definition:
     dataConnectorCommand:
       function: hello
   graphql:
-    rootFieldName: app_hello
+    rootFieldName: hello
     rootFieldKind: Query
 
 ---

--- a/docs/connectors/mongodb/native-operations/native-mutations.mdx
+++ b/docs/connectors/mongodb/native-operations/native-mutations.mdx
@@ -94,7 +94,7 @@ With the example above, you can then use the query in your GraphQL API like this
 
 ```graphql
 mutation MyMutation {
-  app_insertArtist(artistId: 10000, name: "Pearl Jam") {
+  insertArtist(artistId: 10000, name: "Pearl Jam") {
     ok
     n
   }

--- a/docs/getting-started/build/04-build-your-api.mdx
+++ b/docs/getting-started/build/04-build-your-api.mdx
@@ -87,7 +87,7 @@ When you're ready, hit the run button to execute your query.
 
 ```graphql title=" For example, if we have a Carts model, we can run the following query:"
 query MyFirstQuery {
-  mySubgraph_carts {
+  carts {
     id
     isComplete
     userId

--- a/docs/getting-started/build/05-add-permissions.mdx
+++ b/docs/getting-started/build/05-add-permissions.mdx
@@ -252,7 +252,7 @@ Now, you can execute queries with your custom JWT. For example::
 
 ```graphql
 query PermissionTest {
-  app_users {
+  users {
     id
     email
     favoriteArtist

--- a/docs/getting-started/build/_databaseDocs/_graphql/_08-mutate-data.mdx
+++ b/docs/getting-started/build/_databaseDocs/_graphql/_08-mutate-data.mdx
@@ -23,7 +23,7 @@ Simply head to the GraphiQL explorer in the console and write a valid mutation l
 
 ```graphql
 mutation InsertTestingMutation {
-  mySubgraph_insertTestingOne(object: { name: "Hasura" }) {
+  insertTestingOne(object: { name: "Hasura" }) {
     id
     name
   }
@@ -49,8 +49,8 @@ definition:
     - name: name
       type: String
   graphql:
-    typeName: MySubgraph_TestingInsertInput
-    inputTypeName: MySubgraph_TestingInsertInputInput
+    typeName: TestingInsertInput
+    inputTypeName: TestingInsertInputInput
   dataConnectorTypeMapping:
     - dataConnectorName: my_graphql
       dataConnectorObjectType: testing_insert_input
@@ -81,8 +81,8 @@ definition:
     - name: where
       type: TestingBoolExp
   graphql:
-    typeName: MySubgraph_TestingOnConflict
-    inputTypeName: MySubgraph_TestingOnConflictInput
+    typeName: TestingOnConflict
+    inputTypeName: TestingOnConflictInput
   dataConnectorTypeMapping:
     - dataConnectorName: my_graphql
       dataConnectorObjectType: testing_on_conflict
@@ -131,7 +131,7 @@ definition:
       objects: objects
       onConflict: on_conflict
   graphql:
-    rootFieldName: mySubgraph_insertTesting
+    rootFieldName: insertTesting
     rootFieldKind: Mutation
   description: 'insert data into the table: "testing"'
 

--- a/docs/getting-started/build/_databaseDocs/_python/_06-add-business-logic.mdx
+++ b/docs/getting-started/build/_databaseDocs/_python/_06-add-business-logic.mdx
@@ -196,7 +196,7 @@ ddn console -l
 
 ```graphql title=" You can then test your new command with the following query:"
 query MyQuery {
-  mySubgraph_formatTimezoneDate(dateString: "2024-03-14T08:00:00Z")
+  formatTimezoneDate(dateString: "2024-03-14T08:00:00Z")
 }
 ```
 

--- a/docs/getting-started/build/_databaseDocs/_typescript/_06-add-business-logic.mdx
+++ b/docs/getting-started/build/_databaseDocs/_typescript/_06-add-business-logic.mdx
@@ -202,7 +202,7 @@ ddn console --local
 
 ```graphql title=" You can then test your new command with the following query:"
 query MyQuery {
-  mySubgraph_formatTimezoneDate(dateString: "2024-03-14T08:00:00Z")
+  formatTimezoneDate(dateString: "2024-03-14T08:00:00Z")
 }
 ```
 

--- a/docs/graphql-api/global-ids.mdx
+++ b/docs/graphql-api/global-ids.mdx
@@ -154,8 +154,8 @@ definition:
     - name: name
       type: Text!
   graphql:
-    typeName: App_Users
-    inputTypeName: App_UsersInput
+    typeName: Users
+    inputTypeName: UsersInput
   dataConnectorTypeMapping:
     - dataConnectorName: postgres_connector
       dataConnectorObjectType: users

--- a/docs/graphql-api/queries/filters/nested-remote-objects.mdx
+++ b/docs/graphql-api/queries/filters/nested-remote-objects.mdx
@@ -31,7 +31,7 @@ For example:
 
 ```graphql {2}
 query UsersCompletedOrders {
-  mySubgraph_users(where: { orders: { status: { _eq: "complete" } } }) {
+  users(where: { orders: { status: { _eq: "complete" } } }) {
     id
     name
     orders {

--- a/docs/graphql-api/queries/sorting.mdx
+++ b/docs/graphql-api/queries/sorting.mdx
@@ -240,7 +240,7 @@ you'll receive a validation error like this:
 
 <GraphiQLIDE
   query={`query UserQuery {
-  app_users(order_by: {lastSeen: Asc, createdAt: Asc}) {
+  users(order_by: {lastSeen: Asc, createdAt: Asc}) {
     id
     name
   }
@@ -260,14 +260,14 @@ query like this wherein an array of objects is passed:
 
 <GraphiQLIDE
   query={`query UserQuery {
-  app_users(order_by: [{lastSeen: Asc}, {createdAt: Asc}]) {
+  users(order_by: [{lastSeen: Asc}, {createdAt: Asc}]) {
     id
     name
   }
 }`}
   response={`{
   "data": {
-    "app_users": [
+    "users": [
       {
         "id": "7cf0a66c-65b7-11ed-b904-fb49f034fbbb",
         "name": "Sean"

--- a/docs/observability/explain/index.mdx
+++ b/docs/observability/explain/index.mdx
@@ -163,7 +163,7 @@ their favorite artists from a remote relationship:
 
 ```graphql
 query MyQuery {
-  app_users {
+  users {
     name
     # local relationship
     notifications {
@@ -183,6 +183,6 @@ query MyQuery {
 Now, from [the explain plan](/observability/explain/api-reference#example), we can understand that:
 
 - There are three sequential steps:
-  - Make a selection on the `app_users` model
+  - Make a selection on the `users` model
   - For each user, make a selection on the `artists` model
-- HashJoin the `app_user` and `artists` models to construct the response
+- HashJoin the `users` and `artists` models to construct the response

--- a/docs/supergraph-modeling/boolean-expressions.mdx
+++ b/docs/supergraph-modeling/boolean-expressions.mdx
@@ -155,7 +155,7 @@ definition:
   isNull:
     enable: true
   graphql:
-    typeName: App_Album_bool_exp
+    typeName: Album_bool_exp
 ```
 
 #### BooleanExpressionTypeV1 {#booleanexpressiontype-booleanexpressiontypev1}

--- a/utilities/generate-metadata-docs/schema.json
+++ b/utilities/generate-metadata-docs/schema.json
@@ -2648,7 +2648,7 @@
                           "enable": true
                         },
                         "graphql": {
-                          "typeName": "App_Album_bool_exp"
+                          "typeName": "Album_bool_exp"
                         }
                       }
                     }


### PR DESCRIPTION
CLI metadata generation no longer sets up a default prefix for graphql root fields and graphql type names. This PR removes the subgraph name prefix from metadata and query response examples.

Users can still specify a prefix to be used via the subgraph.yaml file.

<!-- 🚧 IMPORTANT: PLEASE READ 🚧 -->
<!-- Thank you for submitting this docs PR! 🤙 -->
<!-- You'll need to complete the two sections below (Description and Quick Links) but please also select `Enable auto-merge` after opening your PR 🙏 -->
<!-- Any merged docs PR will be picked up by our CI/CD pipeline and — if there are no merge conflicts — automatically be deployed to production 🎉 -->

## Description

<!-- 1. Give us a tl;dr of what this docs contribution is / does -->
<!-- 2. If you're submitting docs that are part of the beta release, please add the `hold-for-beta` label -->

## Quick Links 🚀

 <!-- Add links to the affected pages / sections here for quick review. We'll generate a comment for you after you open the PR with a link to your preview site, which will need to build. -->

## 🤖 DX: Assertion Tests

<!-- Between the comments below, you can add assertions to test your docs contribution! E.g., A user should be able to easily add a comment to their PR's description.  -->
<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->
<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->
