### PR TITLE
JSON session variables tweaks and CompatibilityConfig rework

### DIFF
--- a/docs/auth/authentication/jwt/setup.mdx
+++ b/docs/auth/authentication/jwt/setup.mdx
@@ -76,11 +76,11 @@ vulnerability**. Learn how to set this [here](supergraph-modeling/auth-config.md
 Your auth service should include an object with a key of `https://hasura.io/jwt/claims` in the JWT's claims. Within
 this, each claim should be prefixed with `x-hasura-*` and include the relevant information.
 
-| Key                      | Required | Value                                                                           |
-| ------------------------ | -------- | ------------------------------------------------------------------------------- |
-| `x-hasura-default-role`  | Yes      | The role that will be used when the optional x-hasura-role header is not passed |
-| `x-hasura-allowed-roles` | Yes      | A list of allowed roles for the user making the request.                        |
-| `x-hasura-[custom]`      | No       | Where `[custom]` is any value you wish (e.g., `org`, `user-id`, `customer`).    |
+| Key                      | Required | Value                                                                                                          |
+| ------------------------ | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `x-hasura-default-role`  | Yes      | The role that will be used when the optional x-hasura-role header is not passed                                |
+| `x-hasura-allowed-roles` | Yes      | A list of allowed roles for the user making the request.                                                       |
+| `x-hasura-[custom]`      | No       | Where `[custom]` is any string you wish (e.g., `org`, `user-id`, `customer`). The value can be any JSON value. |
 
 As an example, we're including the required claims by stating the default role is `user` and the list of available roles
 is limited to `user` and `admin`. Additionally, we're passing a custom key of `x-hasura-user-id` which can be used with
@@ -96,7 +96,7 @@ is limited to `user` and `admin`. Additionally, we're passing a custom key of `x
   "claims.jwt.hasura.io": {
     "x-hasura-default-role": "user",
     "x-hasura-allowed-roles": ["user", "admin"],
-    "x-hasura-user-id": "1234"
+    "x-hasura-user-id": 1234
   }
 }
 ```

--- a/docs/auth/authentication/webhook/setup.mdx
+++ b/docs/auth/authentication/webhook/setup.mdx
@@ -54,8 +54,8 @@ Based on the validation result, the webhook will need to respond with either a `
 a `401` status code (for an invalid or missing token).
 
 To allow the GraphQL request to go through, your webhook must return a `200` status code. You should respond with
-session variables beginning with `X-Hasura-*` in the body of your response. These will be available to your
-[permissions](/supergraph-modeling/permissions.mdx) in Hasura.
+session variables beginning with `X-Hasura-*` in the body of your response. The value of each session variable can be
+any JSON value. These will be available to your [permissions](/supergraph-modeling/permissions.mdx) in Hasura.
 
 You will, at least, need to set the `X-Hasura-Role` session variable to let the Hasura DDN know which role to use for
 this request. Unlike [JWT auth mode](auth/authentication/jwt/index.mdx), you do not have to pass
@@ -70,7 +70,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "X-Hasura-User-Id": "25",
+    "X-Hasura-User-Id": 25,
     "X-Hasura-Role": "user",
     "X-Hasura-Is-Owner": "true",
     "X-Hasura-Custom": "custom value"

--- a/docs/graphql-api/queries/filters/nested-objects.mdx
+++ b/docs/graphql-api/queries/filters/nested-objects.mdx
@@ -200,7 +200,7 @@ details.
 
 To utilize relationship comparisons without the `relation_comparisons` capability, you must update the compatibility
 date. For detailed instructions, please refer to the
