### PR TITLE
Clarify supergraph build workflow including common pitfalls

### DIFF
--- a/docs/getting-started/build/04-build-your-api.mdx
+++ b/docs/getting-started/build/04-build-your-api.mdx
@@ -41,24 +41,27 @@ a GraphQL query on your API using any models you've added.
 
 ### Step 1. Create a supergraph build
 
-```bash title="Run the following command, updating the referenced paths to match your directory structure:"
+```bash title="Run:"
 ddn supergraph build local
 ```
 
 This will create a build of your supergraph located in the `/engine/build` directory.
 
-:::tip Start your engines!
+### Step 2. Start your engines!
 
-Want to test your supergraph? Make sure that your services are still up and running with the following command.
+If you are already running this command, first stop the command with `CTRL+C`. Then run the command to start the connector and engine services with the updated configurations.
 
 ```bash title="Run:"
 ddn run docker-start
 ```
 
-**If you haven't [included your connector(s)](/getting-started/build/03-connect-to-data/01-connect-a-source.mdx) in your
-`compose.yaml`, don't forget to start it as well.**
+:::tip Port conflicts?
+
+Stop any previously running `ddn run docker-start` commands in your terminal. Existing running servers can conflict with the ports needed. In particular, engine always starts on port 3000.
 
 :::
+
+### Step 3. Launch the Hasura console
 
 You can check out your local API by launching the Hasura console using the CLI.
 
@@ -77,7 +80,7 @@ browsers for the best experience with the Hasura Console including for local dev
 
 :::
 
-### Step 2. Write your first query
+### Step 4. Write your first query
 
 Use the GraphiQL explorer to either write a query or construct it using the menu on the left-hand side of the console.
 When you're ready, hit the run button to execute your query.
@@ -92,8 +95,7 @@ query MyFirstQuery {
 }
 ```
 
-All types are namespaced with the subgraph to which they belong. Here, you can see that `carts` belongs to a subgraph
-named `my_subgraph`. Thus, the query above will return a response that looks like this:
+The above query will return a response that looks like this:
 
 ![Simple query with carts](/img/get-started/beta/console_simple-carts-query.png)
 


### PR DESCRIPTION
## Description 📝

Solve the following issues:
* Previously running `ddn run docker-start` in a different terminal window, even in other ddn project directories, cause a commonly recurring port conflict error
* `ddn run docker-start` does not hot reload new configuration and builds. If users are following along from earlier steps they must be told to stop and start the script for changes to take effect
* Subgraph prefixing has been removed from the default CLI scaffold

In addition:
* Split up the supergraph build page into smaller distinct steps, so that no step is inadvertantly missed by users

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->