### PR TITLE
Docs: Fix lambda examples

### DIFF
--- a/docs/business-logic/tutorials/3-hash-passwords.mdx
+++ b/docs/business-logic/tutorials/3-hash-passwords.mdx
@@ -73,7 +73,7 @@ across many systems.**
 
     connector = FunctionConnector()
 
-    @connector.register_query
+    @connector.register_mutation
     async def hash_password(password: str) -> str:
         salt = bcrypt.gensalt()
         hashedPassword = bcrypt.hashpw(password.encode("utf-8"), salt).decode("utf-8")
@@ -113,8 +113,8 @@ across many systems.**
     // HashPasswordResult defines the output result for the function
     type HashPasswordResult string
 
-    // FunctionHashPassword hashes a password string and returns it as a string result
-    func FunctionHashPassword(ctx context.Context, state *types.State, arguments *HashPasswordArguments) (*HashPasswordResult, error) {
+    // ProcedureHashPassword hashes a password string and returns it as a string result
+    func ProcedureHashPassword(ctx context.Context, state *types.State, arguments *HashPasswordArguments) (*HashPasswordResult, error) {
       hashedPassword, err := bcrypt.GenerateFromPassword([]byte(arguments.Password), bcrypt.DefaultCost)
       if err != nil {
         return nil, fmt.Errorf("failed to hash password: %v", err)


### PR DESCRIPTION
## Description 📝

For the Python and Go connectors, our labmda examples were exposing Open DD functions instead of procedures. This resolves them while still allowing us to use `mutation` via the GraphQL API.
