### PR TITLE
Docs: Add update example for Native Mutation in Postgres

### DIFF
--- a/docs/connectors/postgresql/native-operations/custom-mutations.mdx
+++ b/docs/connectors/postgresql/native-operations/custom-mutations.mdx
@@ -66,8 +66,27 @@ CLI to add it to the connector configuration. For example:
      native-operation create --operation-path native_operations/mutations/insert_artist.sql --kind mutation
    ```
 
-4. Add a source entity as described in our
-   [add source entities](/getting-started/quickstart.mdx) guide.
+4. Add a source entity as described in our [add source entities](/getting-started/quickstart.mdx) guide.
+
+:::tip Other operations
+
+You can also create bespoke mutations for updates and deletes. As an example, this mutation can be used to update an
+artist's name:
+
+```sql
+-- in update_artist_name.sql
+UPDATE public."Artist"
+SET "Name" = {{new_name}}
+WHERE "ArtistId" = (
+  SELECT "ArtistId"
+  FROM public."Artist"
+  WHERE "Name" = {{current_name}}
+  LIMIT 1
+)
+RETURNING *;
+```
+
+:::
 
 ## List Native Operations
 


### PR DESCRIPTION
## Description 📝

Adds an update example for a native mutation in Postgres.

## Quick Links 🚀

[Head down to the admonition in this section](https://rob-docs-add-update-nm.v3-docs-eny.pages.dev/connectors/postgresql/native-operations/custom-mutations/#create-a-native-mutation)
