### PR TITLE
Update quickstart.mdx add missing “be”

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -141,7 +141,7 @@ and try it out!
 
 **Congratulations! At this point, you've created your very first, fully-functioning supergraph 🎉**
 
-Next, lets deploy your supergraph to Hasura DDN. Note that your data source will need to accessible from the internet to
+Next, lets deploy your supergraph to Hasura DDN. Note that your data source will need to be accessible from the internet to
 be able to connect to it from Hasura DDN.
 
 </Step>


### PR DESCRIPTION
## Description 📝

Adds a missing "be" to the quickstart text. 

[Thread](https://hasurahq.slack.com/archives/CKASRHUM8/p1725057620030629)

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->
/getting-started/quickstart
