### PR TITLE
Docs: Add MongoDB & ClickHouse tutorials

### DIFF
--- a/docs/how-to-build-with-ddn/overview.mdx
+++ b/docs/how-to-build-with-ddn/overview.mdx
@@ -26,12 +26,12 @@ of how it works.
 ### You have data
 
 Your data can live in a variety of places - relational or non-relational databases, OLAP or OLTP databases, vector
-stores, 3rd party services, or output by your code. With Hasura you can access all of it from a single API endpoint.
+stores, third-party services, or output by your code. With Hasura you can access all of it from a single API endpoint.
 
 ### You connect it to Hasura
 
 Regardless of where your data lives, you'll connect it to your API using a **native data connector**. These connectors
-will introspect your data sources and generate metadata that Hasura DDN will use to generate your API.
+will introspect your data sources and generate metadata that Hasura DDN will use to build your API.
 
 ### You configure your API in metadata
 

--- a/docs/how-to-build-with-ddn/overview.mdx
+++ b/docs/how-to-build-with-ddn/overview.mdx
@@ -19,17 +19,19 @@ import Link from "@docusaurus/Link";
 
 ## Introduction
 
-Hasura DDN enables a powerful, yet simple-to-create API on all your data. Each tutorial in this section will guide you through creating your first Hasura DDN API on top of your preferred data source. First, let's go over the broad stokes of how it works.
+Hasura DDN enables a powerful, yet simple-to-create API on all your data. Each tutorial in this section will guide you
+through creating your first Hasura DDN API on top of your preferred data source. First, let's go over the broad stokes
+of how it works.
 
 ### You have data
 
-
-Your data can live in a variety of places - relational or non-relational databases, OLAP or OLTP databases, vector stores, 3rd party services, or output by your code. With Hasura you can access all of it from a single API endpoint.
+Your data can live in a variety of places - relational or non-relational databases, OLAP or OLTP databases, vector
+stores, 3rd party services, or output by your code. With Hasura you can access all of it from a single API endpoint.
 
 ### You connect it to Hasura
 
-Regardless of where your data lives, you'll connect it to your API using a **native data connector**. These connectors will introspect your data sources and generate metadata that Hasura DDN will use to generate
-your API.
+Regardless of where your data lives, you'll connect it to your API using a **native data connector**. These connectors
+will introspect your data sources and generate metadata that Hasura DDN will use to generate your API.
 
 ### You configure your API in metadata
 
@@ -39,7 +41,9 @@ metadata objects for permissions, relationships, configuring authentication, etc
 
 ### You serve the API
 
-To convert your metadata into something that you can query, you'll create a build - an immutable snapshot of your API at that point in time which the Hasura Engine can run and serve. You can then use the **console** - Hasura's GUI - to query and analyze your GraphQL API, or integrate it with your client apps.
+To convert your metadata into something that you can query, you'll create a build - an immutable snapshot of your API at
+that point in time which the Hasura Engine can run and serve. You can then use the **console** - Hasura's GUI - to query
+and analyze your GraphQL API, or integrate it with your client apps.
 
 You can serve this API locally during development for testing and iteration, on Hasura DDN for scalability and ease of
 use, or on your own infrastructure if you need complete control and customization.
@@ -47,4 +51,5 @@ use, or on your own infrastructure if you need complete control and customizatio
 ## Get started with your favorite source
 
 - [PostgreSQL](/how-to-build-with-ddn/with-postgresql.mdx)
+- [MongoDB](/how-to-build-with-ddn/with-mongodb.mdx)
 - [Others](/how-to-build-with-ddn/with-others.mdx)

