### PR TITLE
Docs: Add note for migrations

### DIFF
--- a/docs/upgrade/feature-availability/tooling.mdx
+++ b/docs/upgrade/feature-availability/tooling.mdx
@@ -81,8 +81,10 @@ In Hasura v2, database migrations were supported through the Hasura CLI, allowin
 schema and metadata.
 
 **In Hasura DDN, database migrations are not supported**. However, there are a variety of excellent free alternatives
-available, such as [Flyway](https://flywaydb.org/) and [Liquibase](https://www.liquibase.org/), that can be used in
-conjunction with Hasura DDN to manage your database schema changes.
+available, such as [Flyway](https://flywaydb.org/), [DbMate](https://github.com/amacneil/dbmate), and
+[Liquibase](https://www.liquibase.org/), that can be used in conjunction with Hasura DDN to manage your database schema
+changes. Check back soon where we'll have dedicated guides for using these tools in conjunction with CI/CD for your
+projects.
 
 ### Prometheus
 


### PR DESCRIPTION
## Description 📝

Adds a note for migrations alerting users that there will be more dedicated guides around handling migrations as a part of CI/CD in the near future. With the upcoming restructure, we can prioritize this being a closed-loop page that shows users how to a) complete migrations and b) integrate the process as a part of CI/CD.
