### PR TITLE
Add pricing information for lambda and third-party connectors

### DIFF
--- a/docs/billing/pricing.mdx
+++ b/docs/billing/pricing.mdx
@@ -49,3 +49,13 @@ independent of traffic, meaning that you won't incur higher costs as your traffi
 | DDN Free     | No charges                   | No charges                                                                   | No charges                                                                                |
 | DDN Base     | $5                           | <ul> <li> $0 on shared infra </li> <li>$1,000 for dedicated infra </li></ul> | <ul> <li> $0 on shared infra </li> <li> As charged to Hasura by cloud provider </li></ul> |
 | DDN Advanced | $30                          | <ul> <li> $0 on shared infra </li> <li>$1,000 for dedicated infra </li></ul> | <ul> <li> $0 on shared infra </li> <li> As charged to Hasura by cloud provider </li></ul> |
+
+:::info Optional hosting for lambda and third-party connectors
+
+Regardless of the plan above, if you elect to host your [lambda connectors](/business-logic/overview.mdx) or any
+third-party connectors (i.e., those not developed or verified by Hasura) on Hasura Cloud, you will be charged:
+
+- $0.075/vCPU-hour
+- $0.0075/GiB-hour
+
+:::


### PR DESCRIPTION
## Description 📝

Adds a note aleritng users to pricing for lambda and third-party connectors. Even if they're on DDN Free, they'll still be charged for "any code we don't write ourselves."

## Quick Links 🚀

[Pricing](https://rob-docs-add-lambda-pricing.v3-docs-eny.pages.dev/billing/pricing)