--- a/docs/how-to-build-with-ddn/with-clickhouse.mdx
+++ b/docs/how-to-build-with-ddn/with-clickhouse.mdx
@@ -1,0 +1,431 @@
+---
+sidebar_position: 5
+sidebar_label: With ClickHouse
+description: "Learn the basics of Hasura DDN and how to get started with a ClickHouse instance."
+keywords:
+  - hasura ddn
+  - graphql api
+  - getting started
+  - guide
+  - clickhouse
+---
+
+import Prereqs from "@site/docs/_prereqs.mdx";
+
+# Get Started with Hasura DDN and ClickHouse
+
+## Overview
+
+This tutorial takes about fifteen minutes to complete. You'll learn how to:
+
+- Set up a new Hasura DDN project
+- Connect it to a ClickHouse instance
+- Generate Hasura metadata
+- Create a build
+- Run your first query
+
+Additionally, we'll familiarize you with the steps and workflows necessary to iterate on your API.
+
+This tutorial assumes you're starting from scratch. We'll use a locally running ClickHouse instance via Docker and
+connect it to Hasura, but you can easily follow the steps if you already have data seeded or are using ClickHouse's
+hosted service; Hasura will never modify your source schema.
+
+<Prereqs />
+
+## Tutorial
+
+### Step 1. Authenticate your CLI
+
+```sh title="Before you can create a new Hasura DDN project, you need to authenticate your CLI:"
+ddn auth login
+```
+
+This will launch a browser window prompting you to log in or sign up for Hasura DDN. After you log in, the CLI will
+acknowledge your login, giving you access to Hasura Cloud resources.
+
+### Step 2. Scaffold out a new local project
+
+```sh title="Next, create a new local project:"
+ddn supergraph init my-project && cd my-project
+```
+
+Once you move into this directory, you'll see your project scaffolded out for you. You can view the structure by either
+running `ls` in your terminal, or by opening the directory in your preferred editor.
+
+### Step 3. Initialize your ClickHouse connector
+
+```sh title="In your project directory, run:"
+ddn connector init my_ch -i
+```
+
+From the dropdown, start typing `clickhouse` and hit enter to accept the default port. Then, provide the following
+values:
+
+**Connection string**
+
+```plaintext
+http://local.hasura.dev:8123
+```
+
+**Username**
+
+```plaintext
+default_user
+```
+
+**Password**
+
+```plaintext
+default_password
+```
+
+### Step 4. Start the local ClickHouse container
+
+```sh title="Begin by creating a compose file for the ClickHouse service:"
+touch app/connector/my_ch/compose.clickhouse.yaml
+```
+
+```yaml title="Then, open the file and add the following:"
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server
+    container_name: clickhouse-server
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    volumes:
+      - ./clickhouse-data:/var/lib/clickhouse
+    environment:
+      CLICKHOUSE_USER: "default_user"
+      CLICKHOUSE_PASSWORD: "default_password"
+      CLICKHOUSE_DB: "default"
+```
+
+```sh title="Run the container:"
+docker compose -f app/connector/my_ch/compose.clickhouse.yaml up -d
+```
+
+```sh title="Send a curl reuest to create the table in the database:"
+curl -u default_user:default_password -X POST \
+    --data "CREATE TABLE users (user_id UInt32, name String, age UInt8) ENGINE = MergeTree() ORDER BY user_id;" \
+    http://localhost:8123
+```
+
+```sh title="Then, seed the table:"
+curl -u default_user:default_password -X POST \
+    --data "INSERT INTO users (user_id, name, age) VALUES (1, 'Alice', 25), (2, 'Bob', 30), (3, 'Charlie', 35);" \
+    http://localhost:8123
+```
+
+```sh title="You can verify this by running:"
+curl -u default_user:default_password -X POST \
+    --data "SELECT * FROM users;" \
+    http://localhost:8123
+```
+
+You should see a list of users returned.
+
+### Step 5. Introspect your ClickHouse database
+
+```sh title="Next, use the CLI to introspect your ClickHouse database:"
+ddn connector introspect my_ch
+```
+
+After running this, you should see a representation of your database's schema in the
+`app/connector/my_ch/configuration.json` file; you can view this using `cat` or open the file in your editor.
+
+### Step 6. Add your model
+
+```sh title="Now, track the table from your ClickHouse database as a model in your DDN metadata:"
+ddn models add my_ch users
+```
+
+Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The DDN CLI will use this Hasura
+Metadata Language file to represent the `users` table from ClickHouse in your API as a
+[model](/supergraph-modeling/models.mdx).
+
+### Step 7. Create a new build
+
+```sh title="To create a local build, run:"
+ddn supergraph build local
+```
+
+The build is stored as a set of JSON files in `engine/build`.
+
+### Step 8. Start your local services
+
+```sh title="Start your local Hasura DDN Engine and ClickHouse connector:"
+ddn run docker-start
+```
+
+Your terminal will be taken over by logs for the different services.
+
+### Step 9. Run your first query
+
+```sh title="In a new terminal tab, open your local console:"
+ddn console --local
+```
+
+```graphql title="In the GraphiQL explorer of the console, write this query:"
+query {
+  users {
+    userId
+    name
+    age
+  }
+}
+```
+
+```json title="You'll get the following response:"
+{
+  "data": {
+    "users": [
+      {
+        "userId": 1,
+        "name": "Alice",
+        "age": 25
+      },
+      {
+        "userId": 2,
+        "name": "Bob",
+        "age": 30
+      },
+      {
+        "userId": 3,
+        "name": "Charlie",
+        "age": 35
+      }
+    ]
+  }
+}
+```
+
+### Step 10. Iterate on your ClickHouse schema
+
+```sh title="Let's add a new table for posts:"
+curl -u default_user:default_password -X POST \
+    --data "CREATE TABLE posts (
+        user_id UInt32,
+        title String,
+        content String
+    ) ENGINE = MergeTree()
+    ORDER BY user_id;" \
+    http://localhost:8123
+```
+
+```sh title="Then, seed it:"
+curl -u default_user:default_password -X POST \
+    --data "INSERT INTO posts (user_id, title, content) VALUES
+    (1, 'My First Post', 'This is Alice''s first post.'),
+    (1, 'Another Post', 'Alice writes again!'),
+    (2, 'Bob''s Post', 'Bob shares his thoughts.'),
+    (3, 'Hello World', 'Charlie joins the conversation.');" \
+    http://localhost:8123
+```
+
+```sh title="Finally, we can check the posts were generated:"
+curl -u default_user:default_password -X POST \
+    --data "SELECT * FROM posts;" \
+    http://localhost:8123
+```
+
+### Step 11. Refresh your metadata and rebuild your project
+
+:::tip
+
+The following steps are necessary each time you make changes to your **source** schema. This includes, adding,
+modifying, or dropping tables.
+
+:::
+
+#### Step 11.1. Re-introspect your data source
+
+```sh title="Run the introspection command again:"
+ddn connector introspect my_ch
+```
+
+In `app/connector/my_ch/configuration.json`, you'll see schema updated to include operations for the `posts` table. In
+`app/metadata/my_ch.hml`, you'll see `posts` present in the metadata as well.
+
+#### Step 11.2. Update your metadata
+
+```sh title="Add the posts model:"
+ddn model add my_ch posts
+```
+
+#### Step 11.3. Kill your services
+
+Bring down the services by pressing `CTRL+C` in the terminal tab logging their activity.
+
+#### Step 11.4. Create a new build
+
+```sh title="Next, create a new build:"
+ddn supergraph build local
+```
+
+#### Step 11.5 Restart your services
+
+```sh title="Bring everything back up:"
+ddn run docker-start
+```
+
+### Step 12. Query your new build
+
+```graphql title="Head back to your console and query the posts model:"
+query GetPosts {
+  posts {
+    userId
+    title
+    content
+  }
+}
+```
+
+```json title="You'll get a response like this:"
+{
+  "data": {
+    "posts": [
+      {
+        "userId": 1,
+        "title": "My First Post",
+        "content": "This is Alice's first post."
+      },
+      {
+        "userId": 1,
+        "title": "Another Post",
+        "content": "Alice writes again!"
+      },
+      {
+        "userId": 2,
+        "title": "Bob's Post",
+        "content": "Bob shares his thoughts."
+      },
+      {
+        "userId": 3,
+        "title": "Hello World",
+        "content": "Charlie joins the conversation."
+      }
+    ]
+  }
+}
+```
+
+### Step 13. Create a relationship
+
+```yaml title="Open the Posts.hml file and add the following to the end:"
+---
+kind: Relationship
+version: v1
+definition:
+  name: user
+  sourceType: Posts
+  target:
+    model:
+      name: Users
+      relationshipType: Object
+  mapping:
+    - source:
+        fieldPath:
+          - fieldName: userId
+      target:
+        modelField:
+          - fieldName: userId
+```
+
+:::tip LSP-Assisted authoring is available
+
+We've created an extension for VS Code that leverages LSP to make authoring these metadata objects easier. Check it out
+[here](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura).
+
+:::
+
+### Step 14. Rebuild your project
+
+Bring down the services by pressing `CTRL+C` in the terminal tab logging their activity.
+
+```sh title="As your metadata has changed, create a new build:"
+ddn supergraph build local
+```
+
+```sh title="Bring everything back up:"
+ddn run docker-start
+```
+
+### Step 15. Query using your relationship
+
+```graphql title="Now, execute a nested query using your relationship:"
+query GetPosts {
+  posts {
+    title
+    content
+    user {
+      userId
+      name
+      age
+    }
+  }
+}
+```
+
+```json title="Which should return a result like this:"
+{
+  "data": {
+    "posts": [
+      {
+        "title": "My First Post",
+        "content": "This is Alice's first post.",
+        "user": {
+          "userId": 1,
+          "name": "Alice",
+          "age": 25
+        }
+      },
+      {
+        "title": "Another Post",
+        "content": "Alice writes again!",
+        "user": {
+          "userId": 1,
+          "name": "Alice",
+          "age": 25
+        }
+      },
+      {
+        "title": "Bob's Post",
+        "content": "Bob shares his thoughts.",
+        "user": {
+          "userId": 2,
+          "name": "Bob",
+          "age": 30
+        }
+      },
+      {
+        "title": "Hello World",
+        "content": "Charlie joins the conversation.",
+        "user": {
+          "userId": 3,
+          "name": "Charlie",
+          "age": 35
+        }
+      }
+    ]
+  }
+}
+```
+
+## Next steps
+
+Congratulations on completing your first Hasura DDN project with ClickHouse! 🎉
+
+Here's what you just accomplished:
+
+- You started with a fresh project and connected it to a local ClickHouse database.
+- You set up metadata to represent your tables and relationships, which acts as the blueprint for your API.
+- Then, you created a build — essentially compiling everything into a ready-to-use API — and successfully ran your first
+  GraphQL queries to fetch data.
+- Along the way, you learned how to iterate on your schema and refresh your metadata to reflect changes.
+
+Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
+
+Take a look at our [ClickHouse docs](/connectors/clickhouse/index.mdx) to learn more about how to use Hasura DDN with
+ClickHouse. Or, if you're ready, get started with adding [permissions](/supergraph-modeling/permissions.mdx) to control
+access to your API.

