### PR TITLE
Docs: Simplify CTA in quickstart

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -20,16 +20,19 @@ import InstallTheCli from "@site/docs/_install-the-cli.mdx";
 
 <div className="flex flex-col xl:flex-row gap-6 xl:gap-12">
   <div className="xl:w-2/5">
-    <p className="text-[1.3rem]">In less than <em>a minute</em> and without needing a data source connection string, you can have a supergraph API deployed on Hasura DDN. 🚀</p>
+    <p className="text-[1.3rem]">
+      In less than <em>a minute</em> and without needing a data source connection string, you can have a supergraph API
+      deployed on Hasura DDN. 🚀
+    </p>
   </div>
   <div className="xl:w-3/5">
-      <iframe
-         src="https://www.youtube.com/embed/OsO6TzwFb30"
-         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-         allowFullScreen
-         title="Quickstart video"
-         className="max-w-full"
-      />
+    <iframe
+      src="https://www.youtube.com/embed/OsO6TzwFb30"
+      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+      title="Quickstart video"
+      className="max-w-full"
+    />
   </div>
 </div>
 
@@ -206,40 +209,18 @@ connectors' URLs, and creates a new immutable build of your supergraph. You can 
 
 What we've laid out above is the quickest way to get started with Hasura DDN. However, you have complete, granular
 control over each step in the process and can extend and customize your supergraph to fit your teams' needs. After
-deploying your first supergraph, check out these sections to see what your supergraph can do!
+deploying your first supergraph, take your next steps with Hasura DDN 👇
 
-### Integrate custom business logic
+### Connect your own data source
 
-We've revolutionized how custom business logic is integrated into an API with our lambda connectors for TypeScript and
-Python. Gone are the days of writing separate microservices to handle business logic; with Hasura DDN, you can write
-your custom functions and expose them directly via your API! Plus, you get all the benefits of the supergraph, including
-the ability to add relationships and permissions for each function. Check it out
-[here](/getting-started/build/06-add-business-logic.mdx).
+If you didn't connect your own data source in the guide above,
+[give it a shot](/getting-started/build/03-connect-to-data/01-connect-a-source.mdx)!
 
-### Add authorization
+Hasura will never affect the schema, and you maintain full control over your data. Hasura maps your existing schema to a
+powerful, flexible API without altering any underlying structures.
 
-You can quickly and easily create access-control rules for any entity in your supergraph using
-[permissions](/supergraph-modeling/permissions.mdx). Learn how to add ModelPermissions to control row-level access, and
-TypePermissions to control which columns are exposed to specific user roles. You can check both out in
-[this guide](/getting-started/build/05-add-permissions.mdx).
+### Add a collaborator
 
-### Iterate on your API
-
-In your day-to-day development cycle, you will be making changes to your data source's schema while developing new
-features. When this happens, you'll need to update your Hasura metadata to bring those changes into your API. Check out
-how to iterate on your API [here](/getting-started/build/03-connect-to-data/02-create-source-metadata.mdx).
-
-### Create relationships across sources
-
-Arguably, the biggest benefit of a GraphQL API is your ability to create nested queries that allow you to return data
-from multiple tables and — with Hasura DDN — multiple sources. With Hasura DDN's metadata-driven approach, you can
-easily author relationships, using our
-[VS Code extension](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura), linking together disparate
-data sources for efficient, elegant queries to power your modern applications. Learn how
-[here](/getting-started/build/07-create-a-relationship.mdx).
-
-### Add new subgraphs
-
-Hasura DDN makes it easy to collaborate and iteratively build a federated API using individual subgraphs. Subgraphs can
-be owned by specific teams and their metadata can even live in separate repositories, ensuring discrete ownership rules
-are honored. Learn how to add new subgraphs to your supergraph [here](/getting-started/build/02-init-subgraph.mdx).
+Hasura DDN makes it easy to collaborate and iteratively build an API with other contributors. You can select from a
+variety of roles ensuring your teammates have the appropriate access level while maintaining control for those who need
+it. [Add you first collaborator](/getting-started/collaborate/invite.mdx)!


### PR DESCRIPTION
## Description 📝

Simplifies the CTA in the quickstart to encourage users to either a) add their own data source or b) add a collaborator.

## Quick Links 🚀

[Quickstart](https://rob-docs-update-quickstart-c.v3-docs-eny.pages.dev/getting-started/quickstart/)