### PR TITLE
Fix: Formatting for examples in auto-generated metadata docs

### DIFF
--- a/docs/supergraph-modeling/permissions.mdx
+++ b/docs/supergraph-modeling/permissions.mdx
@@ -375,7 +375,9 @@ definition:
             operator: _eq
             value:
               sessionVariable: x-hasura-user-id
-```,
+```
+
+
 
 ```yaml
 kind: ModelPermissions
@@ -508,7 +510,9 @@ fieldComparison:
   operator: _eq
   value:
     sessionVariable: x-hasura-user-id
-```,
+```
+
+
 
 ```yaml
 relationship:
@@ -519,7 +523,9 @@ relationship:
       operator: _eq
       value:
         sessionVariable: x-hasura-user-id
-```,
+```
+
+
 
 ```yaml
 and:
@@ -533,7 +539,9 @@ and:
       operator: _eq
       value:
         literal: Hello World
-```,
+```
+
+
 
 ```yaml
 not:
@@ -738,7 +746,9 @@ fieldComparison:
   operator: _eq
   value:
     sessionVariable: x-hasura-user-id
-```,
+```
+
+
 
 ```yaml
 relationship:
@@ -749,7 +759,9 @@ relationship:
       operator: _eq
       value:
         sessionVariable: x-hasura-user-id
-```,
+```
+
+
 
 ```yaml
 and:
@@ -763,7 +775,9 @@ and:
       operator: _eq
       value:
         literal: Hello World
-```,
+```
+
+
 
 ```yaml
 not:

--- a/utilities/generate-metadata-docs/src/logic/helpers.ts
+++ b/utilities/generate-metadata-docs/src/logic/helpers.ts
@@ -155,9 +155,9 @@ export function getDescription(metadataObject: JSONSchema7Definition): string {
 export function getExamples(metadataObject: JSONSchema7Definition): string {
   let examples = '';
   if (metadataObject.examples) {
-    examples = `\n **Example${metadataObject.examples.length > 1 ? 's' : ''}:**${metadataObject.examples.map(
-      example => `\n\n\`\`\`yaml\n${jsYaml.dump(example)}\`\`\``
-    )}`;
+    examples =
+      `\n **Example${metadataObject.examples.length > 1 ? 's' : ''}:**` +
+      metadataObject.examples.map(example => `\n\n\`\`\`yaml\n${jsYaml.dump(example)}\`\`\``).join('\n\n');
   }
 
   return examples;


### PR DESCRIPTION
## Description 📝

Fixes formatting for examples in auto-generated metadata docs via refactoring `getExamples()` to properly join multiple examples with linebreaks.

## Quick Links 🚀

[Permissions](https://rob-ci-update-example-buildi.v3-docs-eny.pages.dev/supergraph-modeling/permissions/#modelpermissions-modelpermissions)