### PR TITLE
add proper connector names in connector init commands

### DIFF
--- a/docs/business-logic/go.mdx
+++ b/docs/business-logic/go.mdx
@@ -58,12 +58,12 @@ Let's begin by initializing the connector on our project. In the example below, 
 `hasura/go` connector from the connector hub.
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_go -i
 ```
 
 - Select `hasura/go` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_go`.
 - Choose a port (press enter to accept the default recommended by the CLI).
+- In this example, we've called the connector `my_go`. You can name it something descriptive.
 
 #### What did this do?
 

--- a/docs/business-logic/python.mdx
+++ b/docs/business-logic/python.mdx
@@ -52,12 +52,12 @@ Let's begin by initializing the connector on our project. In the example below, 
 `hasura/python` connector from the connector hub.
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_python -i
 ```
 
 - Select `hasura/python` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_python`.
 - Choose a port (press enter to accept the default recommended by the CLI).
+- In this example, we've called the connector `my_python`. You can name it something descriptive.
 
 #### What did this do?
 

--- a/docs/business-logic/typescript.mdx
+++ b/docs/business-logic/typescript.mdx
@@ -53,12 +53,13 @@ Let's begin by initializing the connector on our project. In the example below, 
 `hasura/nodejs` connector from the connector hub.
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_ts -i
 ```
 
 - Select `hasura/nodejs` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_ts`.
 - Choose a port (press enter to accept the default recommended by the CLI).
+- In this example, we've called the connector `my_ts`. You can name it something descriptive.
+
 
 #### What did this do?
 

--- a/docs/getting-started/build/03-connect-to-data/02-create-source-metadata.mdx
+++ b/docs/getting-started/build/03-connect-to-data/02-create-source-metadata.mdx
@@ -38,7 +38,7 @@ configuration of the connector and also update the corresponding `DataConnectorL
 to be able to interact with the connector.
 
 ```bash title="Run the following command, updating the referenced name to match your connector:"
-ddn connector introspect my_connector
+ddn connector introspect <connector-name>
 ```
 
 After this command runs, you can open your `my_subgraph/metadata/my_connector.hml` file and see the `DataConnectorLink`

--- a/docs/getting-started/build/03-connect-to-data/_databaseDocs/_clickHouse/_01-connect-a-source.mdx
+++ b/docs/getting-started/build/03-connect-to-data/_databaseDocs/_clickHouse/_01-connect-a-source.mdx
@@ -22,13 +22,13 @@ To initialize the ClickHouse connector, with the appropriate subgraph set in con
 terminal:
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_clickhouse -i
 ```
 
 - Select `hasura/clickhouse` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_clickhouse`.
 - Choose a port (press enter to accept the default recommended by the CLI).
 - Enter your connection details.
+- In this example, we've called the connector `my_clickhouse`. You can name it something descriptive.
 
 :::tip Best practices
 

--- a/docs/getting-started/build/03-connect-to-data/_databaseDocs/_graphql/_01-connect-a-source.mdx
+++ b/docs/getting-started/build/03-connect-to-data/_databaseDocs/_graphql/_01-connect-a-source.mdx
@@ -22,12 +22,12 @@ connection.
 To initialize the GraphQL connector, with the appropriate subgraph set in context, run the following in your terminal:
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_graphql -i
 ```
 
 - Select `hasura/graphql` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_graphql`.
 - Choose a port (press enter to accept the default recommended by the CLI).
+- In this example, we've called the connector `my_graphql`. You can name it something descriptive.
 
 :::tip Best practices
 

--- a/docs/getting-started/build/03-connect-to-data/_databaseDocs/_mongoDB/_01-connect-a-source.mdx
+++ b/docs/getting-started/build/03-connect-to-data/_databaseDocs/_mongoDB/_01-connect-a-source.mdx
@@ -32,13 +32,13 @@ To initialize the MongoDB connector, with the appropriate subgraph set in contex
 terminal:
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_mongo -i
 ```
 
 - Select `hasura/mongodb` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_mongo`.
 - Choose a port (press enter to accept the default recommended by the CLI).
 - Enter your connection string
+- In this example, we've called the connector `my_mongo`. You can name it something descriptive.
 
 :::tip Best practices
 

--- a/docs/getting-started/build/03-connect-to-data/_databaseDocs/_openAPI/_01-connect-a-source.mdx
+++ b/docs/getting-started/build/03-connect-to-data/_databaseDocs/_openAPI/_01-connect-a-source.mdx
@@ -27,13 +27,13 @@ additional business logic.
 To initialize the OpenAPI connector, run the following command in your terminal:
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_openapi -i
 ```
 
 - Select `hasura/openapi` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_openapi`.
 - Choose a port (press enter to accept the default recommended by the CLI).
 - Enter your connection details. For more information, see Step 2 below.
+- In this example, we've called the connector `my_openapi`. You can name it something descriptive.
 
 :::tip Best practices
 

--- a/docs/getting-started/build/03-connect-to-data/_databaseDocs/_postgreSQL/_01-connect-a-source.mdx
+++ b/docs/getting-started/build/03-connect-to-data/_databaseDocs/_postgreSQL/_01-connect-a-source.mdx
@@ -22,13 +22,13 @@ To initialize the PostgreSQL connector, with the appropriate subgraph set in con
 terminal.
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_pg -i
 ```
 
 - Select `hasura/postgres` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_pg`.
 - Choose a port (press enter to accept the default recommended by the CLI).
 - Enter your connection string (press enter to accept the sample, read-only database).
+- In this example, we've called the connector `my_pg`. You can name it something descriptive.
 
 :::tip Best practices
 

--- a/docs/getting-started/build/_databaseDocs/_go/_06-add-business-logic.mdx
+++ b/docs/getting-started/build/_databaseDocs/_go/_06-add-business-logic.mdx
@@ -35,12 +35,12 @@ Let's begin by initializing the connector on our project. In the example below, 
 `hasura/go` connector from the connector hub.
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_go -i
 ```
 
 - Select `hasura/go` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_go`.
 - Choose a port (press enter to accept the default recommended by the CLI).
+- In this example, we've called the connector `my_go`. You can name it something descriptive.
 
 :::tip Best practices
 

--- a/docs/getting-started/build/_databaseDocs/_python/_06-add-business-logic.mdx
+++ b/docs/getting-started/build/_databaseDocs/_python/_06-add-business-logic.mdx
@@ -36,12 +36,12 @@ Let's begin by initializing the connector on our project. In the example below, 
 `hasura/python` connector from the connector hub.
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_python -i
 ```
 
 - Select `hasura/python` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_python`.
 - Choose a port (press enter to accept the default recommended by the CLI).
+- In this example, we've called the connector `my_python`. You can name it something descriptive.
 
 :::tip Best practices
 

--- a/docs/getting-started/build/_databaseDocs/_typescript/_06-add-business-logic.mdx
+++ b/docs/getting-started/build/_databaseDocs/_typescript/_06-add-business-logic.mdx
@@ -36,12 +36,12 @@ Let's begin by initializing the connector on our project. In the example below, 
 `hasura/nodejs` connector from the connector hub.
 
 ```bash title="Run the following command:"
