### PR TITLE
Quickfix: Update supergraph init for smoother workflow and fix incorrect flag

### DIFF
--- a/docs/getting-started/build/01-init-supergraph.mdx
+++ b/docs/getting-started/build/01-init-supergraph.mdx
@@ -33,16 +33,12 @@ Your supergraph is the composite of all your subgraphs, their various data sourc
 
 ### Step 1. Initialize your supergraph
 
-```bash title="To initialize your supergraph, from an empty directory, run:"
-ddn supergraph init .
+Your supergraph will be initialized in a new directory `mysupergraph`. Remember to change your working directory to this new directory for the following steps.
+
+```bash title="Run:"
+ddn supergraph init mysupergraph
+cd mysupergraph
 ```
-
-:::tip Specifying a directory
-
-Instead of passing a `.` (the "this" directory specifier) you can pass the `--dir` flag and a directory name to the
-`supergraph init` command to create your supergraph in a specific directory. If it doesn't exist it will be created.
-
-:::
 
 ### Step 2. Start your supergraph
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -64,12 +64,12 @@ you'll be redirected to your CLI session and can proceed with creating your supe
 <Step
 id="supergraph-init"
 language="bash"
-code={`mkdir hasura_project && cd hasura_project\nddn supergraph init .`}
-heading={`Initialize a new supergraph in an empty directory`}
+code={`ddn supergraph init mysupergraph\ncd mysupergraph`}
+heading={`Initialize a new supergraph in a new directory`}
 >
 
 The `ddn supergraph init` command initializes a supergraph — which is a composite API — by setting up all necessary
-files and directories for development.
+files and directories for development in the new `mysupergraph` directory.
 
 When you execute this command, the CLI creates a Docker Compose file and a .env file to run the Hasura engine locally
 and other configuration files describing your supergraph. Additionally, the CLI creates two


### PR DESCRIPTION
## Description 📝

The `--dir` flag is no longer valid.

`ddn supergraph init .` fails in a directory that is not empty, this is a common mistake. It is also easy to miss the `.`

Instead, by specifying the new directory name as `mysupergraph` and then later cd'ing into it we avoid many errors.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->