### PR TITLE
Fix incorrect CLI flags in subgraph prefixing

### DIFF
--- a/docs/federation/subgraph-prefixing.mdx
+++ b/docs/federation/subgraph-prefixing.mdx
@@ -54,14 +54,14 @@ By default, the `subgraph.yaml` file is generated without any prefixes. You can 
 
 This codemod will rename prefixes in already generated metadata. It can also be used to add or remove prefixes altogether.
 
-The `fromGraphqlRootField` prefix will be stripped if provided, and the new prefix, `graphqlRootField`, will be added. 
+The `--from-graphql-root-field` prefix will be stripped if provided, and the new prefix, `--graphql-root-field`, will be added. 
 If the new prefix is already present, it will not be reapplied.
 
 Examples:
 ```bash
 # Add root field and type name prefixes to the subgraph set in the context
-ddn codemod rename-graphql-prefixes --graphqlRootField 'app_' --graphqlTypeName 'App_'
+ddn codemod rename-graphql-prefixes --graphql-root-field 'app_' --graphql-type-name 'App_'
 
 # Change the root field prefix for the specified subgraph
-ddn codemod rename-graphql-prefixes --subgraph app/subgraph.yaml --fromGraphqlRootField 'app_' --graphqlRootField 'new_' 
+ddn codemod rename-graphql-prefixes --subgraph app/subgraph.yaml --from-graphql-root-field 'app_' --graphql-root-field 'new_'
 ```


### PR DESCRIPTION
## Description 📝
This fixes the CLI flags in the Subgraph Prefixing doco page, which are wrong. They were written using camelCase, rather than kebab-case.


## Quick Links 🚀

[Subgraph Prefixing page](https://daniel-fix-subgraph-prefixin.v3-docs-eny.pages.dev/federation/subgraph-prefixing/#renaming-graphql-root-fields-and-graphql-type-name-prefixes)

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->