### PR TITLE
make local pg guide link more conspicuous

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -106,7 +106,7 @@ your connector to the supergraph.
 **Don't have a data source at hand?**
 
 You can choose our `hasura/postgres` connector which by default connects to our sample Postgres database for you to
-explore. Or check [this guide](/connectors/postgresql/local-postgres.mdx) to set up a local Postgres database using
+explore. Or check this guide to [set up a local Postgres database](/connectors/postgresql/local-postgres.mdx) using
 Docker.
 
 </Step>


### PR DESCRIPTION
## Description 📝

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

make local pg guide link more conspicuous in the quickstart

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->