### PR TITLE
CI: Add PDF exporter

### DIFF
--- a/.github/workflows/create-docs-pdf.yml
+++ b/.github/workflows/create-docs-pdf.yml
@@ -1,0 +1,38 @@
+name: Build and Upload PDF
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Prince
+        run: |
+          curl https://www.princexml.com/download/prince-14.2-linux-generic-x86_64.tar.gz -O
+          tar zxf prince-14.2-linux-generic-x86_64.tar.gz
+          cd prince-14.2-linux-generic-x86_64
+          yes "" | sudo ./install.sh
+
+      - name: Get current date
+        id: date
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Build PDF
+        run: npx docusaurus-prince-pdf -u https://hasura.io/docs/3.0/index/ --output "output-$(date +'%Y-%m-%d').pdf"
+
+      - name: Upload PDF as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: pdf-output
+          path: output-$(date +'%Y-%m-%d').pdf
+          if-no-files-found: error


### PR DESCRIPTION
## Description 📝

Adds a GitHub Action which can be manually invoked to generate a PDF of docs in their current production state and upload the artifact to GitHub.

**NB: Merging this so we can continue with testing.**