### PR TITLE
add missing end for the warning admonition

### DIFF
--- a/docs/private-ddn/create-a-data-plane.mdx
+++ b/docs/private-ddn/create-a-data-plane.mdx
@@ -123,6 +123,8 @@ Run the following command, replacing `<region>` with your desired region:
 - Consult with your network administrator if you're unsure about potential conflicts.
 - Remember that VPC CIDR and Kubernetes Service CIDR cannot be modified once the Data Plane has been created. :::
 
+:::
+
 <Thumbnail src="/img/data-plane/vpc-form.png" alt="Data Plane Creation Form" width="800px" />
 
 ### Step 3. Create and Monitor your Data Plane


### PR DESCRIPTION

## Description 📝
admonition was taking up the whole rest of the page

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->