### PR TITLE
Tighten Home Page Communication with CTA to Quickstart

### DIFF
--- a/docs/basics/background.mdx
+++ b/docs/basics/background.mdx
@@ -24,15 +24,25 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 ## Why are we building Hasura DDN?
 
-With the rapid evolution of digital experiences, businesses are constantly seeking solutions to build next-generation
-applications efficiently and cost-effectively. However, a common bottleneck is the inability to swiftly provide secure
-and efficient access to necessary data.
+A common bottleneck to building next-generation applications is the inability to swiftly provide secure and efficient
+access to necessary data.
 
 Hasura DDN addresses this challenge, by utilizing the **[data supergraph](/basics/core-concepts.mdx#supergraph)**
 architecture and development methodology in a way which unlocks improved team and developer productivity.
 
 In conversations with developers focused on building APIs and microservices, we've identified key challenges within the
-community. Hasura DDN is designed to address these challenges, simplifying the workflow for software developers and
+community. 
+
+- Slow product development and time-to-market cycles.
+- Difficult data source federation and API composition.
+- Runaway microservice sprawl.
+- Unstructured governance with difficult collaboration.
+- Complex and untrustworthy security.
+- Compromised performance and difficult scalability.
+- Opaque query observability.
+- Multiple API consumers with different requirements.
+
+Hasura DDN is designed to address these challenges, simplifying the workflow for software developers and
 architects globally.
 
 ### For API Authors

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -32,20 +32,19 @@ import Quickstart from "@site/static/icons/cloud-lightning.svg";
 import Introduction from "@site/static/icons/award-02.svg";
 import { OverviewIconCard } from "@site/src/components/OverviewIconCard";
 import Link from "@docusaurus/Link";
-import useBaseUrl from "@docusaurus/useBaseUrl";
 
 # Hasura DDN Documentation
 
 <div className={'front-matter'}>
   <div>
-    Hasura DDN streamlines the development and operation of modern federated data APIs, solving key challenges in the process.
+    Hasura DDN streamlines the development and operation of modern federated data APIs, <Link to="/basics/background/">solving key challenges</Link> in the process.
 
     With powerful tooling and a code-driven workflow, Hasura DDN is not just an improvement in the data access
     portion of the product development lifecycle, but a complete game-changer in the way APIs are created, run, and managed.
 
-    <a href={useBaseUrl("/getting-started/quickstart/")} className="cta-button mb-5 xl:mb-0 xl:mt-8">
-      <span>Quickstart.</span>&nbsp;&nbsp;Free. Easy. Fast.
-    </a>
+    <Link to="/getting-started/quickstart/" className="cta-button mb-5 xl:mb-0 xl:mt-8">
+      <span>Quickstart.</span> Free. Easy. Fast.
+    </Link>
 
   </div>
   <div className={'video-wrapper'}>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -28,51 +28,24 @@ import Thumbnail from "@site/src/components/Thumbnail";
 import Basics from "@site/static/icons/book-open-01.svg";
 import GraphQLAPI from "@site/static/icons/graphql-logo.svg";
 import ChevronRight from "@site/static/icons/chevron-right.svg";
-import GetStarted from "@site/static/icons/cloud-lightning.svg";
+import Quickstart from "@site/static/icons/cloud-lightning.svg";
 import Introduction from "@site/static/icons/award-02.svg";
 import { OverviewIconCard } from "@site/src/components/OverviewIconCard";
 import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 # Hasura DDN Documentation
 
 <div className={'front-matter'}>
   <div>
-    Hasura DDN directly addresses the problems developing and running modern APIs, including:
-    <ul className={"introList"}>
-      <li>
-        Slow product development and time-to-market cycles.
-      </li>
-      <li>
-        Difficult data source federation and API composition.
-      </li>
-      <li>
-        Runaway microservice sprawl.
-      </li>
-      <li>
-        Unstructured governance with difficult collaboration.
-      </li>
-      <li>
-        Complex and untrustworthy security.
-      </li>
-      <li>
-        Compromised performance and difficult scalability.
-      </li>
-      <li>
-        Opaque or impossible complex query observability.
-      </li>
-      <li>
-        Multiple API consumers with different requirements.
-      </li>
-    </ul>
-
-    Hasura DDN solves all of these issues.
-
-    Hasura's approach is to facilitate connection between the Hasura Engine and data sources via Data Connectors and to
-    define these connections using simple, declarative metadata in order to create a rich Supergraph of
-    interconnected sources, business logic, and third-party APIs.
+    Hasura DDN streamlines the development and operation of modern federated data APIs, solving key challenges in the process.
 
     With powerful tooling and a code-driven workflow, Hasura DDN is not just an improvement in the data access
-    portion of the product development lifecycle, but a complete game-changer in the way APIs are created and run.
+    portion of the product development lifecycle, but a complete game-changer in the way APIs are created, run, and managed.
+
+    <a href={useBaseUrl("/getting-started/quickstart/")} className="cta-button mb-5 xl:mb-0 xl:mt-8">
+      <span>Quickstart.</span>&nbsp;&nbsp;Free. Easy. Fast.
+    </a>
 
   </div>
   <div className={'video-wrapper'}>
@@ -89,6 +62,22 @@ import Link from "@docusaurus/Link";
 ### Popular Topics
 
 <div className={"card-wrapper"}>
+<div className={"card"}>
+    <div className={"card-content-items"}>
+      <Thumbnail src="/img/get-started.png" alt="Get Started" />
+      <div className={"card-content"}>
+        <h4>
+          <Quickstart />
+          Quickstart
+        </h4>
+        <p>Learn how to get started with Hasura and deploy a GraphQL API on your data in minutes.</p>
+      </div>
+    </div>
+    <Link href={"/getting-started/quickstart"}>
+      Quickstart with Hasura DDN
+      <ChevronRight />
+    </Link>
+  </div>
   <div className={"card"}>
     <div className={"card-content-items"}>
       <Thumbnail src="/img/basics.png" alt="Basics" />
@@ -105,22 +94,6 @@ import Link from "@docusaurus/Link";
     </div>
     <Link href={"/basics/overview/"}>
       Learn the basics
-      <ChevronRight />
-    </Link>
-  </div>
-  <div className={"card"}>
-    <div className={"card-content-items"}>
-      <Thumbnail src="/img/get-started.png" alt="Get Started" />
-      <div className={"card-content"}>
-        <h4>
-          <GetStarted />
-          Get Started
-        </h4>
-        <p>Learn how to get started with Hasura and deploy a GraphQL API on your data in minutes.</p>
-      </div>
-    </div>
-    <Link href={"/getting-started/overview"}>
-      Create your first project
       <ChevronRight />
     </Link>
   </div>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -40,7 +40,7 @@ import Link from "@docusaurus/Link";
     Hasura DDN streamlines the development and operation of modern federated data APIs, <Link to="/basics/background/">solving key challenges</Link> in the process.
 
     With powerful tooling and a code-driven workflow, Hasura DDN is not just an improvement in the data access
-    portion of the product development lifecycle, but a complete game-changer in the way APIs are created, run, and managed.
+    portion of the product development lifecycle, but a complete game-changer in the way you create, run, and manage APIs.
 
     <Link to="/getting-started/quickstart/" className="cta-button mb-5 xl:mb-0 xl:mt-8">
       <span>Quickstart.</span> Free. Easy. Fast.

--- a/docs/support/faq.mdx
+++ b/docs/support/faq.mdx
@@ -109,7 +109,7 @@ This ensures that your API remains available to users while updates are being ap
 unique build ID, making it easier to track and manage different versions of your metadata. This enhances transparency
 and auditability during the development process.
 
-### What can be automated?
+## What can be automated?
 
 Since metadata authoring is mostly code driven using the
 [Hasura VS Code extension](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura) and the CLI, many
@@ -178,7 +178,7 @@ We will still support, maintain and improve Hasura v2 as per our
 [version support policy](https://hasura.io/docs/latest/policies/versioning/) and will be providing migration tools to
 move Hasura v2 deployments to DDN in the near future.
 
-# If I have an Alpha/Beta DDN project, will it be compatible with the GA release?
+## If I have an Alpha/Beta DDN project, will it be compatible with the GA release?
 
 We recommend [creating a new project](getting-started/build/index.mdx) and use the new CLI to populate metadata again.
 
@@ -195,14 +195,14 @@ Rust's performance, ecosystem and community for DDN. Rust is a modern, high-perf
 also gaining much traction in the cloud-native space, and we are excited to be using it for the significant parts of the
 Hasura DDN codebase. If you are a Rust developer and want to do cool stuff, please check out our careers page.
 
-### If currently running a v2.x will it be moved automatically to v3?
+## If currently running a v2.x will it be moved automatically to v3?
 
 No, it will not. The v2 cloud projects will remain untouched and there will be no change of business. Moving to DDN will
 be an opt-in process. Having said that, we strongly encourage upgrading to DDN early when features you require are
 available. Our teams are available to make the migration process as smooth as possible and please keep an eye on our
 [official announcements and releases](https://hasura.io/community/) for upcoming information about migration tools.
 
-### Can we request to lock ourselves to 2.x?
+## Can we request to lock ourselves to 2.x?
 
 The migration is an opt-in process, so you do not need to request to have yourselves locked to a particular version. If
 however, you see no upgrade path even in the next two years, please give us a heads-up and we will work out options with

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -541,6 +541,7 @@ div:has(> .DocSearch.DocSearch-Button) {
 
 .cta-button p span {
   @apply font-bold;
+  margin-right: 8px;
 }
 
 .cta-button p::after {
@@ -548,7 +549,7 @@ div:has(> .DocSearch.DocSearch-Button) {
   background-image: url('data:image/svg+xml;utf8,<svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.5 15.5L12.5 10.5L7.5 5.5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
   width: 20px;
   height: 21px;
-  margin-left: 10px;
+  margin-left: 8px;
   display: inline-block;
   transition: transform 0.3s ease-in-out;
 }
@@ -1507,10 +1508,10 @@ table td {
 ol {
   font-size: 0.9375rem;
 
-  li {
+  /* li {
     @apply mb-4 mt-4;
     line-height: 1.625rem;
-  }
+  } */
 }
 
 .front-matter li {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -41,6 +41,7 @@
   --ifm-color-info-dark: #c6d6ff;
   --purple-pill: #8c49fa;
   --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15,12.5,L10,7.5L5,12.5" stroke="gray" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  --cta-button-green: #22c55e;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -513,6 +514,47 @@ div:has(> .DocSearch.DocSearch-Button) {
 
 .navbar__items--right .navbar__link:last-child:hover {
   background-color: var(--primary-blue-600);
+}
+
+.cta-button {
+  display: inline-block;
+  /* @apply bg-green-500; */
+  background-color: var(--secondary-blue-500);
+  padding: 12px 24px;
+  border-radius: 38px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.cta-button:hover {
+  /* @apply bg-green-600; */
+  background-color: var(--primary-blue-600);
+  text-decoration: none;
+}
+
+.cta-button p {
+  color: var(--base-neutral-0);
+  margin-bottom: 0;
+  display: flex;
+  align-items: center;
+}
+
+.cta-button p span {
+  @apply font-bold;
+}
+
+.cta-button p::after {
+  content: '';
+  background-image: url('data:image/svg+xml;utf8,<svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.5 15.5L12.5 10.5L7.5 5.5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  width: 20px;
+  height: 21px;
+  margin-left: 10px;
+  display: inline-block;
+  transition: transform 0.3s ease-in-out;
+}
+
+.cta-button:hover p::after {
+  transform: translateX(4px);
 }
 
 /* Header */


### PR DESCRIPTION
## Description 📝

Tightens Home Page Communication with CTA to Quickstart. Moves pain points on homepage to Basics > Background.

Note. Tried green CTA button style. Left CSS there but commented out. Worth a look. 

Also, side quests: 
- Fixes FAQ headings.
- Removes the extra line height double ups in `li`s. Something was going weird there. Checking out another day. 

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->
[Home](https://sean-docs-home-tighten.v3-docs-eny.pages.dev/index/)

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->