### PR TITLE
update Data Plane creation time expectations

### DIFF
--- a/docs/private-ddn/creating-a-data-plane/dedicated.mdx
+++ b/docs/private-ddn/creating-a-data-plane/dedicated.mdx
@@ -221,7 +221,7 @@ Data Plane Configuration form for GCP and Azure:
 ### Step 3. Create and Monitor your Data Plane
 
 Click the `Create` button after filling out all required fields. The creation process will begin, and you'll see your
-Data Plane listed with a `Creating` status. The creation process typically takes 60 minutes to complete.
+Data Plane listed with a `Creating` status. The creation process typically takes 60 minutes to complete for AWS and GCP deployments, and 2-3 business days for Azure deployments.
 
 <Thumbnail src="/img/data-plane/data-plane-page.png" alt="Data Plane Page" width="1000px" />
 


### PR DESCRIPTION
## Description 📝

Updates the documented creation time expectations for Data Planes across different cloud providers to accurately reflect:
- AWS and GCP: 60 minutes
- Azure: 2-3 business days

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->