### PR TITLE
docs: fix operation name in example lambda connector tutorial

### DIFF
--- a/docs/business-logic/tutorials/3-hash-passwords.mdx
+++ b/docs/business-logic/tutorials/3-hash-passwords.mdx
@@ -157,7 +157,7 @@ In your project's explorer, you should see the new function exposed as a type an
 mutation like this:
 
 <GraphiQLIDE
-  query={`mutation HashPassword {
+  query={`query HashPassword {
   hashPassword(password: "Thisisthesecure1!")
 }`}
   response={`{


### PR DESCRIPTION
## Description 📝
Update operation name from 'mutation' to 'query', because the function is func not procedure