### PR TITLE
Fix broken NodeJS Lambda URLs

### DIFF
--- a/docs/business-logic/typescript.mdx
+++ b/docs/business-logic/typescript.mdx
@@ -18,8 +18,8 @@ import Thumbnail from "@site/src/components/Thumbnail";
 
 ## Introduction
 
-The [Node.js Lambda Connector](https://hasura.io/connectors/nodejs-lambda) can be added to any project to incorporate
-custom business logic directly into your supergraph.
+The [Node.js Lambda Connector](https://hasura.io/connectors/nodejs) can be added to any project to incorporate custom
+business logic directly into your supergraph.
 
 This can be used to enrich data returned to clients, or to write custom mutations in TypeScript with Node.js.
 
@@ -32,8 +32,8 @@ If you've never used Hasura DDN, we recommend that you first go through the
 
 ## Functions or Procedures
 
-TypeScript functions defined in a file in the [Node.js Lambda Connector](https://hasura.io/connectors/nodejs-lambda)
-directory and then tracked, will be available from your Hasura DDN GraphQL API in the form of either **functions** or
+TypeScript functions defined in a file in the [Node.js Lambda Connector](https://hasura.io/connectors/nodejs) directory
+and then tracked, will be available from your Hasura DDN GraphQL API in the form of either **functions** or
 **procedures**.
 
 In Hasura metadata, **functions** are used for read operations. They will not modify the data in the database and can
@@ -59,7 +59,6 @@ ddn connector init my_ts -i
 - Select `hasura/nodejs` from the list of connectors.
 - Choose a port (press enter to accept the default recommended by the CLI).
 - In this example, we've called the connector `my_ts`. You can name it something descriptive.
-
 
 #### What did this do?
 
@@ -225,11 +224,14 @@ However, if you prefer to run Node.js directly on your local machine, you can do
 
 1. Ensure you have [Node.js](https://nodejs.org/en) version `>=20.0.0` installed on your machine.
 2. Install the necessary dependencies:
+
 ```bash title="Change to the connector directory and install dependencies:"
 cd my_subgraph/connector/my_ts && npm i
 ```
+
 3. From the `my_ts` directory, run this command to load environment variables from your project's `.env` file, start the
-connector, and watch for any changes:
+   connector, and watch for any changes:
+
 ```bash title="Run the connector with env vars loaded from config"
 ddn connector setenv --connector connector.yaml -- npm run start
 ```


### PR DESCRIPTION
## Description 📝
Fixes two broken URLs linking to the Node.js Lambda page on the connector hub.

## Quick Links 🚀

https://daniel-fix-nodejs-urls.v3-docs-eny.pages.dev/business-logic/typescript/

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->