### PR TITLE
Remove unnecessary MongoDB steps

### DIFF
--- a/docs/how-to-build-with-ddn/with-mongodb.mdx
+++ b/docs/how-to-build-with-ddn/with-mongodb.mdx
@@ -231,18 +231,11 @@ Bring down the services by pressing `CTRL+C` in the terminal tab logging their a
 ddn supergraph build local
 ```
 
-#### Step 12.5. Delete your connector's image
-
-Open Docker Desktop and delete the container **and** image for your MongoDB connector. It should be named something
-similar to `app-my_mongo-1`.
-
-#### Step 12.6 Restart your services
+#### Step 12.5 Restart your services
 
 ```sh title="Bring everything back up:"
 ddn run docker-start
 ```
-
-This will create a fresh image of your connector along with restarting your other services.
 
 ### Step 13. Query your new build
 
@@ -326,9 +319,6 @@ Bring down the services by pressing `CTRL+C` in the terminal tab logging their a
 ```sh title="As your metadata has changed, create a new build:"
 ddn supergraph build local
 ```
-
-As before, open Docker Desktop and delete the container **and** image for your MongoDB connector. It should be named
-something similar to `app-my_mongo-1`.
 
 ```sh title="Bring everything back up:"
 ddn run docker-start


### PR DESCRIPTION
## Description 📝

The MongoDB connector has been updated to no longer require deleting the container and image. 

## Quick Links 🚀

[/how-to-build-with-ddn/with-mongodb/](https://sean-remove-unnecessary-with.v3-docs-eny.pages.dev/how-to-build-with-ddn/with-mongodb/)