### PR TITLE
Push a compatibility date back one day

### DIFF
--- a/docs/supergraph-modeling/compatibility-config.mdx
+++ b/docs/supergraph-modeling/compatibility-config.mdx
@@ -31,7 +31,7 @@ will be disabled. To enable these features, simply increase your `date` to a new
 The following is a list of dates at which backwards-incompatible changes were added to Hasura DDN. Projects with
 CompatibilityConfig `date`s prior to these dates will have these features disabled.
 
-#### 2024-12-03
+#### 2024-12-04
 
 ##### Prevent conflicts between boolean expression fields in GraphQL
 


### PR DESCRIPTION
## Description 📝
The deployment that would have used that compatibility date was delayed, so the date needs to be pushed back a day.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->
