### PR TITLE
Demonstrate empty pre- and post- checks in Postgres mutations

### DIFF
--- a/docs/getting-started/build/_databaseDocs/_postgreSQL/_08-mutate-data.mdx
+++ b/docs/getting-started/build/_databaseDocs/_postgreSQL/_08-mutate-data.mdx
@@ -97,6 +97,35 @@ definition:
                   literal: b1358c05-a457-41e7-b77e-56efce2cdd06
 ```
 
+If we don't wish to provide any checks at this time, we can provide the following:
+
+```hml
+value:
+  booleanExpression:
+    and: []
+```
+
+For example, used here as both `pre-` and `post-` checks on an update mutation:
+
+```hml
+kind: CommandPermissions
+version: v1
+definition:
+  commandName: V2UpdateUsersById
+  permissions:
+    - role: admin
+      allowExecution: true
+      argumentPresets:
+        - argument: preCheck
+          value:
+            booleanExpression:
+              and: []
+        - argument: postCheck
+          value:
+            booleanExpression:
+              and: []
+```
+
 #### Step 4. Build and run
 
 After editing the `.hml` files of your models, create a new build of our supergraph:


### PR DESCRIPTION
## Description 📝

Users are finding it hard to use these mutations without understanding boolean expressions, so let's add an example for using them without any checks.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->