### PR TITLE
Add reference in the Postgres docs to mention the certificate environment variables.

### DIFF
--- a/docs/connectors/postgresql/configuration-reference/index.mdx
+++ b/docs/connectors/postgresql/configuration-reference/index.mdx
@@ -103,6 +103,14 @@ or Docker container:
 - `CLIENT_KEY`: the contents of the SSL client key.
 - `ROOT_CERT`: the contents of the SSL root certificate.
 
+If your certificates are stored in files, these files can be read into
+environment variables. As an example, we could read the client certificate
+into the environment variable like so:
+
+```bash
+CLIENT_CERT="$(cat client-certficate.pem)"
+```
+
 ### Updating with introspection
 
 Whenever the schema of your database changes you will need to update your data connector configuration accordingly to


### PR DESCRIPTION
## Description 📝

Hopefully not too controversial: this adds a paragraph to the Postgres documentation to note which environment variables can be used to configure SSL certificates.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
A user should be able to discover the environment variables involved in configuring SSL certificates.
<!-- DX:Assertion-end -->