### PR TITLE
Docs: Fix Windows CLI install instructions

### DIFF
--- a/docs/_install-the-cli.mdx
+++ b/docs/_install-the-cli.mdx
@@ -21,7 +21,7 @@ Simply run the installer script in your terminal:
 Download the latest `cli-ddn-windows-amd64.exe` binary and run it.
 
 <CodeBlock language="bash">
-  {`curl -L https://graphql-engine-cdn.hasura.io/ddn/cli/${
+  {`curl.exe -L https://graphql-engine-cdn.hasura.io/ddn/cli/${
     props.revision || "v4"
   }/latest/cli-ddn-windows-amd64.exe -o ddn.exe`}
 </CodeBlock>


### PR DESCRIPTION
## Description 📝

Fixes Widnows CLI install instructions to use the executable instead of the lingering alias. Context: https://hasurahq.slack.com/archives/C05PBMG3GD9/p1726722063685779?thread_ts=1726628246.111889&cid=C05PBMG3GD9

## Quick Links 🚀

Quickstart with the install component.

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
A user should be able to install the CLI without issue on Windows.
<!-- DX:Assertion-end -->