### PR TITLE
Docs: Update Quickstart to use npm create cloudflare

### DIFF
--- a/docs/plugins/quickstart.mdx
+++ b/docs/plugins/quickstart.mdx
@@ -27,15 +27,13 @@ other tool or service that hosts HTTPS services you wish. You can get started wi
 
 :::
 
-## Step 1. Create a new Wrangler project
+## Step 1. Create a new Worker project
 
-Create a Wrangler project with the `allowlist` plugin template.
+Create a new Cloudflare Worker project using the `create-cloudflare` command with the `allowlist` plugin template:
 
 ```bash
-wrangler generate allowlist-plugin https://github.com/hasura/engine-plugin-allowlist
+npm create cloudflare@latest allowlist-plugin -- --template [https://github.com/hasura/engine-plugin-allowlist](https://github.com/hasura/engine-plugin-allowlist)
 ```
-
-This will create a new local Wrangler project using the allowlist plugin as a template in your current directory.
 
 ## Step 2. Install the dependencies
 


### PR DESCRIPTION
## Update Quickstart to Use `npm create cloudflare`

This PR updates the Quickstart guide to use the recommended `npm create cloudflare@latest` command for creating a new Worker project with the allowlist plugin template. This replaces the deprecated `wrangler generate` command, ensuring the guide is up-to-date and aligned with current best practices.

**Key changes:**

- Replaces `wrangler generate` with `npm create cloudflare@latest` in Step 1.
- Provides a clear explanation of the new command and its options.
- Ensures consistency and accuracy throughout the Quickstart guide.

**Benefits:**

- Improved user experience by guiding users with the most current and supported method.
- Reduced confusion by removing outdated instructions.
- Enhanced maintainability by aligning with the Cloudflare Workers ecosystem.

**Testing:**

- Manually tested the updated Quickstart guide to confirm the successful creation of a new Worker project with the allowlist plugin template using the `npm create cloudflare@latest` command.

## Quick Links 🚀

## Assertion Tests 🤖

- A user following the updated Quickstart guide should be able to successfully create a new Cloudflare Worker project with the allowlist plugin template.
- The guide should clearly explain the purpose and usage of the `npm create cloudflare@latest` command.
- The guide should be free of any references to the deprecated `wrangler generate` command.