### PR TITLE
Fix incorrect codemod command example

### DIFF
--- a/docs/project-configuration/upgrading-project-config/upgrade-context-v3.mdx
+++ b/docs/project-configuration/upgrading-project-config/upgrade-context-v3.mdx
@@ -84,7 +84,7 @@ ddn update-cli
 ```
 2. Run codemod from Hasura project directory to update your project context configuration to v3.
 ```bash
-ddn codemod upgrade-context-v2-to-v3
+ddn codemod upgrade-context-v2-to-v3 --dir .
 ```
 3. By default, we add a `docker-start` script for you so that you can just run `ddn run docker-start` to get the local
 local supergraph and connectors running using Docker


### PR DESCRIPTION
## Description 📝

The example we give for running the context config upgrade codemod is not correct. When I run it as stated in the docs, I get the following error (CLI v2.5.0)

![image](https://github.com/user-attachments/assets/bdd0acd5-f1d1-4a76-9fe4-ebfff53f05e1)

The command we really need to run is (added `--dir .`)

```
ddn codemod upgrade-context-v2-to-v3 --dir .
```

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->
https://daniel-codemod-example-fix.v3-docs-eny.pages.dev/project-configuration/upgrading-project-config/upgrade-context-v3#migrate-an-existing-project

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->