### PR TITLE
Quickstart tweak time estimate to be same as video

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: Quickstart
-description: "Create your first supergraph API with Hasura DDN in less than two minutes."
+description: "Create your first supergraph API with Hasura DDN in less than a minute."
 keywords:
   - hasura ddn
   - graphql api
@@ -20,7 +20,7 @@ import InstallTheCli from "@site/docs/_install-the-cli.mdx";
 
 <div className="flex flex-col xl:flex-row gap-6 xl:gap-12">
   <div className="xl:w-2/5">
-    <p className="text-[1.3rem]">In less than <em>2 minutes</em> and without needing a data source connection string, you can have a supergraph API deployed on Hasura DDN. 🚀</p>
+    <p className="text-[1.3rem]">In less than <em>a minute</em> and without needing a data source connection string, you can have a supergraph API deployed on Hasura DDN. 🚀</p>
   </div>
   <div className="xl:w-3/5">
       <iframe


### PR DESCRIPTION
## Description 📝

Tweak the time estimate in Quickstart to be same as video.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->