### PR TITLE
updates to the pre-route plugin docs

### DIFF
--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -35,9 +35,7 @@ calling third-party services before the client receives the response.
 
 ### Pre-Route plugins
 
-Pre-route plugins are executed at the very beginning of the request handling (for other than pre-defined endpoints).
-This allows you to add custom HTTP handlers to your API. You can use these plugins to add RESTified GraphQL endpoints or
-internal tools like GraphQL schema visualizers, Swagger UI for JSON API, etc.
+Pre-route plugins are executed at the very beginning of request handling, **before predefined endpoints are processed**. They allow you to insert custom HTTP handlers into your API, enabling features like REST-style GraphQL endpoints, internal tools, or documentation interfaces such as a GraphQL schema visualizer or Swagger UI for a JSON API.
 
 ## Find out more
 

--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -33,6 +33,12 @@ Pre-response plugins are triggered at the final stage of the execution pipeline,
 before the response is sent to the client**. These plugins allow you to execute logic based on the response such as
 calling third-party services before the client receives the response.
 
+### Pre-Route plugins
+
+Pre-route plugins are executed at the very beginning of the request handling (for other than pre-defined endpoints).
+This allows you to add custom HTTP handlers to your API. You can use these plugins to add RESTified GraphQL endpoints or
+internal tools like GraphQL schema visualizers, Swagger UI for JSON API, etc.
+
 ## Find out more
 
 - [Learn more about how plugins work](/plugins/introduction.mdx)

--- a/docs/plugins/restified-endpoints/how-to.mdx
+++ b/docs/plugins/restified-endpoints/how-to.mdx
@@ -71,7 +71,7 @@ definition:
   url:
     valueFromEnv: RESTIFIED_ENDPOINTS_URL
   config:
-    match: "/v1/api/rest/*"
+    matchPath: "/v1/api/rest/*"
     matchMethods: ["GET", "POST"]
     request:
       method: GET
@@ -79,6 +79,7 @@ definition:
         forward:
           - Authorization
           - x-hasura-role
+          - x-hasura-ddn-token
         additional:
           hasura-m-auth:
             valueFromEnv: M_AUTH_KEY
@@ -87,6 +88,11 @@ definition:
         query: {}
         method: {}
         body: {}
+    response:
+      headers:
+        additional:
+          content-type:
+            value: application/json
 ```
 
 :::tip URL Match
@@ -167,7 +173,6 @@ Update the `src/config.ts` file with the RESTified GraphQL endpoints that you wa
 ```typescript
 export const Config = {
   graphqlServer: {
-    url: "http://localhost:3000/graphql",
     headers: {
       additional: {
         "Content-Type": "application/json",
@@ -218,10 +223,14 @@ In `restified-endpoints-plugin` directory, update the `wrangler.toml` file with 
 [vars]
 OTEL_EXPORTER_OTLP_ENDPOINT = "https://gateway.otlp.hasura.io:443/v1/traces"
 OTEL_EXPORTER_PAT = "<PAT>"
+GRAPHQL_SERVER_URL = "<DDN_GRAPHQL_SERVER_URL>"
 ```
 
 Replace `<PAT>` with the Personal Access Token (PAT) for the Hasura Cloud account. You can display this using the
 `ddn auth print-pat` command.
+
+Replace `<DDN_GRAPHQL_SERVER_URL>` with the URL of your DDN GraphQL server. You can find this in the DDN console under
+the `Settings > Project Summary` section.
 
 ## Step 7. Deploy the plugin
 
@@ -249,5 +258,10 @@ Create a new supergraph build on Hasura DDN to check your work in the cloud.
 ```bash
 ddn supergraph build create
 ```
+
+## Step 9. Apply the build
+
+Apply the build to make it the default one served by your Hasura DDN project endpoint. You can do this from the DDN
+console by choosing the build from the `Builds` tab and clicking `Apply Build`.
 
 The engine will execute the plugin for each requests to the RESTified GraphQL endpoints you defined.


### PR DESCRIPTION
## Description 📝

This PR updates the docs for the pre-route plugin and RESTified endpoints plugin "how to".

## Quick Links 🚀

- Added the section on pre-route plugin in the overview: https://paritosh-pre-route-plugin-im.v3-docs-eny.pages.dev/plugins/overview/#pre-route-plugins
- Updated the "how to" page for the RESTified endpoints plugin: https://paritosh-pre-route-plugin-im.v3-docs-eny.pages.dev/plugins/restified-endpoints/how-to/

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->