### PR TITLE
Docs: Add note for lambda deps

### DIFF
--- a/docs/business-logic/add-a-lambda-connector.mdx
+++ b/docs/business-logic/add-a-lambda-connector.mdx
@@ -32,17 +32,26 @@ ddn connector init <your_name_for_the_connector> -i
 When you add the `hasura/nodejs` connector, the CLI will generate a Node.js package with a `functions.ts` file. This
 file is the entrypoint for your connector.
 
+As this is a Node.js project, you can easily add any dependencies you desire by running `npm i <package-name>` from this
+connector's directory.
+
 </TabItem>
 <TabItem value="Python" label="Python">
 
 When you add the `hasura/python` connector, the CLI will generate a Python application with a `functions.py` file. This
 file is the entrypoint for your connector.
 
+As this is a Python project, you can easily add any dependencies you desire by adding them to the `requirements.txt` in
+this connector's directory.
+
 </TabItem>
 <TabItem value="Go" label="Go">
 
 When you add the `hasura/go` connector, the CLI will generate a Go application with a `/functions` directory. The
 connector will use this directory — and any `*.go` file in it — as the entrypoint for your connector.
+
+As this is a Go project, you can easily add any dependencies you desire by adding them to the `go.mod` file and running
+`go mod tidy` from this connector's directory.
 
 </TabItem>
 


### PR DESCRIPTION
## Description 📝

Adds a note for lambda deps on how to include additional packages, varying by language.

## Quick Links 🚀

[Add a Lambda](https://robdominguez-doc-2340-add-a.v3-docs-eny.pages.dev/business-logic/add-a-lambda-connector/)

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
A user should understand how to add dependencies to a lambda connector.
<!-- DX:Assertion-end -->