### PR TITLE
Fix location of Hello.hml for Node.js Lambda connector

### DIFF
--- a/docs/business-logic/typescript.mdx
+++ b/docs/business-logic/typescript.mdx
@@ -131,8 +131,8 @@ The CLI then used this to create Hasura metadata for each function which can the
 :::info Each function or procedure has tracked metadata
 
 <details>
-<summary>For the boilerplate `hello()` function included by default, you'll see a `Hello.hml` file in the `commands`
-subdirectory of the connector. Click here to check it out »</summary>
+<summary>For the boilerplate `hello()` function included by default, you'll see a `Hello.hml` file in the `metadata`
+directory of the subgraph. Click here to check it out »</summary>
 
 ```yaml
 ---


### PR DESCRIPTION
## Description 📝

Fix location of Hello.hml for Node.js Lambda connector

## Quick Links 🚀

[Link](https://sean-fix-file-location-lamda.v3-docs-eny.pages.dev/business-logic/typescript/#what-did-this-do-1)

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
Fixes location of Hello.hml for Node.js Lambda connector
<!-- DX:Assertion-end -->