--- a/docs/how-to-build-with-ddn/with-clickhouse.mdx
+++ b/docs/how-to-build-with-ddn/with-clickhouse.mdx
@@ -105,7 +105,7 @@ services:
 docker compose -f app/connector/my_ch/compose.clickhouse.yaml up -d
 ```
 
-```sh title="Send a curl reuest to create the table in the database:"
+```sh title="Send a curl request to create the table in the database:"
 curl -u default_user:default_password -X POST \
     --data "CREATE TABLE users (user_id UInt32, name String, age UInt8) ENGINE = MergeTree() ORDER BY user_id;" \
     http://localhost:8123

--- a/docs/how-to-build-with-ddn/with-mongodb.mdx
+++ b/docs/how-to-build-with-ddn/with-mongodb.mdx
@@ -93,8 +93,7 @@ docker compose -f app/connector/my_mongo/compose.mongo.yaml up -d
 ```
 
 ```sh title="Use the mongosh shell to seed the database:"
-docker exec -it mongodb mongosh --eval "
-db = db.getSiblingDB('my_database');
+docker exec -it mongodb mongosh my_database --eval "
 db.users.insertMany([
   { user_id: 1, name: 'Alice', age: 25 },
   { user_id: 2, name: 'Bob', age: 30 },

--- a/docs/how-to-build-with-ddn/with-mongodb.mdx
+++ b/docs/how-to-build-with-ddn/with-mongodb.mdx
@@ -1,0 +1,399 @@
+---
+sidebar_position: 4
+sidebar_label: With MongoDB
+description: "Learn the basics of Hasura DDN and how to get started with a MongoDB database."
+keywords:
+  - hasura ddn
+  - graphql api
+  - getting started
+  - guide
+  - mongodb
+  - mongo
+---
+
+import Prereqs from "@site/docs/_prereqs.mdx";
+
+# Get Started with Hasura DDN and MongoDB
+
+## Overview
+
+This tutorial takes about fifteen minutes to complete. You'll learn how to:
+
+- Set up a new Hasura DDN project
+- Connect it to a MongoDB database
+- Generate Hasura metadata
+- Create a build
+- Run your first query
+
+Additionally, we'll familiarize you with the steps and workflows necessary to iterate on your API.
+
+This tutorial assumes you're starting from scratch. We'll use a locally running MongoDB instance via Docker and connect
+it to Hasura, but you can easily follow the steps if you already have data seeded; Hasura will never modify your source
+schema.
+
+<Prereqs />
+
+:::info Additionally, you'll need mongosh
+
+This tutorial uses mongosh — the Mongo shell — to interact with the local MongoDB instance. You can download it
+[here](https://www.mongodb.com/try/download/shell).
+
+:::
+
+## Tutorial
+
+### Step 1. Authenticate your CLI
+
+```sh title="Before you can create a new Hasura DDN project, you need to authenticate your CLI:"
+ddn auth login
+```
+
+This will launch a browser window prompting you to log in or sign up for Hasura DDN. After you log in, the CLI will
+acknowledge your login, giving you access to Hasura Cloud resources.
+
+### Step 2. Scaffold out a new local project
+
+```sh title="Next, create a new local project:"
+ddn supergraph init my-project && cd my-project
+```
+
+Once you move into this directory, you'll see your project scaffolded out for you. You can view the structure by either
+running `ls` in your terminal, or by opening the directory in your preferred editor.
+
+### Step 3. Initialize your MongoDB connector
+
+```sh title="In your project directory, run:"
+ddn connector init my_mongo -i
+```
+
+From the dropdown, start typing `mongo` and hit enter to accept the default port. Then, provide the following connection
+string:
+
+```plaintext
+mongodb://local.hasura.dev:27017/my_database
+```
+
+### Step 4. Start the local MongoDB container
+
+```sh title="Begin by creating a compose file for the Mongo service:"
+touch app/connector/my_mongo/compose.mongo.yaml
+```
+
+```yaml title="Then, open the file and add the following:"
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+```
+
+```sh title="Run the container:"
+docker compose -f app/connector/my_mongo/compose.mongo.yaml up -d
+```
+
+```sh title="Use the mongosh shell to seed the database:"
+docker exec -it mongodb mongosh --eval "
+db = db.getSiblingDB('my_database');
+db.users.insertMany([
+  { user_id: 1, name: 'Alice', age: 25 },
+  { user_id: 2, name: 'Bob', age: 30 },
+  { user_id: 3, name: 'Charlie', age: 35 }
+]);
+"
+```
+
+The shell will return information about the newly-inserted `users` records.
+
+### Step 6. Introspect your MongoDB database
+
+```sh title="Next, use the CLI to introspect your MongoDB database:"
+ddn connector introspect my_mongo
+```
+
+After running this, you should see a representation of your collection's schema in
+`app/connector/my_mongo/schema/users.json`; you can view this using `cat` or open the file in your editor.
+
+For each collection in your database, the MongoDB connector will generate a separate JSON file representing it.
+
+### Step 7. Add your model
+
+```sh title="Now, track the collection from your MongoDB database as a model:"
+ddn models add my_mongo users
+```
+
+Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The Hasura engine will use this
+Hasura Metadata Language file to bring the `users` table from MongoDB into your API as a
+[model](/supergraph-modeling/models.mdx).
+
+### Step 8. Create a new build
+
+```sh title="To create a local build, run:"
+ddn supergraph build local
+```
+
+The build is stored as a set of JSON files in `engine/build`.
+
+### Step 9. Start your local services
+
+```sh title="Start your local Hasura DDN Engine and MongoDB connector:"
+ddn run docker-start
+```
+
+Your terminal will be taken over by logs for the different services.
+
+### Step 10. Run your first query
+
+```sh title="In a new terminal tab, open your local console:"
+ddn console --local
+```
+
+```graphql title="In the GraphiQL explorer of the console, write this query:"
+query {
+  users {
+    userId
+    name
+    age
+  }
+}
+```
+
+```json title="You'll get the following response:"
+{
+  "data": {
+    "users": [
+      {
+        "userId": 1,
+        "name": "Alice",
+        "age": 25
+      },
+      {
+        "userId": 2,
+        "name": "Bob",
+        "age": 30
+      },
+      {
+        "userId": 3,
+        "name": "Charlie",
+        "age": 35
+      }
+    ]
+  }
+}
+```
+
+### Step 11. Iterate on your MongoDB schema
+
+```sh title="Let's add a new collection for posts:"
+
+docker exec -it mongodb mongosh --eval "
+db = db.getSiblingDB('my_database');
+db.posts.insertMany([
+  { user_id: 1, title: 'My First Post', content: 'This is Alice\'s first post.' },
+  { user_id: 1, title: 'Another Post', content: 'Alice writes again!' },
+  { user_id: 2, title: 'Bob\'s Post', content: 'Bob shares his thoughts.' },
+  { user_id: 3, title: 'Hello World', content: 'Charlie joins the conversation.' }
+]);
+"
+```
+
+### Step 12. Refresh your metadata and rebuild your project
+
+:::tip
+
+The following steps are necessary each time you make changes to your **source** schema. This includes, adding,
+modifying, or dropping collections.
+
+:::
+
+#### Step 12.1. Re-introspect your data source
+
+```sh title="Run the introspection command again:"
+ddn connector introspect my_mongo
+```
+
+In `app/connector/my_mongo/configuration.json`, you'll see schema updated to include operations for the `posts`
+collection. You'll also see a `posts.json` file in the `schema` directory.
+
+#### Step 12.2. Update your metadata
+
+```sh title="Add the posts model:"
+ddn model add my_mongo posts
+```
+
+#### Step 12.3. Kill your services
+
+Bring down the services by pressing `CTRL+C` in the terminal tab logging their activity.
+
+#### Step 12.4. Create a new build
+
+```sh title="Next, create a new build:"
+ddn supergraph build local
+```
+
+#### Step 12.5 Restart your services
+
+```sh title="Bring everything back up:"
+ddn run docker-start
+```
+
+### Step 13. Query your new build
+
+```graphql title="Head back to your console and query the posts model:"
+query GetPosts {
+  posts {
+    userId
+    title
+    content
+  }
+}
+```
+
+```json title="You'll get a response like this:"
+{
+  "data": {
+    "posts": [
+      {
+        "userId": 1,
+        "title": "My First Post",
+        "content": "This is Alice's first post."
+      },
+      {
+        "userId": 1,
+        "title": "Another Post",
+        "content": "Alice writes again!"
+      },
+      {
+        "userId": 2,
+        "title": "Bob's Post",
+        "content": "Bob shares his thoughts."
+      },
+      {
+        "userId": 3,
+        "title": "Hello World",
+        "content": "Charlie joins the conversation."
+      }
+    ]
+  }
+}
+```
+
+### Step 14. Create a relationship
+
+```yaml title="Open the Posts.hml file and add the following to the end:"
+---
+kind: Relationship
+version: v1
+definition:
+  name: user
+  sourceType: Posts
+  target:
+    model:
+      name: Users
+      relationshipType: Object
+  mapping:
+    - source:
+        fieldPath:
+          - fieldName: userId
+      target:
+        modelField:
+          - fieldName: userId
+```
+
+:::tip LSP-Assisted authoring is available
+
+We've created an extension for VS Code that leverages LSP to make authoring these metadata objects easier. Check it out
+[here](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura).
+
+:::
+
+### Step 15. Rebuild your project
+
+Bring down the services by pressing `CTRL+C` in the terminal tab logging their activity.
+
+```sh title="As your metadata has changed, create a new build:"
+ddn supergraph build local
+```
+
+```sh title="Bring everything back up:"
+ddn run docker-start
+```
+
+### Step 16. Query using your relationship
+
+```graphql title="Now, execute a nested query using your relationship:"
+query GetPosts {
+  posts {
+    title
+    content
+    user {
+      userId
+      name
+      age
+    }
+  }
+}
+```
+
+```json title="Which should return a result like this:"
+{
+  "data": {
+    "posts": [
+      {
+        "title": "My First Post",
+        "content": "This is Alice's first post.",
+        "user": {
+          "userId": 1,
+          "name": "Alice",
+          "age": 25
+        }
+      },
+      {
+        "title": "Another Post",
+        "content": "Alice writes again!",
+        "user": {
+          "userId": 1,
+          "name": "Alice",
+          "age": 25
+        }
+      },
+      {
+        "title": "Bob's Post",
+        "content": "Bob shares his thoughts.",
+        "user": {
+          "userId": 2,
+          "name": "Bob",
+          "age": 30
+        }
+      },
+      {
+        "title": "Hello World",
+        "content": "Charlie joins the conversation.",
+        "user": {
+          "userId": 3,
+          "name": "Charlie",
+          "age": 35
+        }
+      }
+    ]
+  }
+}
+```
+
+## Next steps
+
+Congratulations on completing your first Hasura DDN project with MongoDB! 🎉
+
+Here's what you just accomplished:
+
+- You started with a fresh project and connected it to a local MongoDB database.
+- You set up metadata to represent your tables and relationships, which acts as the blueprint for your API.
+- Then, you created a build—essentially compiling everything into a ready-to-use API—and successfully ran your first
+  GraphQL queries to fetch data.
+- Along the way, you learned how to iterate on your schema and refresh your metadata to reflect changes.
+
+Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
+
+Take a look at our [MongoDB docs](/connectors/mongodb/index.mdx) to learn more about how to use Hasura DDN with MongoDB.
+Or, if you're ready, get started with adding [permissions](/supergraph-modeling/permissions.mdx) to control access to
+your API.

--- a/docs/how-to-build-with-ddn/with-mongodb.mdx
+++ b/docs/how-to-build-with-ddn/with-mongodb.mdx
@@ -185,8 +185,7 @@ query {
 
 ```sh title="Let's add a new collection for posts:"
 
