### PR TITLE
Docs: Fix OpenReplay on localhost

### DIFF
--- a/src/theme/DocRoot/Layout/index.js
+++ b/src/theme/DocRoot/Layout/index.js
@@ -40,7 +40,7 @@ export default function DocRootLayout({ children }) {
   }, [isBrowser, hasInitialized]);
 
   useEffect(() => {
-    if (isBrowser && hasInitializedOpenReplay) {
+    if (isBrowser && hasInitializedOpenReplay && window.location.hostname !== 'localhost') {
       startOpenReplayTracking();
     }
   }, [hasInitializedOpenReplay]);


### PR DESCRIPTION
## Description 📝

When adding the OpenReplay package(s) and testing, this error didn't occur. However, hot reloading after any modification to a page causes a runtime error triggered by the package. This check prevents OpenReplay from running on localhost and the error.
