### PR TITLE
Add command to track commands to quickstart

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -128,7 +128,7 @@ Is introspect not working? Confirm that the environment variables defined in the
 <Step
 id="add-resources"
 language="bash"
-code={`ddn model add my_connector '*'\nddn relationship add my_connector '*'`}
+code={`ddn model add my_connector '*'\nddn command add my_connector '*'\nddn relationship add my_connector '*'`}
 heading={`Add your resources`}
 >
 


### PR DESCRIPTION
## Description 📝
As per [this Slack thread](https://hasurahq.slack.com/archives/C04NS5JCD8A/p1729222895745189?thread_ts=1729198016.141299&cid=C04NS5JCD8A), the quickstart is missing instructions to track commands, and as such users don't do it when using connectors that produce commands (such as the OpenAPI connector).

## Quick Links 🚀

https://daniel-quickstart-add-comman.v3-docs-eny.pages.dev/getting-started/quickstart/ (scroll to "Add your resources")

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->