### PR TITLE
CI: Update Review Logic

### DIFF
--- a/utilities/create-docs-ticket/src/assignGitHubReviewer.ts
+++ b/utilities/create-docs-ticket/src/assignGitHubReviewer.ts
@@ -1,15 +1,10 @@
 import dotenv from 'dotenv';
+import { Reviewer } from './types';
 
 dotenv.config();
 
-interface Reviewer {
-  github_username: string;
-  name: string;
-}
-
-export const assignGitHubReviewer = async (prUrl: string): Promise<Response> => {
+export const assignGitHubReviewer = async (prUrl: string, assignedReviewer: Reviewer): Promise<Response> => {
   const prNumber = prUrl.split('/').pop();
-  const reviewer: Reviewer = JSON.parse(process.env.REVIEWER!);
   const apiUrl = `https://api.github.com/repos/${process.env.REPO_OWNER}/${process.env.REPO_NAME}/pulls/${prNumber}/requested_reviewers`;
   const assignResponse = await fetch(apiUrl, {
     method: 'POST',
@@ -18,12 +13,12 @@ export const assignGitHubReviewer = async (prUrl: string): Promise<Response> => 
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      reviewers: [reviewer.github_username],
+      reviewers: [assignedReviewer.github_username],
     }),
   });
 
   if (assignResponse.ok) {
-    console.log(`${reviewer.name} has been assigned to review this PR on GitHub.`);
+    console.log(`${assignedReviewer.name} has been assigned to review this PR on GitHub.`);
   } else {
     console.error('Error assigning reviewer on GitHub:', assignResponse.statusText);
   }

--- a/utilities/create-docs-ticket/src/githubComment.ts
+++ b/utilities/create-docs-ticket/src/githubComment.ts
@@ -1,15 +1,7 @@
 import dotenv from 'dotenv';
+import { Reviewer } from './types';
 
 dotenv.config();
-
-interface Reviewer {
-  github_username: string;
-  name: string;
-}
-
-interface Reviewer {
-  name: string;
-}
 
 const generateGhComment = (author: string, reviewer: Reviewer): string => {
   return `@${author} Thanks for your PR! I've assigned @${reviewer.github_username} to review it.`;
@@ -29,10 +21,9 @@ const getPrAuthor = async (prUrl: string): Promise<string | null> => {
   return pr.user?.login || null;
 };
 
-export const addGitHubCommentToPr = async (prUrl: string): Promise<string> => {
+export const addGitHubCommentToPr = async (prUrl: string, assignedReviewer: Reviewer): Promise<string> => {
   const prNumber = prUrl.split('/').pop();
   const apiUrl = `https://api.github.com/repos/${process.env.REPO_OWNER}/${process.env.REPO_NAME}/issues/${prNumber}/comments`;
-  const reviewer: Reviewer = JSON.parse(process.env.REVIEWER!);
   const author = await getPrAuthor(prUrl);
   if (!author) {
     console.error('Error getting author, skipping comment');
@@ -45,7 +36,7 @@ export const addGitHubCommentToPr = async (prUrl: string): Promise<string> => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      body: `${generateGhComment(author, reviewer)}`,
+      body: `${generateGhComment(author, assignedReviewer)}`,
     }),
   });
   const comment = await addComment.json();

--- a/utilities/create-docs-ticket/src/linearTicketGeneration.ts
+++ b/utilities/create-docs-ticket/src/linearTicketGeneration.ts
@@ -1,18 +1,14 @@
 import dotenv from 'dotenv';
+import { Reviewer } from './types';
 import { linearClient } from './linearClient';
-import { AttachmentPayload, IssuePayload } from '@linear/sdk';
+import { AttachmentPayload } from '@linear/sdk';
 
 dotenv.config();
 
 interface PRInfo {
   prTitle: string;
   prUrl: string;
-}
-
-interface Reviewer {
-  linear_id: string;
-  github_username: string;
-  name: string;
+  assignedReviewer: Reviewer;
 }
 
 const getCurrentCycle = async (): Promise<string> => {
@@ -26,14 +22,13 @@ const getCurrentCycle = async (): Promise<string> => {
   }
 };
 
-export const createLinearTicket = async ({ prTitle, prUrl }: PRInfo) => {
-  const reviewer: Reviewer = JSON.parse(process.env.REVIEWER!);
+export const createLinearTicket = async ({ prTitle, prUrl, assignedReviewer }: PRInfo) => {
   return await linearClient.createIssue({
     teamId: process.env.LINEAR_TEAM_ID!,
     title: `DDN PR Review: ${prTitle}`,
     description: `Link to PR: ${prUrl}`,
     stateId: process.env.LINEAR_TODO_COLUMN_ID!,
-    assigneeId: reviewer.linear_id,
+    assigneeId: assignedReviewer.linear_id,
     cycleId: await getCurrentCycle(),
   });
 };

--- a/utilities/create-docs-ticket/src/selectReviewer.ts
+++ b/utilities/create-docs-ticket/src/selectReviewer.ts
@@ -1,0 +1,26 @@
+import { Reviewer } from './types';
+
+// Get the current hour
+function getCurrentHour(): number {
+  const now = new Date();
+  return now.getUTCHours();
+}
+
+// Find the right JSON
+function findReviewerByName(reviewers: Reviewer[], name: string): Reviewer | undefined {
+  return reviewers.find(reviewer => reviewer.name === name);
+}
+
+// Whose turn is it?
+export const selectReviewer = (reviewers: Reviewer[]): Reviewer => {
+  const hour = getCurrentHour();
+
+  const sean = findReviewerByName(reviewers, 'Sean');
+  const rob = findReviewerByName(reviewers, 'Rob');
+
+  if (!sean || !rob) {
+    throw new Error('Reviewer not found');
+  }
+
+  return hour < 12 ? sean : rob;
+};

--- a/utilities/create-docs-ticket/src/types.ts
+++ b/utilities/create-docs-ticket/src/types.ts
@@ -1,0 +1,6 @@
+export interface Reviewer {
+  name: string;
+  github_username: string;
+  linear_id: string;
+  slack_link: string;
+}


### PR DESCRIPTION
## Description 📝

Updates how we assign reviewers to PRs for docs tickets. Instead of hardcoding a single reviewer from the environment, I’ve switched things up to dynamically select a reviewer (either Sean or me, depending on the time of day).

**What changed:**
- Introduced `SEAN_INFO` and `ROB_INFO` env vars to store each reviewer’s details.
- Swapped out the static `REVIEWER` logic for a `selectReviewer` function that picks the right person based on UTC hour.
- Updated `assignGitHubReviewer`, `addGitHubCommentToPr`, and `createLinearTicket` to pass in the assigned reviewer, keeping things consistent.
- Removed redundant `Reviewer` interfaces scattered across files—now we’re importing it cleanly from a single source.

This should make it easier to maintain and tweak the reviewer assignment logic without touching env vars every time. Give it a look, and let me know if anything feels off!

## TODO:
- [x] Switch out the env vars in the repo