-ddn connector init -i
+ddn connector init my_ts -i
 ```
 
 - Select `hasura/nodejs` from the list of connectors.
-- Name it something descriptive. For this example, we'll call it `my_ts`.
 - Choose a port (press enter to accept the default recommended by the CLI).
+- In this example, we've called the connector `my_ts`. You can name it something descriptive.
 
 :::tip Best practices
 


### PR DESCRIPTION
## Description 📝

We are seeing [a lot of errors](https://cloud-data-metabase.hasura-app.io/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxMywidHlwZSI6InF1ZXJ5IiwicXVlcnkiOnsic291cmNlLXRhYmxlIjo1NjU0LCJvcmRlci1ieSI6W1siZGVzYyIsWyJmaWVsZCIsNzk1NjAseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lV2l0aExvY2FsVFoiLCJ0ZW1wb3JhbC11bml0IjoiZGVmYXVsdCJ9XV1dLCJmaWVsZHMiOltbImZpZWxkIiw3OTU2Nyx7ImJhc2UtdHlwZSI6InR5cGUvSW50ZWdlciJ9XSxbImZpZWxkIiw3OTU2MCx7ImJhc2UtdHlwZSI6InR5cGUvRGF0ZVRpbWVXaXRoTG9jYWxUWiJ9XSxbImZpZWxkIiw3OTU2Myx7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XSxbImZpZWxkIiw3OTU2OSx7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XSxbImZpZWxkIiw3OTU1OSx7ImJhc2UtdHlwZSI6InR5cGUvQm9vbGVhbiJ9XSxbImZpZWxkIiw3OTU2OCx7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XSxbImZpZWxkIiw3OTU1NSx7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XV0sImZpbHRlciI6WyJjb250YWlucyIsWyJmaWVsZCIsNzk1NTUseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQifV0sIm5vdCBmb3VuZCBpbiBTdWJncmFwaCBjb25maWciLHsiY2FzZS1zZW5zaXRpdmUiOmZhbHNlfV19fSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e30sIm9yaWdpbmFsX2NhcmRfaWQiOm51bGx9) in the `connector introspect` due to incorrect connector names. Most of these seem to be due to copy pasting of commands from the docs. to avoid this i've added the name of the connector in the connector init commands to reduce chances of name mismatches

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->