-[Compatibility Config](supergraph-modeling/compatibility-config.mdx#bypass-relation_comparisons-ndc-capability).
+[Compatibility Config](supergraph-modeling/compatibility-config.mdx#enable-relationships-in-predicates-to-be-used-even-if-the-data-connector-does-not-support-it).
 
 ### Remote Relationships
 

--- a/docs/recipes/authorization/2-public-access-role.mdx
+++ b/docs/recipes/authorization/2-public-access-role.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: Public access
-description: "Learn how to creata a public-access role that can view data without authentication."
+description: "Learn how to create a public-access role that can view data without authentication."
 keywords:
   - hasura
   - hasura ddn

--- a/docs/supergraph-modeling/compatibility-config.mdx
+++ b/docs/supergraph-modeling/compatibility-config.mdx
@@ -21,79 +21,93 @@ The CompatibilityConfig object is a metadata object that defines the compatibili
 By default, all projects are created with a default CompatibilityConfig object in the **globals** subgraph. It can be
 defined in any subgraph of your choice, but only once across your supergraph.
 
-The `date` field in the CompatibilityConfig object specifies the date after which any backwards incompatible changes
-made to Hasura DDN won't impact the metadata.
+The `date` field in the CompatibilityConfig object specifies the date after which any new backwards-incompatible changes
+made to Hasura DDN will be disabled and will not impact the Hasura project. For example, if your project has its `date`
+set to `2024-10-16`, then any new features added after that date that would result in breaking changes to your project
+will be disabled. To enable these features, simply increase your `date` to a newer date.
 
-### Examples
+### Compatibility dates and breaking changes
 
-#### Require valid NDC v01 version
+The following is a list of dates at which backwards-incompatible changes were added to Hasura DDN. Projects with
+CompatibilityConfig `date`s prior to these dates will have these features disabled.
 
-**Date:** `2024-11-15`
+#### 2024-11-15
 
-**Description:** When enabled, raise an error when there is an invalid version in the capabilities
-of the data connector's schema. To fix the error, please consider upgrading to the latest version
-of the data connector. Before this, we would have assumed that they were NDC v0.1.x connectors.
+##### Require a valid NDC version in data connector capabilities
 
-#### Require unique command GraphQL names
+A build error is now raised when there is an invalid version in the capabilities of a data connector's schema. To fix
+the error, please consider upgrading to the latest version of the data connector and running `ddn connector introspect`
+to correct the invalid version. Prior to this change, it was assumed that the data connector with the invalid version
+was an NDC v0.1.x connector.
 
-**Date:** `2024-10-07`
+#### 2024-10-31
 
-**Description:** When enabled, raise an error when there is a conflict with a GraphQL 
-root field or GraphQL type name that is already in use. Before this, the command would 
-be silently dropped from the GraphQL schema.
+##### Disallow comparisons against scalar array fields in predicates
 
-#### Propagate boolean expression deprecation status
+A build error is now raised if a scalar array field is configured in a BooleanExpressionType as a comparable field.
+Comparisons against scalar array fields are not supported as at this compatibility date.
 
-**Date:** `2024-09-26`
+#### 2024-10-16
 
-**Description:** Enables propagating `deprecated` status for relationship
-fields to boolean expressions that use them. The default GraphQL introspection
-behavior is to hide such fields from the schema, so this behavior is opt-in
-to avoid breakage.
+##### Enable JSON session variable support
 
-#### Disallow scalar types names conflicting with inbuilt types
+Session variables provided in JWT claims, webhook responses or in the NoAuth settings can now be any JSON value, instead
+of just a string. This enable scenarios such as being able to put lists of values into a single session variable.
+However, this now means that if you use the session variable in a comparison against a field, the field's type must
+match the type of the session variable. For example, if you are comparing against an integer field, your session
+variable must be set as a JSON number and not a string.
 
-**Date:** `2024-09-26`
+#### 2024-10-07
 
-**Description:** When enabled, defining a `ScalarType` metadata type that
-conflicts with any of the built-in type names (`ID`, `Int`, `String`,
-`Boolean`, `Float`) now raises an error that halts the build.
+##### Require unique command GraphQL names
 
-#### Require nested array filtering capability
+A build error is now raised when there is a conflict with a GraphQL root field or GraphQL type name that is already in
+use. Before this, the command would be silently dropped from the GraphQL schema.
 
-**Date:** `2024-09-18`
+#### 2024-09-26
 
-**Description:** When enabled, defining a nested array field against a model
-whose underlying data connector does not have the
-`query.exists.nested_collections` capability defined will raise an error that
-halts the build.
+##### Propagate boolean expression deprecation status
 
-#### Bypass `relation_comparisons` NDC Capability
+The `deprecated` status for relationship fields is now propagated to boolean expressions that use them. The default
+GraphQL introspection behavior is to hide such fields from the schema, so this behavior is considered a breaking change.
 
-**Date:** `2024-09-03`
+##### Disallow scalar types names conflicting with inbuilt types
 
-**Description:** Enables bypassing the `relation_comparisons` NDC capability for relationship predicates. This allows
-you to use relationships in boolean expressions even if the data connector lacks compatibility. When the capability is
-available, relationship predicates are resolved directly within the native data connector for more efficient processing.
-If not, the predicates are handled at the API layer.
+A build error is now raised when a `ScalarType` metadata type is defined that conflicts with any of the built-in type
+names (`ID`, `Int`, `String`, `Boolean`, `Float`).
 
-#### Require GraphQL Config
+#### 2024-09-18
 
-**Date:** `2024-06-30`
+##### Require nested array filtering capability
 
-**Description:** Enforce the need for [GraphQL Config](supergraph-modeling/graphql-config.mdx).
+A build error is now raised when a nested array field is defined on an ObjectType used in a Model whose underlying data
+connector does not have the `query.exists.nested_collections` capability defined.
 
+#### 2024-09-03
+
+##### Enable relationships in predicates to be used even if the data connector does not support it
+
+Previously, only data connectors that supported the `relationships.relation_comparisons` capability supported
+relationships in predicates. This change allows you to use relationships in boolean expressions even if the data
+connector lacks support. When the capability is available, relationship predicates are resolved directly within the
+native data connector for more efficient processing. If not, the predicates are handled at the API layer.
+
+#### 2024-06-30
+
+##### Require GraphQL Config
+
+A build error is now raised if a [GraphQLConfig](supergraph-modeling/graphql-config.mdx) is not provided in the project
+metadata.
 
 ---
 
 ## Metadata structure
 
-
 ### v2_CompatibilityConfig {#v2_compatibilityconfig-v2_compatibilityconfig}
 
 The compatibility configuration of the Hasura metadata.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `CompatibilityConfig` | true |  |
-| `date` | string | true | Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata. |
+| Key    | Value                 | Required | Description                                                                                      |
+| ------ | --------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `kind` | `CompatibilityConfig` | true     |                                                                                                  |
+| `date` | string                | true     | Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata. |

--- a/docs/supergraph-modeling/permissions.mdx
+++ b/docs/supergraph-modeling/permissions.mdx
@@ -93,9 +93,9 @@ You can restrict access to certain rows by adding a new item to the `permissions
 object. Each item in the array should have a `role` field and a `select` field. The `select` field should contain a
 `filter` expression that determines which rows are accessible to the role when selecting from the model.
 
-Most commonly, you'll use session variables — passed in the header of a request — to restrict access to rows based on
-the user's identity or other criteria. You can also use argument presets to enforce row-level security. You can see an
-example of this below.
+Most commonly, you'll use session variables — provided via your configured
+[authentication mechanism](/auth/authentication/index.mdx) — to restrict access to rows based on the user's identity or
+other criteria. You can also use argument presets to enforce row-level security. You can see an example of this below.
 
 To make a new ModelPermission or role available in your supergraph, after updating your metadata, you'll need to
 [create a new build](/cli/commands/ddn_supergraph_build_local.mdx) using the CLI.
@@ -209,18 +209,17 @@ definition:
 
 ## Metadata structure
 
-
 ### TypePermissions {#typepermissions-typepermissions}
 
 Definition of permissions for an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `TypePermissions` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [TypePermissionsV1](#typepermissions-typepermissionsv1) | true | Definition of permissions for an OpenDD type. |
+| Key          | Value                                                   | Required | Description                                   |
+| ------------ | ------------------------------------------------------- | -------- | --------------------------------------------- |
+| `kind`       | `TypePermissions`                                       | true     |                                               |
+| `version`    | `v1`                                                    | true     |                                               |
+| `definition` | [TypePermissionsV1](#typepermissions-typepermissionsv1) | true     | Definition of permissions for an OpenDD type. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: TypePermissions
@@ -241,29 +240,26 @@ definition:
           - author_id
 ```
 
-
 #### TypePermissionsV1 {#typepermissions-typepermissionsv1}
 
 Definition of permissions for an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `typeName` | [CustomTypeName](#typepermissions-customtypename) | true | The name of the type for which permissions are being defined. Must be an object type. |
-| `permissions` | [[TypePermission](#typepermissions-typepermission)] | true | A list of type permissions, one for each role. |
-
-
+| Key           | Value                                               | Required | Description                                                                           |
+| ------------- | --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------- |
+| `typeName`    | [CustomTypeName](#typepermissions-customtypename)   | true     | The name of the type for which permissions are being defined. Must be an object type. |
+| `permissions` | [[TypePermission](#typepermissions-typepermission)] | true     | A list of type permissions, one for each role.                                        |
 
 #### TypePermission {#typepermissions-typepermission}
 
 Defines permissions for a particular role for a type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `role` | [Role](#typepermissions-role) | true | The role for which permissions are being defined. |
-| `output` | [TypeOutputPermission](#typepermissions-typeoutputpermission) / null | false | Permissions for this role when this type is used in an output context. If null, this type is inaccessible for this role in an output context. |
-| `input` | [TypeInputPermission](#typepermissions-typeinputpermission) / null | false | Permissions for this role when this type is used in an input context. If null, this type is accessible for this role in an input context. |
+| Key      | Value                                                                | Required | Description                                                                                                                                   |
+| -------- | -------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `role`   | [Role](#typepermissions-role)                                        | true     | The role for which permissions are being defined.                                                                                             |
+| `output` | [TypeOutputPermission](#typepermissions-typeoutputpermission) / null | false    | Permissions for this role when this type is used in an output context. If null, this type is inaccessible for this role in an output context. |
+| `input`  | [TypeInputPermission](#typepermissions-typeinputpermission) / null   | false    | Permissions for this role when this type is used in an input context. If null, this type is accessible for this role in an input context.     |
 
- **Example:**
+**Example:**
 
 ```yaml
 role: user
@@ -278,85 +274,71 @@ input:
         sessionVariable: x-hasura-user-id
 ```
 
-
 #### TypeInputPermission {#typepermissions-typeinputpermission}
 
 Permissions for a type for a particular role when used in an input context.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldPresets` | [[FieldPreset](#typepermissions-fieldpreset)] | false | Preset values for fields of the type |
-
-
+| Key            | Value                                         | Required | Description                          |
+| -------------- | --------------------------------------------- | -------- | ------------------------------------ |
+| `fieldPresets` | [[FieldPreset](#typepermissions-fieldpreset)] | false    | Preset values for fields of the type |
 
 #### FieldPreset {#typepermissions-fieldpreset}
 
 Preset value for a field
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#typepermissions-fieldname) | true | Field name for preset |
-| `value` | [ValueExpression](#typepermissions-valueexpression) | true | Value for preset |
-
-
+| Key     | Value                                               | Required | Description           |
+| ------- | --------------------------------------------------- | -------- | --------------------- |
+| `field` | [FieldName](#typepermissions-fieldname)             | true     | Field name for preset |
+| `value` | [ValueExpression](#typepermissions-valueexpression) | true     | Value for preset      |
 
 #### ValueExpression {#typepermissions-valueexpression}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | string | false |  |
-
-
+| Key               | Value  | Required | Description |
+| ----------------- | ------ | -------- | ----------- |
+| `literal`         |        | false    |             |
+| `sessionVariable` | string | false    |             |
 
 #### TypeOutputPermission {#typepermissions-typeoutputpermission}
 
 Permissions for a type for a particular role when used in an output context.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `allowedFields` | [[FieldName](#typepermissions-fieldname)] | true | Fields of the type that are accessible for a role |
-
-
+| Key             | Value                                     | Required | Description                                       |
+| --------------- | ----------------------------------------- | -------- | ------------------------------------------------- |
+| `allowedFields` | [[FieldName](#typepermissions-fieldname)] | true     | Fields of the type that are accessible for a role |
 
 #### FieldName {#typepermissions-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### Role {#typepermissions-role}
 
 The role for which permissions are being defined.
 
-
 **Value:** string
-
 
 #### CustomTypeName {#typepermissions-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
+
 ### ModelPermissions {#modelpermissions-modelpermissions}
 
 Definition of permissions for an OpenDD model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `ModelPermissions` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [ModelPermissionsV1](#modelpermissions-modelpermissionsv1) | true | Definition of permissions for an OpenDD model. |
+| Key          | Value                                                      | Required | Description                                    |
+| ------------ | ---------------------------------------------------------- | -------- | ---------------------------------------------- |
+| `kind`       | `ModelPermissions`                                         | true     |                                                |
+| `version`    | `v1`                                                       | true     |                                                |
+| `definition` | [ModelPermissionsV1](#modelpermissions-modelpermissionsv1) | true     | Definition of permissions for an OpenDD model. |
 
- **Examples:**
+**Examples:**
 
 ```yaml
 kind: ModelPermissions
@@ -376,8 +358,6 @@ definition:
             value:
               sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 kind: ModelPermissions
@@ -401,28 +381,25 @@ definition:
                   sessionVariable: x-hasura-user-id
 ```
 
-
 #### ModelPermissionsV1 {#modelpermissions-modelpermissionsv1}
 
 Definition of permissions for an OpenDD model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `modelName` | [ModelName](#modelpermissions-modelname) | true | The name of the model for which permissions are being defined. |
-| `permissions` | [[ModelPermission](#modelpermissions-modelpermission)] | true | A list of model permissions, one for each role. |
-
-
+| Key           | Value                                                  | Required | Description                                                    |
+| ------------- | ------------------------------------------------------ | -------- | -------------------------------------------------------------- |
+| `modelName`   | [ModelName](#modelpermissions-modelname)               | true     | The name of the model for which permissions are being defined. |
+| `permissions` | [[ModelPermission](#modelpermissions-modelpermission)] | true     | A list of model permissions, one for each role.                |
 
 #### ModelPermission {#modelpermissions-modelpermission}
 
 Defines the permissions for an OpenDD model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `role` | [Role](#modelpermissions-role) | true | The role for which permissions are being defined. |
-| `select` | [SelectPermission](#modelpermissions-selectpermission) / null | false | The permissions for selecting from this model for this role. If this is null, the role is not allowed to query the model. |
+| Key      | Value                                                         | Required | Description                                                                                                               |
+| -------- | ------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `role`   | [Role](#modelpermissions-role)                                | true     | The role for which permissions are being defined.                                                                         |
+| `select` | [SelectPermission](#modelpermissions-selectpermission) / null | false    | The permissions for selecting from this model for this role. If this is null, the role is not allowed to query the model. |
 
- **Example:**
+**Example:**
 
 ```yaml
 role: user
@@ -439,70 +416,59 @@ select:
         literal: true
 ```
 
-
 #### SelectPermission {#modelpermissions-selectpermission}
 
 Defines the permissions for selecting a model for a role.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `filter` | null / [ModelPredicate](#modelpermissions-modelpredicate) | true | Filter expression when selecting rows for this model. Null filter implies all rows are selectable. |
-| `argumentPresets` | [[ArgumentPreset](#modelpermissions-argumentpreset)] | false | Preset values for arguments for this role |
-| `allowSubscriptions` | boolean | false | Whether the role is allowed to subscribe to the root fields of this model. |
-
-
+| Key                  | Value                                                     | Required | Description                                                                                        |
+| -------------------- | --------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `filter`             | null / [ModelPredicate](#modelpermissions-modelpredicate) | true     | Filter expression when selecting rows for this model. Null filter implies all rows are selectable. |
+| `argumentPresets`    | [[ArgumentPreset](#modelpermissions-argumentpreset)]      | false    | Preset values for arguments for this role                                                          |
+| `allowSubscriptions` | boolean                                                   | false    | Whether the role is allowed to subscribe to the root fields of this model.                         |
 
 #### ArgumentPreset {#modelpermissions-argumentpreset}
 
 Preset value for an argument
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argument` | [ArgumentName](#modelpermissions-argumentname) | true | Argument name for preset |
-| `value` | [ValueExpressionOrPredicate](#modelpermissions-valueexpressionorpredicate) | true | Value for preset |
-
-
+| Key        | Value                                                                      | Required | Description              |
+| ---------- | -------------------------------------------------------------------------- | -------- | ------------------------ |
+| `argument` | [ArgumentName](#modelpermissions-argumentname)                             | true     | Argument name for preset |
+| `value`    | [ValueExpressionOrPredicate](#modelpermissions-valueexpressionorpredicate) | true     | Value for preset         |
 
 #### ValueExpressionOrPredicate {#modelpermissions-valueexpressionorpredicate}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | string | false | Used to represent the name of a session variable, like "x-hasura-role". |
-| `booleanExpression` | [ModelPredicate](#modelpermissions-modelpredicate) | false |  |
-
-
+| Key                 | Value                                              | Required | Description                                                             |
+| ------------------- | -------------------------------------------------- | -------- | ----------------------------------------------------------------------- |
+| `literal`           |                                                    | false    |                                                                         |
+| `sessionVariable`   | string                                             | false    | Used to represent the name of a session variable, like "x-hasura-role". |
+| `booleanExpression` | [ModelPredicate](#modelpermissions-modelpredicate) | false    |                                                                         |
 
 #### ArgumentName {#modelpermissions-argumentname}
 
 The name of an argument.
 
-
 **Value:** string
-
 
 #### ModelPredicate {#modelpermissions-modelpredicate}
 
 A predicate that can be used to restrict the objects returned when querying a model.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldComparison` | [FieldComparisonPredicate](#modelpermissions-fieldcomparisonpredicate) | false | Field comparison predicate filters objects based on a field value. |
-| `fieldIsNull` | [FieldIsNullPredicate](#modelpermissions-fieldisnullpredicate) | false | Predicate to check if the given field is null. |
-| `relationship` | [RelationshipPredicate](#modelpermissions-relationshippredicate) | false | Relationship predicate filters objects of a source model based on a predicate on the related model. |
-| `and` | [[ModelPredicate](#modelpermissions-modelpredicate)] | false |  |
-| `or` | [[ModelPredicate](#modelpermissions-modelpredicate)] | false |  |
-| `not` | [ModelPredicate](#modelpermissions-modelpredicate) | false |  |
+| Key               | Value                                                                  | Required | Description                                                                                         |
+| ----------------- | ---------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `fieldComparison` | [FieldComparisonPredicate](#modelpermissions-fieldcomparisonpredicate) | false    | Field comparison predicate filters objects based on a field value.                                  |
+| `fieldIsNull`     | [FieldIsNullPredicate](#modelpermissions-fieldisnullpredicate)         | false    | Predicate to check if the given field is null.                                                      |
+| `relationship`    | [RelationshipPredicate](#modelpermissions-relationshippredicate)       | false    | Relationship predicate filters objects of a source model based on a predicate on the related model. |
+| `and`             | [[ModelPredicate](#modelpermissions-modelpredicate)]                   | false    |                                                                                                     |
+| `or`              | [[ModelPredicate](#modelpermissions-modelpredicate)]                   | false    |                                                                                                     |
+| `not`             | [ModelPredicate](#modelpermissions-modelpredicate)                     | false    |                                                                                                     |
 
- **Examples:**
+**Examples:**
 
 ```yaml
 fieldComparison:
@@ -511,8 +477,6 @@ fieldComparison:
   value:
     sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 relationship:
@@ -524,8 +488,6 @@ relationship:
       value:
         sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 and:
@@ -541,8 +503,6 @@ and:
         literal: Hello World
 ```
 
-
-
 ```yaml
 not:
   fieldComparison:
@@ -552,103 +512,85 @@ not:
       sessionVariable: x-hasura-user-id
 ```
 
-
 #### RelationshipPredicate {#modelpermissions-relationshippredicate}
 
 Relationship predicate filters objects of a source model based on a predicate on the related model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [RelationshipName](#modelpermissions-relationshipname) | true | The name of the relationship of the object type of the model to follow. |
-| `predicate` | [ModelPredicate](#modelpermissions-modelpredicate) / null | false | The predicate to apply on the related objects. If this is null, then the predicate evaluates to true as long as there is at least one related object present. |
-
-
+| Key         | Value                                                     | Required | Description                                                                                                                                                   |
+| ----------- | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`      | [RelationshipName](#modelpermissions-relationshipname)    | true     | The name of the relationship of the object type of the model to follow.                                                                                       |
+| `predicate` | [ModelPredicate](#modelpermissions-modelpredicate) / null | false    | The predicate to apply on the related objects. If this is null, then the predicate evaluates to true as long as there is at least one related object present. |
 
 #### RelationshipName {#modelpermissions-relationshipname}
 
 The name of the GraphQL relationship field.
 
-
 **Value:** string
-
 
 #### FieldIsNullPredicate {#modelpermissions-fieldisnullpredicate}
 
 Predicate to check if the given field is null.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#modelpermissions-fieldname) | true | The name of the field that should be checked for a null value. |
-
-
+| Key     | Value                                    | Required | Description                                                    |
+| ------- | ---------------------------------------- | -------- | -------------------------------------------------------------- |
+| `field` | [FieldName](#modelpermissions-fieldname) | true     | The name of the field that should be checked for a null value. |
 
 #### FieldComparisonPredicate {#modelpermissions-fieldcomparisonpredicate}
 
 Field comparison predicate filters objects based on a field value.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#modelpermissions-fieldname) | true | The field name of the object type of the model to compare. |
-| `operator` | [OperatorName](#modelpermissions-operatorname) | true | The name of the operator to use for comparison. |
-| `value` | [ValueExpression](#modelpermissions-valueexpression) | true | The value expression to compare against. |
-
-
+| Key        | Value                                                | Required | Description                                                |
+| ---------- | ---------------------------------------------------- | -------- | ---------------------------------------------------------- |
+| `field`    | [FieldName](#modelpermissions-fieldname)             | true     | The field name of the object type of the model to compare. |
+| `operator` | [OperatorName](#modelpermissions-operatorname)       | true     | The name of the operator to use for comparison.            |
+| `value`    | [ValueExpression](#modelpermissions-valueexpression) | true     | The value expression to compare against.                   |
 
 #### ValueExpression {#modelpermissions-valueexpression}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | string | false |  |
-
-
+| Key               | Value  | Required | Description |
+| ----------------- | ------ | -------- | ----------- |
+| `literal`         |        | false    |             |
+| `sessionVariable` | string | false    |             |
 
 #### OperatorName {#modelpermissions-operatorname}
 
 The name of an operator
 
-
 **Value:** string
-
 
 #### FieldName {#modelpermissions-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### Role {#modelpermissions-role}
 
 The role for which permissions are being defined.
 
-
 **Value:** string
-
 
 #### ModelName {#modelpermissions-modelname}
 
 The name of data model.
 
-
 **Value:** string
+
 ### CommandPermissions {#commandpermissions-commandpermissions}
 
 Definition of permissions for an OpenDD command.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `CommandPermissions` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [CommandPermissionsV1](#commandpermissions-commandpermissionsv1) | true | Definition of permissions for an OpenDD command. |
+| Key          | Value                                                            | Required | Description                                      |
+| ------------ | ---------------------------------------------------------------- | -------- | ------------------------------------------------ |
+| `kind`       | `CommandPermissions`                                             | true     |                                                  |
+| `version`    | `v1`                                                             | true     |                                                  |
+| `definition` | [CommandPermissionsV1](#commandpermissions-commandpermissionsv1) | true     | Definition of permissions for an OpenDD command. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: CommandPermissions
@@ -662,29 +604,26 @@ definition:
       allowExecution: true
 ```
 
-
 #### CommandPermissionsV1 {#commandpermissions-commandpermissionsv1}
 
 Definition of permissions for an OpenDD command.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `commandName` | [CommandName](#commandpermissions-commandname) | true | The name of the command for which permissions are being defined. |
-| `permissions` | [[CommandPermission](#commandpermissions-commandpermission)] | true | A list of command permissions, one for each role. |
-
-
+| Key           | Value                                                        | Required | Description                                                      |
+| ------------- | ------------------------------------------------------------ | -------- | ---------------------------------------------------------------- |
+| `commandName` | [CommandName](#commandpermissions-commandname)               | true     | The name of the command for which permissions are being defined. |
+| `permissions` | [[CommandPermission](#commandpermissions-commandpermission)] | true     | A list of command permissions, one for each role.                |
 
 #### CommandPermission {#commandpermissions-commandpermission}
 
 Defines the permissions for a role for a command.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `role` | [Role](#commandpermissions-role) | true | The role for which permissions are being defined. |
-| `allowExecution` | boolean | true | Whether the command is executable by the role. |
-| `argumentPresets` | [[ArgumentPreset](#commandpermissions-argumentpreset)] | false | Preset values for arguments for this role |
+| Key               | Value                                                  | Required | Description                                       |
+| ----------------- | ------------------------------------------------------ | -------- | ------------------------------------------------- |
+| `role`            | [Role](#commandpermissions-role)                       | true     | The role for which permissions are being defined. |
+| `allowExecution`  | boolean                                                | true     | Whether the command is executable by the role.    |
+| `argumentPresets` | [[ArgumentPreset](#commandpermissions-argumentpreset)] | false    | Preset values for arguments for this role         |
 
- **Example:**
+**Example:**
 
 ```yaml
 role: user
@@ -695,50 +634,43 @@ argumentPresets:
       session_variable: x-hasura-user_id
 ```
 
-
 #### ArgumentPreset {#commandpermissions-argumentpreset}
 
 Preset value for an argument
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argument` | [ArgumentName](#commandpermissions-argumentname) | true | Argument name for preset |
-| `value` | [ValueExpressionOrPredicate](#commandpermissions-valueexpressionorpredicate) | true | Value for preset |
-
-
+| Key        | Value                                                                        | Required | Description              |
+| ---------- | ---------------------------------------------------------------------------- | -------- | ------------------------ |
+| `argument` | [ArgumentName](#commandpermissions-argumentname)                             | true     | Argument name for preset |
+| `value`    | [ValueExpressionOrPredicate](#commandpermissions-valueexpressionorpredicate) | true     | Value for preset         |
 
 #### ValueExpressionOrPredicate {#commandpermissions-valueexpressionorpredicate}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | string | false | Used to represent the name of a session variable, like "x-hasura-role". |
-| `booleanExpression` | [ModelPredicate](#commandpermissions-modelpredicate) | false |  |
-
-
+| Key                 | Value                                                | Required | Description                                                             |
+| ------------------- | ---------------------------------------------------- | -------- | ----------------------------------------------------------------------- |
+| `literal`           |                                                      | false    |                                                                         |
+| `sessionVariable`   | string                                               | false    | Used to represent the name of a session variable, like "x-hasura-role". |
+| `booleanExpression` | [ModelPredicate](#commandpermissions-modelpredicate) | false    |                                                                         |
 
 #### ModelPredicate {#commandpermissions-modelpredicate}
 
 A predicate that can be used to restrict the objects returned when querying a model.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldComparison` | [FieldComparisonPredicate](#commandpermissions-fieldcomparisonpredicate) | false | Field comparison predicate filters objects based on a field value. |
-| `fieldIsNull` | [FieldIsNullPredicate](#commandpermissions-fieldisnullpredicate) | false | Predicate to check if the given field is null. |
-| `relationship` | [RelationshipPredicate](#commandpermissions-relationshippredicate) | false | Relationship predicate filters objects of a source model based on a predicate on the related model. |
-| `and` | [[ModelPredicate](#commandpermissions-modelpredicate)] | false |  |
-| `or` | [[ModelPredicate](#commandpermissions-modelpredicate)] | false |  |
-| `not` | [ModelPredicate](#commandpermissions-modelpredicate) | false |  |
+| Key               | Value                                                                    | Required | Description                                                                                         |
+| ----------------- | ------------------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------- |
+| `fieldComparison` | [FieldComparisonPredicate](#commandpermissions-fieldcomparisonpredicate) | false    | Field comparison predicate filters objects based on a field value.                                  |
+| `fieldIsNull`     | [FieldIsNullPredicate](#commandpermissions-fieldisnullpredicate)         | false    | Predicate to check if the given field is null.                                                      |
+| `relationship`    | [RelationshipPredicate](#commandpermissions-relationshippredicate)       | false    | Relationship predicate filters objects of a source model based on a predicate on the related model. |
+| `and`             | [[ModelPredicate](#commandpermissions-modelpredicate)]                   | false    |                                                                                                     |
+| `or`              | [[ModelPredicate](#commandpermissions-modelpredicate)]                   | false    |                                                                                                     |
+| `not`             | [ModelPredicate](#commandpermissions-modelpredicate)                     | false    |                                                                                                     |
 
- **Examples:**
+**Examples:**
 
 ```yaml
 fieldComparison:
@@ -747,8 +679,6 @@ fieldComparison:
   value:
     sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 relationship:
@@ -760,8 +690,6 @@ relationship:
       value:
         sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 and:
@@ -777,8 +705,6 @@ and:
         literal: Hello World
 ```
 
-
-
 ```yaml
 not:
   fieldComparison:
@@ -788,97 +714,76 @@ not:
       sessionVariable: x-hasura-user-id
 ```
 
-
 #### RelationshipPredicate {#commandpermissions-relationshippredicate}
 
 Relationship predicate filters objects of a source model based on a predicate on the related model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [RelationshipName](#commandpermissions-relationshipname) | true | The name of the relationship of the object type of the model to follow. |
-| `predicate` | [ModelPredicate](#commandpermissions-modelpredicate) / null | false | The predicate to apply on the related objects. If this is null, then the predicate evaluates to true as long as there is at least one related object present. |
-
-
+| Key         | Value                                                       | Required | Description                                                                                                                                                   |
+| ----------- | ----------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`      | [RelationshipName](#commandpermissions-relationshipname)    | true     | The name of the relationship of the object type of the model to follow.                                                                                       |
+| `predicate` | [ModelPredicate](#commandpermissions-modelpredicate) / null | false    | The predicate to apply on the related objects. If this is null, then the predicate evaluates to true as long as there is at least one related object present. |
 
 #### RelationshipName {#commandpermissions-relationshipname}
 
 The name of the GraphQL relationship field.
 
-
 **Value:** string
-
 
 #### FieldIsNullPredicate {#commandpermissions-fieldisnullpredicate}
 
 Predicate to check if the given field is null.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#commandpermissions-fieldname) | true | The name of the field that should be checked for a null value. |
-
-
+| Key     | Value                                      | Required | Description                                                    |
+| ------- | ------------------------------------------ | -------- | -------------------------------------------------------------- |
+| `field` | [FieldName](#commandpermissions-fieldname) | true     | The name of the field that should be checked for a null value. |
 
 #### FieldComparisonPredicate {#commandpermissions-fieldcomparisonpredicate}
 
 Field comparison predicate filters objects based on a field value.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#commandpermissions-fieldname) | true | The field name of the object type of the model to compare. |
-| `operator` | [OperatorName](#commandpermissions-operatorname) | true | The name of the operator to use for comparison. |
-| `value` | [ValueExpression](#commandpermissions-valueexpression) | true | The value expression to compare against. |
-
-
+| Key        | Value                                                  | Required | Description                                                |
+| ---------- | ------------------------------------------------------ | -------- | ---------------------------------------------------------- |
+| `field`    | [FieldName](#commandpermissions-fieldname)             | true     | The field name of the object type of the model to compare. |
+| `operator` | [OperatorName](#commandpermissions-operatorname)       | true     | The name of the operator to use for comparison.            |
+| `value`    | [ValueExpression](#commandpermissions-valueexpression) | true     | The value expression to compare against.                   |
 
 #### ValueExpression {#commandpermissions-valueexpression}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | string | false |  |
-
-
+| Key               | Value  | Required | Description |
+| ----------------- | ------ | -------- | ----------- |
+| `literal`         |        | false    |             |
+| `sessionVariable` | string | false    |             |
 
 #### OperatorName {#commandpermissions-operatorname}
 
 The name of an operator
 
-
 **Value:** string
-
 
 #### FieldName {#commandpermissions-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### ArgumentName {#commandpermissions-argumentname}
 
 The name of an argument.
 
-
 **Value:** string
-
 
 #### Role {#commandpermissions-role}
 
 The role for which permissions are being defined.
 
-
 **Value:** string
-
 
 #### CommandName {#commandpermissions-commandname}
 
 The name of a command.
-
 
 **Value:** string


### PR DESCRIPTION
## Description 📝
I've tweaked a few pages that talk about session variables to mention that session variables can be returned as JSON values, not just strings.

I also reworked the CompatibilityConfig page. I went to add the new date for JSON session variable support, but I realised the page was listing new features rather than listing dates, with the new features underneath them. So I reworked the page to list dates (thereby making it easier to see that the whole point is about dates), reworked some wording to clarify things and added any missing compatibility dates and their features.

## Quick Links 🚀

https://daniel-json-session-vars.v3-docs-eny.pages.dev/auth/authentication/jwt/setup/#step-2-create-the-claims
https://daniel-json-session-vars.v3-docs-eny.pages.dev/auth/authentication/webhook/setup/#response
https://daniel-json-session-vars.v3-docs-eny.pages.dev/supergraph-modeling/compatibility-config/
https://daniel-json-session-vars.v3-docs-eny.pages.dev/supergraph-modeling/permissions/#modelpermissions

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->