### PR TITLE
Quickstart with postgres should not do command add

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -101,7 +101,7 @@ This will then be used in the next step to generate metadata for each resource f
 
 <Step
 language="bash"
-code={`ddn model add my_connector '*'\nddn command add my_connector '*'\nddn relationship add my_connector '*'`}
+code={`ddn model add my_connector '*'\nddn relationship add my_connector '*'`}
 heading={`Add your resources`}
 >
 


### PR DESCRIPTION
## Description 📝

Quickstart uses a postgres database which does not have any commands.

Doing command add shows a slightly scary error message telling the users that there are no commands.

The disadvantage is that we no longer introduce the primitive in the quickstart. Instead, we should introduce command add elsewhere.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->