### PR TITLE
Fix native query link that erroneously linked to native mutations

### DIFF
--- a/docs/reference/connectors/mongodb/native-operations/index.mdx
+++ b/docs/reference/connectors/mongodb/native-operations/index.mdx
@@ -20,7 +20,7 @@ queries and mutations directly from your Hasura GraphQL API.
 ## Get started
 
 - [Syntax](/reference/connectors/mongodb/native-operations/syntax.mdx)
-- [Native queries](/reference/connectors/mongodb/native-operations/native-mutations.mdx)
+- [Native queries](/reference/connectors/mongodb/native-operations/native-queries.mdx)
 - [Native mutations](/reference/connectors/mongodb/native-operations/native-mutations.mdx)
 - [Security best practices](/reference/connectors/mongodb/native-operations/security-best-practices.mdx)
 - [Supported aggregation pipeline features](/reference/connectors/mongodb/native-operations/supported-aggregation-pipeline-features.mdx)


### PR DESCRIPTION
## Description 📝

A link on the MongoDB connector Native Operations page had a URL for the wrong sub-page. But the sidebar links are correct.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->