### PR TITLE
Nit: link to docs for graphql connector

### DIFF
--- a/docs/getting-started/build/03-connect-to-data/_databaseDocs/_graphql/_01-connect-a-source.mdx
+++ b/docs/getting-started/build/03-connect-to-data/_databaseDocs/_graphql/_01-connect-a-source.mdx
@@ -4,7 +4,7 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 You can easily and quickly connect any GraphQL API to your supergraph.
 
-To do this, we use the Hasura [GraphQL Native Data Connector](https://github.com/hasura/ndc-graphql) to facilitate the
+To do this, we use the Hasura [GraphQL Native Data Connector](/connectors/external-apis/graphql.mdx) to facilitate the
 connection.
 
 <Thumbnail src="/img/get-started/ERD/connect-data.png" alt="Connect a data source" width="1000px" />


### PR DESCRIPTION
## Description 📝
Nit: Change link from GitHub to docs for GraphQL connector from getting started page. 

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->
/getting-started/build/connect-to-data/connect-a-source?db=GraphQL

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->