### PR TITLE
Docs: Add "2025-01-07" compatibility date

### DIFF
--- a/docs/supergraph-modeling/compatibility-config.mdx
+++ b/docs/supergraph-modeling/compatibility-config.mdx
@@ -31,6 +31,33 @@ will be disabled. To enable these features, simply increase your `date` to a new
 The following is a list of dates at which backwards-incompatible changes were added to Hasura DDN. Projects with
 CompatibilityConfig `date`s prior to these dates will have these features disabled.
 
+#### 2025-01-07
+
+##### Disallow duplicate operator definitions for scalar type
+
+A build error is now raised when a scalar type has multiple operator definitions with the same name. For example, if you
+have a custom scalar type and define multiple operators with the same name in its boolean expression configuration, the
+build will fail. This ensures that operator definitions for scalar types are unique and prevents ambiguity in boolean
+expressions.
+
+##### Disallow multidimensional arrays in boolean expressions
+
+A build error is now raised when multidimensional arrays (arrays of arrays) are used in boolean expressions. This
+restriction applies to both array comparison operators and array relationship fields within boolean expressions.
+Previously, such configurations might have been allowed but could lead to runtime errors or undefined behavior. This
+change ensures that only single-dimensional arrays can be used in boolean expressions, making the behavior more
+predictable and preventing potential runtime issues.
+
+##### Disallow duplicate names across types and expressions
+
+A build error is now raised when there are duplicate names across types and expressions in your metadata. This includes
+conflicts between objects with the following definitions:
+
+- `BooleanExpressionType`
+- `OrderByExpression`
+- `ScalarType`
+- `ObjectType`
+
 #### 2024-12-18
 
 ##### Disallow non-scalar fields in Model v1 `orderableFields`
@@ -176,26 +203,22 @@ metadata.
 
 ## Metadata structure
 
-
 ### v2_CompatibilityConfig {#v2_compatibilityconfig-v2_compatibilityconfig}
 
 The compatibility configuration of the Hasura metadata.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `CompatibilityConfig` | true |  |
-| `date` | [CompatibilityDate](#v2_compatibilityconfig-compatibilitydate) | true | Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata. |
-
-
+| Key    | Value                                                          | Required | Description                                                                                      |
+| ------ | -------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `kind` | `CompatibilityConfig`                                          | true     |                                                                                                  |
+| `date` | [CompatibilityDate](#v2_compatibilityconfig-compatibilitydate) | true     | Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata. |
 
 #### CompatibilityDate {#v2_compatibilityconfig-compatibilitydate}
 
 Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
+| Value                                                                                                                                                                                                                          | Description               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------- |
 | `2024-06-30` / `2024-09-03` / `2024-09-18` / `2024-09-26` / `2024-10-07` / `2024-10-16` / `2024-10-31` / `2024-11-13` / `2024-11-15` / `2024-11-18` / `2024-11-26` / `2024-12-05` / `2024-12-10` / `2024-12-18` / `2025-01-07` | Known compatibility dates |
-| string | Any date |
+| string                                                                                                                                                                                                                         | Any date                  |

--- a/docs/supergraph-modeling/compatibility-config.mdx
+++ b/docs/supergraph-modeling/compatibility-config.mdx
@@ -203,22 +203,26 @@ metadata.
 
 ## Metadata structure
 
+
 ### v2_CompatibilityConfig {#v2_compatibilityconfig-v2_compatibilityconfig}
 
 The compatibility configuration of the Hasura metadata.
 
-| Key    | Value                                                          | Required | Description                                                                                      |
-| ------ | -------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `kind` | `CompatibilityConfig`                                          | true     |                                                                                                  |
-| `date` | [CompatibilityDate](#v2_compatibilityconfig-compatibilitydate) | true     | Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata. |
+| Key | Value | Required | Description |
+|-----|-----|-----|-----|
+| `kind` | `CompatibilityConfig` | true |  |
+| `date` | [CompatibilityDate](#v2_compatibilityconfig-compatibilitydate) | true | Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata. |
+
+
 
 #### CompatibilityDate {#v2_compatibilityconfig-compatibilitydate}
 
 Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata
 
+
 **One of the following values:**
 
-| Value                                                                                                                                                                                                                          | Description               |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------- |
+| Value | Description |
+|-----|-----|
 | `2024-06-30` / `2024-09-03` / `2024-09-18` / `2024-09-26` / `2024-10-07` / `2024-10-16` / `2024-10-31` / `2024-11-13` / `2024-11-15` / `2024-11-18` / `2024-11-26` / `2024-12-05` / `2024-12-10` / `2024-12-18` / `2025-01-07` | Known compatibility dates |
-| string                                                                                                                                                                                                                         | Any date                  |
+| string | Any date |


### PR DESCRIPTION
## Description 📝
This PR adds documentation for the new compatibility date `2025-01-07` and its associated breaking changes in `docs/supergraph-modeling/compatibility-config.mdx`. The changes include detailed descriptions of three new build-time validations:

1. Disallowing duplicate operator definitions for scalar types
2. Preventing usage of multidimensional arrays in boolean expressions
3. Enforcing unique names across types and expressions

These changes help users understand the implications of setting their project's compatibility date and what validations will be enforced.
## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->