### PR TITLE
Setting up DDN CLI autcompletion docs

### DIFF
--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -31,3 +31,129 @@ Running `ddn version` should print the CLI version, For example:
 ```
 DDN CLI Version: v2.0.1
 ```
+
+## Setup DDN CLI Completion
+
+The DDN CLI supports auto-completion for [zsh](#zsh),[bash](#bash),[PowerShell](#powershell) and [fish](#fish).
+
+## zsh
+
+#### Temporary Setup
+To load completions in the current session:
+
+```sass
+source <(ddn completion zsh)
+```
+#### Permanent Setup
+
+1. Ensure shell completion is enabled by adding the following to your `~/.zshrc` file
+
+```sass
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
+### MacOs
+execute the following
+
+```sass
+ddn completion zsh > $(brew --prefix)/share/zsh/site-functions/_ddn
+```
+
+### Linux
+execute the following
+
+```sass
+ddn completion zsh > "${fpath[1]}/_ddn"
+```
+:::note
+Restart your shell so the changes take effect
+:::
+
+## bash
+
+Install the bash-completion package using your OS's package manager if it's not already installed.
+
+#### Temporary Setup
+To load completions in the current session:
+
+```sass
+source <(ddn completion bash)
+```
+#### Permanent Setup
+
+### MacOs
+execute the following
+
+```sass
+ddn completion bash > $(brew --prefix)/etc/bash_completion.d/ddn
+```
+
+### Linux
+execute the following
+
+```sass
+ddn completion bash > /etc/bash_completion.d/ddn
+```
+:::note
+Restart your shell so the changes take effect
+:::
+
+
+## PowerShell
+
+
+Run the following command to generate the script for enabling autocompletion:
+
+```sass
+ddn completion powershell | Out-String | Invoke-Expression
+```
+This temporarily enables autocompletion for the current session.
+
+Locate your PowerShell profile by running the following command:
+```sass
+$PROFILE
+```
+Your PowerShell profile is a script that runs each time PowerShell starts.
+
+Common paths for the PowerShell profile are:
+ - Windows PowerShell: `C:\Users\<YourUsername>\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
+ - PowerShell Core: `C:\Users\<YourUsername>\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`
+
+Edit your PowerShell Profile
+
+Open the profile in a text editor: 
+```sass
+notepad $PROFILE
+```
+Add the following line to the end of the file:
+```sass
+ddn completion powershell | Out-String | Invoke-Expression
+```
+Save the file and close the editor.
+
+:::note
+Restart your shell so the changes take effect
+:::
+
+## fish
+
+#### Temporary Setup
+execute the following
+
+```sass
+ddn completion fish | source
+```
+
+#### Permanent Setup
+execute the following
+
+```sass
+ddn completion fish > ~/.config/fish/completions/ddn.fish
+```
+
+:::note
+Restart your shell so the changes take effect
+:::
+
+:::info 
+Try using the ddn CLI with autocompletion by typing part of a command and pressing Tab to verify.
+:::

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -16,15 +16,18 @@ keywords:
   - installing hasura on mac
   - hasura for linux
 seoFrontMatterUpdated: true
+toc_max_heading_level: 3
 ---
 
 import InstallTheCli from "@site/docs/_install-the-cli.mdx";
 
 # Installation {#install-instructions}
 
+## Install the CLI
+
 <InstallTheCli />
 
-## Verify Installation
+## Verify the installation
 
 Running `ddn version` should print the CLI version, For example:
 
@@ -32,128 +35,141 @@ Running `ddn version` should print the CLI version, For example:
 DDN CLI Version: v2.0.1
 ```
 
-## Setup DDN CLI Completion
+## Set up auto-completion (optional)
 
 The DDN CLI supports auto-completion for [zsh](#zsh),[bash](#bash),[PowerShell](#powershell) and [fish](#fish).
 
-## zsh
+### zsh
 
-#### Temporary Setup
-To load completions in the current session:
+**Temporary set up**
 
-```sass
+```sh title="To load completions in the current session:"
 source <(ddn completion zsh)
 ```
-#### Permanent Setup
 
-1. Ensure shell completion is enabled by adding the following to your `~/.zshrc` file
+**Permanent set up**
 
-```sass
+```sh title="Ensure shell completion is enabled by adding the following to your ~/.zshrc file:"
 echo "autoload -U compinit; compinit" >> ~/.zshrc
 ```
-### MacOs
-execute the following
+
+#### macOS
 
 ```sass
 ddn completion zsh > $(brew --prefix)/share/zsh/site-functions/_ddn
 ```
 
-### Linux
-execute the following
+#### Linux
 
-```sass
+```sh title="Execute the following:"
 ddn completion zsh > "${fpath[1]}/_ddn"
 ```
+
 :::note
+
 Restart your shell so the changes take effect
+
 :::
 
-## bash
+Try using the DDN CLI with auto-completion by typing part of a command and pressing `TAB` to verify.
 
-Install the bash-completion package using your OS's package manager if it's not already installed.
+### Bash
 
-#### Temporary Setup
-To load completions in the current session:
+Install the [bash-completion package](https://github.com/scop/bash-completion) using your OS's package manager if it's
+not already installed.
 
-```sass
+**Temporary set up**
+
+```sh title="To load completions in the current session:"
 source <(ddn completion bash)
 ```
-#### Permanent Setup
 
-### MacOs
-execute the following
+**Permanent set up**
 
-```sass
+#### macOS
+
+```sh title="Execute the following:"
 ddn completion bash > $(brew --prefix)/etc/bash_completion.d/ddn
 ```
 
-### Linux
-execute the following
+#### Linux
 
-```sass
+```sh title="Execute the following:"
 ddn completion bash > /etc/bash_completion.d/ddn
 ```
+
 :::note
+
 Restart your shell so the changes take effect
+
 :::
 
+Try using the DDN CLI with auto-completion by typing part of a command and pressing `TAB` to verify.
 
-## PowerShell
+### PowerShell
 
+#### Step 1. Generate the auto-completion script
 
-Run the following command to generate the script for enabling autocompletion:
+Run the following command to generate the script for enabling auto-completion:
 
-```sass
+```sh
 ddn completion powershell | Out-String | Invoke-Expression
 ```
-This temporarily enables autocompletion for the current session.
 
-Locate your PowerShell profile by running the following command:
-```sass
+This temporarily enables auto-completion for the current session.
+
+#### Step 2. Locate your profile
+
+```sh title="Locate your PowerShell profile by running the following command:"
 $PROFILE
 ```
+
 Your PowerShell profile is a script that runs each time PowerShell starts.
 
 Common paths for the PowerShell profile are:
- - Windows PowerShell: `C:\Users\<YourUsername>\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
- - PowerShell Core: `C:\Users\<YourUsername>\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`
 
-Edit your PowerShell Profile
+- Windows PowerShell: `C:\Users\<YourUsername>\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
+- PowerShell Core: `C:\Users\<YourUsername>\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`
 
-Open the profile in a text editor: 
-```sass
+#### Step 3. Edit your PowerShell profile
+
+```sh title="Open the profile in a text editor:"
 notepad $PROFILE
 ```
-Add the following line to the end of the file:
-```sass
+
+```plaintext title="Add the following line to the end of the file:"
 ddn completion powershell | Out-String | Invoke-Expression
 ```
+
 Save the file and close the editor.
 
 :::note
+
 Restart your shell so the changes take effect
+
 :::
 
-## fish
+Try using the DDN CLI with auto-completion by typing part of a command and pressing `TAB` to verify.
 
-#### Temporary Setup
-execute the following
+### fish
 
-```sass
+**Temporary set up**
+
+```sh title="Execute the following:"
 ddn completion fish | source
 ```
 
-#### Permanent Setup
-execute the following
+**Permanent set up**
 
-```sass
+```sh title="Execute the following:"
 ddn completion fish > ~/.config/fish/completions/ddn.fish
 ```
 
 :::note
+
 Restart your shell so the changes take effect
+
 :::
 
-:::info 
-Try using the ddn CLI with autocompletion by typing part of a command and pressing Tab to verify.
-:::
+Try using the DDN CLI with auto-completion by typing part of a command and pressing `TAB` to verify.
+


### PR DESCRIPTION
## Description 📝
This PR adds a section to the install DDN CLI page with instructions to setup the DDN CLI autocompletion for shells zsh, bash, Powershell  and fish.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->