### PR TITLE
Bump back compatibility date

### DIFF
--- a/docs/supergraph-modeling/compatibility-config.mdx
+++ b/docs/supergraph-modeling/compatibility-config.mdx
@@ -31,7 +31,7 @@ will be disabled. To enable these features, simply increase your `date` to a new
 The following is a list of dates at which backwards-incompatible changes were added to Hasura DDN. Projects with
 CompatibilityConfig `date`s prior to these dates will have these features disabled.
 
-#### 2024-12-04
+#### 2024-12-05
 
 ##### Prevent conflicts between boolean expression fields in GraphQL
 


### PR DESCRIPTION
## Description 📝

Bump back a compatibility date because we missed the deploy window and now it needs to be pushed back a day.