-docker exec -it mongodb mongosh --eval "
-db = db.getSiblingDB('my_database');
+docker exec -it mongodb mongosh my_database --eval "
 db.posts.insertMany([
   { user_id: 1, title: 'My First Post', content: 'This is Alice\'s first post.' },
   { user_id: 1, title: 'Another Post', content: 'Alice writes again!' },

--- a/docs/how-to-build-with-ddn/with-mongodb.mdx
+++ b/docs/how-to-build-with-ddn/with-mongodb.mdx
@@ -33,16 +33,14 @@ schema.
 
 <Prereqs />
 
-:::info Additionally, you'll need mongosh
+## Tutorial
+
+### Step 1. Install mongosh
 
 This tutorial uses mongosh — the Mongo shell — to interact with the local MongoDB instance. You can download it
 [here](https://www.mongodb.com/try/download/shell).
 
-:::
-
-## Tutorial
-
-### Step 1. Authenticate your CLI
+### Step 2. Authenticate your CLI
 
 ```sh title="Before you can create a new Hasura DDN project, you need to authenticate your CLI:"
 ddn auth login
@@ -51,7 +49,7 @@ ddn auth login
 This will launch a browser window prompting you to log in or sign up for Hasura DDN. After you log in, the CLI will
 acknowledge your login, giving you access to Hasura Cloud resources.
 
-### Step 2. Scaffold out a new local project
+### Step 3. Scaffold out a new local project
 
 ```sh title="Next, create a new local project:"
 ddn supergraph init my-project && cd my-project
@@ -60,7 +58,7 @@ ddn supergraph init my-project && cd my-project
 Once you move into this directory, you'll see your project scaffolded out for you. You can view the structure by either
 running `ls` in your terminal, or by opening the directory in your preferred editor.
 
-### Step 3. Initialize your MongoDB connector
+### Step 4. Initialize your MongoDB connector
 
 ```sh title="In your project directory, run:"
 ddn connector init my_mongo -i
@@ -73,7 +71,7 @@ string:
 mongodb://local.hasura.dev:27017/my_database
 ```
 
-### Step 4. Start the local MongoDB container
+### Step 5. Start the local MongoDB container
 
 ```sh title="Begin by creating a compose file for the Mongo service:"
 touch app/connector/my_mongo/compose.mongo.yaml
@@ -117,12 +115,12 @@ For each collection in your database, the MongoDB connector will generate a sepa
 
 ### Step 7. Add your model
 
-```sh title="Now, track the collection from your MongoDB database as a model:"
+```sh title="Now, track the collection from your MongoDB database as a model in your DDN metadata:"
 ddn models add my_mongo users
 ```
 
-Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The Hasura engine will use this
-Hasura Metadata Language file to bring the `users` table from MongoDB into your API as a
+Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The DDN CLI will use this Hasura
+Metadata Language file to represent the `users` collections from MongoDB in your API as a
 [model](/supergraph-modeling/models.mdx).
 
 ### Step 8. Create a new build
@@ -385,8 +383,8 @@ Congratulations on completing your first Hasura DDN project with MongoDB! 🎉
 Here's what you just accomplished:
 
 - You started with a fresh project and connected it to a local MongoDB database.
-- You set up metadata to represent your tables and relationships, which acts as the blueprint for your API.
-- Then, you created a build—essentially compiling everything into a ready-to-use API—and successfully ran your first
+- You set up metadata to represent your collections and relationships, which acts as the blueprint for your API.
+- Then, you created a build — essentially compiling everything into a ready-to-use API — and successfully ran your first
   GraphQL queries to fetch data.
 - Along the way, you learned how to iterate on your schema and refresh your metadata to reflect changes.
 

--- a/docs/how-to-build-with-ddn/with-postgresql.mdx
+++ b/docs/how-to-build-with-ddn/with-postgresql.mdx
@@ -114,12 +114,12 @@ After running this, you should see a representation of your database's schema in
 
 ### Step 7. Add your model
 
-```sh title="Now, track the tables as models in your PostgreSQL database:"
+```sh title="Now, track the table from your PostgreSQL database as a model in your DDN metadata:"
 ddn models add my_pg users
 ```
 
-Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The Hasura engine will use this
-Hasura Metadata Language file to bring the `users` table from PostgreSQL into your API as a
+Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The DDN CLI will use this Hasura
+Metadata Language file to represent the `users` table from PostgreSQL in your API as a
 [model](/supergraph-modeling/models.mdx).
 
 ### Step 8. Create a new build
@@ -384,7 +384,7 @@ Here's what you just accomplished:
 
 - You started with a fresh project and connected it to a local PostgreSQL database.
 - You set up metadata to represent your tables and relationships, which acts as the blueprint for your API.
-- Then, you created a build—essentially compiling everything into a ready-to-use API—and successfully ran your first
+- Then, you created a build — essentially compiling everything into a ready-to-use API — and successfully ran your first
   GraphQL queries to fetch data.
 - Along the way, you learned how to iterate on your schema and refresh your metadata to reflect changes.
 


### PR DESCRIPTION
## Description 📝

Adds MongoDB & ClickHouse tutorials in the style of PostgreSQL.

This is meant to be a very prescriptive tutorial and to aid users in "learning by doing." It follows the same format as the PostgreSQL tutorial, but has been tweaked to account for variations in how MongoDB is seeded and how the mongo connector respects the iterative workflow relative to the postgres connector. The same is true for ClickHouse.

## Quick Links 🚀

- [New MongoDB tutorial](https://rob-docs-add-monog-and-click.v3-docs-eny.pages.dev/how-to-build-with-ddn/with-mongodb/)
- [New ClickHouse tutorial](https://rob-docs-add-monog-and-click.v3-docs-eny.pages.dev/how-to-build-with-ddn/with-clickhouse/)