### PR TITLE
Fix typo in plugin quickstart page

### DIFF
--- a/docs/plugins/quickstart.mdx
+++ b/docs/plugins/quickstart.mdx
@@ -21,7 +21,7 @@ allowlist layer on top of your supergraph to restrict access to only specific qu
 
 :::info We're using Cloudflare Wrangler
 
-In this exmaple, we're using Cloudflare Wrangler to deploy our plugin as a Cloudflare Worker. However, you can use any
+In this example, we're using Cloudflare Wrangler to deploy our plugin as a Cloudflare Worker. However, you can use any
 other tool or service that hosts HTTPS services you wish. You can get started with Wrangler
 [here](https://developers.cloudflare.com/workers/wrangler/install-and-update/).
 


### PR DESCRIPTION
## Description 📝
Fixes a typo in the plugin quickstart page.

## Quick Links 🚀

https://daniel-fix-typo.v3-docs-eny.pages.dev/plugins/quickstart/

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->