### PR TITLE
Update caching config example

### DIFF
--- a/docs/plugins/caching/how-to.mdx
+++ b/docs/plugins/caching/how-to.mdx
@@ -153,8 +153,8 @@ For local development, `HASURA_CACHING_PRE_PARSE_URL` should be `http://local.ha
 At this point, we can create a build of our project and start local development:
 
 ```bash
-ddn supergraph build local
-ddn run docker-start
+$ ddn supergraph build local
+$ ddn run docker-start
 ```
 
 Queries marked in the caching config as cacheable should now be cached. The caching plugin will output logs to indicate

--- a/docs/plugins/caching/how-to.mdx
+++ b/docs/plugins/caching/how-to.mdx
@@ -54,9 +54,6 @@ export const Config = {
     "hasura-m-auth": "zZkhKqFjqXR4g5MZCsJUZCnhCcoPyZ",
   },
 
-  // How long a cached response should live (in seconds).
-  time_to_live: 600,
-
   // A URL for redis. If you copied the docker-compose configuration for
   // `redis` above, this doesn't need changing.
   redis_url: "redis://redis:6379",
@@ -71,13 +68,17 @@ export const Config = {
   // A list of queries that we want to cache. Note that these queries will be
   // cached based on their parsed structures, so white space doesn't matter.
   queries_to_cache: [
-    ` query MyQuery {
-        customers {
-          firstName
-          lastName
+    {
+      query: ` query MyQuery {
+          customers {
+            firstName
+            lastName
+          }
         }
-      }
-    `,
+      `,
+      // How long a cached response should live (in seconds).
+      time_to_live: 600,
+    },
   ],
 };
 ```
@@ -152,8 +153,8 @@ For local development, `HASURA_CACHING_PRE_PARSE_URL` should be `http://local.ha
 At this point, we can create a build of our project and start local development:
 
 ```bash
-$ ddn supergraph build local
-$ ddn run docker-start
+ddn supergraph build local
+ddn run docker-start
 ```
 
 Queries marked in the caching config as cacheable should now be cached. The caching plugin will output logs to indicate


### PR DESCRIPTION
## Description 📝
The caching plugin updated to use ttl per query. This updates the config example in the docs.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->