### PR TITLE
Docs: Write MVP for Snowflake docs

### DIFF
--- a/docs/data-sources/connect-to-a-source.mdx
+++ b/docs/data-sources/connect-to-a-source.mdx
@@ -90,6 +90,13 @@ it requires:
 | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | `JDBC_URL` | `jdbc:snowflake://<account-identifier.<region>.snowflakecomputing.com?user=YOUR_USERNAME&&password=YOUR_PASSWORD&db=YOUR_DATABASE&warehouse=YOUR_WAREHOUSE&schema=YOUR_SCHEMA&role=YOUR_ROLE` | This connector requires a JDBC URL. |
 
+:::info Optional parameters for Snowflake
+
+Snowflake allows you to set a number of defaults. Your JDBC can minimal (i.e., only including the account identifier,
+username, and password) or more granular depending on your settings within Snowflake.
+
+:::
+
 </TabItem>
 </Tabs>
 

--- a/docs/data-sources/connect-to-a-source.mdx
+++ b/docs/data-sources/connect-to-a-source.mdx
@@ -84,7 +84,13 @@ it requires:
 | `ELASTICSEARCH_INDEX_PATTERN` | `hasura*`                                                      | The pattern for matching Elasticsearch indices, potentially including wildcards, used by the connector                                                                     |
 
 </TabItem>
+<TabItem value="Snowflake" label="Snowflake">
 
+| ENV        | Example                                                                                                                                                                                       | Description                         |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `JDBC_URL` | `jdbc:snowflake://<account-identifier.<region>.snowflakecomputing.com?user=YOUR_USERNAME&&password=YOUR_PASSWORD&db=YOUR_DATABASE&warehouse=YOUR_WAREHOUSE&schema=YOUR_SCHEMA&role=YOUR_ROLE` | This connector requires a JDBC URL. |
+
+</TabItem>
 </Tabs>
 
 If your data source requires a connection string or endpoint, the CLI will confirm that it successfully tested the

--- a/docs/how-to-build-with-ddn/with-snowflake.mdx
+++ b/docs/how-to-build-with-ddn/with-snowflake.mdx
@@ -1,0 +1,389 @@
+---
+sidebar_position: 6
+sidebar_label: With Snowflake
+description: "Learn the basics of Hasura DDN and how to get started with a Snowflake instance."
+keywords:
+  - hasura ddn
+  - graphql api
+  - getting started
+  - guide
+  - snowflake
+---
+
+import Prereqs from "@site/docs/_prereqs.mdx";
+
+# Get Started with Hasura DDN and Snowflake
+
+## Overview
+
+This tutorial takes about twenty minutes to complete. You'll learn how to:
+
+- Set up a new Hasura DDN project
+- Connect it to a Snowflake instance
+- Generate Hasura metadata
+- Create a build
+- Run your first query
+- Create relationships
+- Mutate data
+
+Additionally, we'll familiarize you with the steps and workflows necessary to iterate on your API.
+
+This tutorial assumes you're starting from scratch, but you can easily follow the steps if you already have data seeded;
+Hasura will never modify your source schema.
+
+<Prereqs />
+
+## Tutorial
+
+### Step 1. Authenticate your CLI
+
+```sh title="Before you can create a new Hasura DDN project, you need to authenticate your CLI:"
+ddn auth login
+```
+
+This will launch a browser window prompting you to log in or sign up for Hasura DDN. After you log in, the CLI will
+acknowledge your login, giving you access to Hasura Cloud resources.
+
+### Step 2. Scaffold out a new local project
+
+```sh title="Next, create a new local project:"
+ddn supergraph init my-project && cd my-project
+```
+
+Once you move into this directory, you'll see your project scaffolded out for you. You can view the structure by either
+running `ls` in your terminal, or by opening the directory in your preferred editor.
+
+### Step 3. Initialize your Snowflake connector
+
+```sh title="In your project directory, run:"
+ddn connector init my_snowflake -i
+```
+
+```plaintext title="The CLI will ask you for a connection string in the JDBC URL format, e.g.:"
+jdbc:snowflake://<account-identifier.<region>.snowflakecomputing.com?user=YOUR_USERNAME&&password=YOUR_PASSWORD&db=YOUR_DATABASE&warehouse=YOUR_WAREHOUSE&schema=YOUR_SCHEMA&role=YOUR_ROLE
+```
+
+:::info More information on JDBC URLs
+
+To learn more about Snowflake's conventions for JDBC URLs, see their
+[docs](https://docs.snowflake.com/developer-guide/jdbc/jdbc-configure#jdbc-driver-connection-string).
+
+:::
+
+### Step 4. Create and seed a new Snowflake database
+
+In a warehouse, create a new database called `DOCS`. Then, on the `PUBLIC` schema for the `DOCS` database, create a new
+table using the standard format via the Snowflake UI:
+
+```sql
+CREATE TABLE users (
+  id INT AUTOINCREMENT START 1 INCREMENT 1 PRIMARY KEY,
+  name STRING NOT NULL,
+  age INT NOT NULL
+);
+```
+
+Next, open a new worksheet on your database's `PUBLIC` schema and insert some seed data:
+
+```sql
+INSERT INTO users (name, age) VALUES ('Alice', 25);
+INSERT INTO users (name, age) VALUES ('Bob', 30);
+INSERT INTO users (name, age) VALUES ('Charlie', 35);
+```
+
+You can verify this worked by using Adminer to query all records from the `users` table:
+
+```sql
+SELECT * FROM users;
+```
+
+### Step 6. Introspect your Snowflake database
+
+```sh title="Next, use the CLI to introspect your Snowflake database:"
+ddn connector introspect my_snowflake
+```
+
+After running this, you should see a representation of your database's schema in the
+`app/connector/my_snowflake/configuration.json` file; you can view this using `cat` or open the file in your editor.
+
+```sh title="Additionally, you can check which resources are available — and their status — at any point using the CLI:"
+ddn connector show-resources my_snowflake
+```
+
+### Step 7. Add your model
+
+```sh title="Now, track the table from your Snowflake database as a model in your DDN metadata:"
+ddn model add my_snowflake DOCS.PUBLIC.USERS
+```
+
+Open the `app/metadata` directory and you'll find a newly-generated file: `DocsPublicUsers.hml`. The DDN CLI will use
+this Hasura Metadata Language file to represent the `users` table from Snowflake in your API as a
+[model](/reference/metadata-reference/models.mdx).
+
+### Step 8. Create a new build
+
+```sh title="To create a local build, run:"
+ddn supergraph build local
+```
+
+The build is stored as a set of JSON files in `engine/build`.
+
+### Step 9. Start your local services
+
+```sh title="Start your local Hasura DDN Engine and Snowflake connector:"
+ddn run docker-start
+```
+
+Your terminal will be taken over by logs for the different services.
+
+### Step 10. Run your first query
+
+```sh title="In a new terminal tab, open your local console:"
+ddn console --local
+```
+
+```graphql title="In the GraphiQL explorer of the console, write this query:"
+query {
+  docsPublicUsers {
+    id
+    name
+    age
+  }
+}
+```
+
+```json title="You'll get the following response:"
+{
+  "data": {
+    "docsPublicUsers": [
+      {
+        "id": 1,
+        "name": "Alice",
+        "age": 25
+      },
+      {
+        "id": 2,
+        "name": "Bob",
+        "age": 30
+      },
+      {
+        "id": 3,
+        "name": "Charlie",
+        "age": 35
+      }
+    ]
+  }
+}
+```
+
+### Step 11. Iterate on your Snowflake schema
+
+```sql title="Add a new table for posts:"
+CREATE TABLE posts (
+  id INT AUTOINCREMENT PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+);
+
+INSERT INTO posts (user_id, title, content) VALUES
+  (1, 'My First Post', 'This is Alice''s first post.'),
+  (1, 'Another Post', 'Alice writes again!'),
+  (2, 'Bob''s Post', 'Bob shares his thoughts.'),
+  (3, 'Hello World', 'Charlie joins the conversation.');
+```
+
+```sql title="Using the worksheet, query the joined data:"
+SELECT
+  posts.id AS post_id,
+  posts.title,
+  posts.content,
+  posts.created_at,
+  users.name AS author
+FROM
+  posts
+JOIN
+  users ON posts.user_id = users.id;
+```
+
+You should see a list of posts returned with the author's information joined from the `users` table
+
+### Step 12. Refresh your metadata and rebuild your project
+
+:::tip
+
+The following steps are necessary each time you make changes to your **source** schema. This includes, adding,
+modifying, or dropping tables.
+
+:::
+
+#### Step 12.1. Re-introspect your data source
+
+```sh title="Run the introspection command again:"
+ddn connector introspect my_snowflake
+```
+
+In `app/connector/my_snowflake/configuration.json`, you'll see schema updated to include operations for the `posts`
+table. In `app/metadata/my_snowflake.hml`, you'll see `DOCS.PUBLIC.POSTS` present in the metadata as well.
+
+#### Step 12.2. Update your metadata
+
+```sh title="Add the posts model:"
+ddn model add my_snowflake "DOCS.PUBLIC.POSTS"
+```
+
+#### Step 12.3. Create a new build
+
+```sh title="Next, create a new build:"
+ddn supergraph build local
+```
+
+#### Step 12.4. Restart your services
+
+```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+ddn run docker-start
+```
+
+### Step 13. Query your new build
+
+```graphql title="Head back to your console and query the posts model:"
+query GetPosts {
+  docsPublicPosts {
+    id
+    title
+    content
+  }
+}
+```
+
+```json title="You'll get a response like this:"
+{
+  "data": {
+    "docsPublicPosts": [
+      {
+        "id": 1,
+        "title": "My First Post",
+        "content": "This is Alice's first post."
+      },
+      {
+        "id": 2,
+        "title": "Another Post",
+        "content": "Alice writes again!"
+      },
+      {
+        "id": 3,
+        "title": "Bob's Post",
+        "content": "Bob shares his thoughts."
+      },
+      {
+        "id": 4,
+        "title": "Hello World",
+        "content": "Charlie joins the conversation."
+      }
+    ]
+  }
+}
+```
+
+### Step 14. Create a relationship
+
+```sh title="Since there's already a foreign key on the posts table in Snowflake, we can easily add the relationship:"
+ddn relationship add my_snowflake "posts"
+```
+
+You'll see a new metadata object added to the `app/metadata/posts.hml` file of kind `Relationship` explaining the
+relationship between `posts` and `users`.
+
+### Step 15. Rebuild your project
+
+```sh title="As your metadata has changed, create a new build:"
+ddn supergraph build local
+```
+
+```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+ddn run docker-start
+```
+
+### Step 16. Query using your relationship
+
+```graphql title="Now, execute a nested query using your relationship:"
+query GetPosts {
+  docsPublicPosts {
+    id
+    title
+    content
+    user {
+      id
+      name
+      age
+    }
+  }
+}
+```
+
+```json title="Which should return a result like this:"
+{
+  "data": {
+    "docsPublicPosts": [
+      {
+        "id": 1,
+        "title": "My First Post",
+        "content": "This is Alice's first post.",
+        "user": {
+          "id": 1,
+          "name": "Alice",
+          "age": 25
+        }
+      },
+      {
+        "id": 2,
+        "title": "Another Post",
+        "content": "Alice writes again!",
+        "user": {
+          "id": 1,
+          "name": "Alice",
+          "age": 25
+        }
+      },
+      {
+        "id": 3,
+        "title": "Bob's Post",
+        "content": "Bob shares his thoughts.",
+        "user": {
+          "id": 2,
+          "name": "Bob",
+          "age": 30
+        }
+      },
+      {
+        "id": 4,
+        "title": "Hello World",
+        "content": "Charlie joins the conversation.",
+        "user": {
+          "id": 3,
+          "name": "Charlie",
+          "age": 35
+        }
+      }
+    ]
+  }
+}
+```
+
+## Next steps
+
+Congratulations on completing your first Hasura DDN project with Snowflake! 🎉
+
+Here's what you just accomplished:
+
+- You started with a fresh project and connected it to a local Snowflake database.
+- You set up metadata to represent your tables and relationships, which acts as the blueprint for your API.
+- Then, you created a build — essentially compiling everything into a ready-to-use API — and successfully ran your first
+  GraphQL queries to fetch data.
+- Along the way, you learned how to iterate on your schema and refresh your metadata to reflect changes.
+
+Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
+
+Take a look at our Snowflake docs to learn more about how to use Hasura DDN with Snowflake. Or, if you're ready, get
+started with adding [permissions](/reference/metadata-reference/permissions.mdx) to control access to your API.

--- a/docs/how-to-build-with-ddn/with-snowflake.mdx
+++ b/docs/how-to-build-with-ddn/with-snowflake.mdx
@@ -286,91 +286,6 @@ query GetPosts {
 }
 ```
 
-### Step 14. Create a relationship
-
-```sh title="Since there's already a foreign key on the posts table in Snowflake, we can easily add the relationship:"
-ddn relationship add my_snowflake "posts"
-```
-
-You'll see a new metadata object added to the `app/metadata/posts.hml` file of kind `Relationship` explaining the
-relationship between `posts` and `users`.
-
-### Step 15. Rebuild your project
-
-```sh title="As your metadata has changed, create a new build:"
-ddn supergraph build local
-```
-
-```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
-ddn run docker-start
-```
-
-### Step 16. Query using your relationship
-
-```graphql title="Now, execute a nested query using your relationship:"
-query GetPosts {
-  docsPublicPosts {
-    id
-    title
-    content
-    user {
-      id
-      name
-      age
-    }
-  }
-}
-```
-
-```json title="Which should return a result like this:"
-{
-  "data": {
-    "docsPublicPosts": [
-      {
-        "id": 1,
-        "title": "My First Post",
-        "content": "This is Alice's first post.",
-        "user": {
-          "id": 1,
-          "name": "Alice",
-          "age": 25
-        }
-      },
-      {
-        "id": 2,
-        "title": "Another Post",
-        "content": "Alice writes again!",
-        "user": {
-          "id": 1,
-          "name": "Alice",
-          "age": 25
-        }
-      },
-      {
-        "id": 3,
-        "title": "Bob's Post",
-        "content": "Bob shares his thoughts.",
-        "user": {
-          "id": 2,
-          "name": "Bob",
-          "age": 30
-        }
-      },
-      {
-        "id": 4,
-        "title": "Hello World",
-        "content": "Charlie joins the conversation.",
-        "user": {
-          "id": 3,
-          "name": "Charlie",
-          "age": 35
-        }
-      }
-    ]
-  }
-}
-```
-
 ## Next steps
 
 Congratulations on completing your first Hasura DDN project with Snowflake! 🎉
@@ -378,7 +293,7 @@ Congratulations on completing your first Hasura DDN project with Snowflake! 🎉
 Here's what you just accomplished:
 
 - You started with a fresh project and connected it to a local Snowflake database.
-- You set up metadata to represent your tables and relationships, which acts as the blueprint for your API.
+- You set up metadata to represent your tables, which acts as the blueprint for your API.
 - Then, you created a build — essentially compiling everything into a ready-to-use API — and successfully ran your first
   GraphQL queries to fetch data.
 - Along the way, you learned how to iterate on your schema and refresh your metadata to reflect changes.

--- a/docs/how-to-build-with-ddn/with-snowflake.mdx
+++ b/docs/how-to-build-with-ddn/with-snowflake.mdx
@@ -57,6 +57,8 @@ running `ls` in your terminal, or by opening the directory in your preferred edi
 ddn connector init my_snowflake -i
 ```
 
+Select `hasura/snowflake` from the list of connectors.
+
 ```plaintext title="The CLI will ask you for a connection string in the JDBC URL format, e.g.:"
 jdbc:snowflake://<account-identifier.<region>.snowflakecomputing.com?user=YOUR_USERNAME&password=YOUR_PASSWORD&db=YOUR_DATABASE&warehouse=YOUR_WAREHOUSE&schema=YOUR_SCHEMA&role=YOUR_ROLE
 ```

--- a/docs/how-to-build-with-ddn/with-snowflake.mdx
+++ b/docs/how-to-build-with-ddn/with-snowflake.mdx
@@ -58,10 +58,13 @@ ddn connector init my_snowflake -i
 ```
 
 ```plaintext title="The CLI will ask you for a connection string in the JDBC URL format, e.g.:"
-jdbc:snowflake://<account-identifier.<region>.snowflakecomputing.com?user=YOUR_USERNAME&&password=YOUR_PASSWORD&db=YOUR_DATABASE&warehouse=YOUR_WAREHOUSE&schema=YOUR_SCHEMA&role=YOUR_ROLE
+jdbc:snowflake://<account-identifier.<region>.snowflakecomputing.com?user=YOUR_USERNAME&password=YOUR_PASSWORD&db=YOUR_DATABASE&warehouse=YOUR_WAREHOUSE&schema=YOUR_SCHEMA&role=YOUR_ROLE
 ```
 
-:::info More information on JDBC URLs
+:::info Generating Snowflake JDBC URLs
+
+From Snowflake's UI, you can click on the account menu in the Snowflake control panel and then select
+`Connect a tool to Snowflake` to get a generated JDBC string from the `Connector/Drivers` tab
 
 To learn more about Snowflake's conventions for JDBC URLs, see their
 [docs](https://docs.snowflake.com/developer-guide/jdbc/jdbc-configure#jdbc-driver-connection-string).
@@ -89,13 +92,13 @@ INSERT INTO users (name, age) VALUES ('Bob', 30);
 INSERT INTO users (name, age) VALUES ('Charlie', 35);
 ```
 
-You can verify this worked by using Adminer to query all records from the `users` table:
+You can verify this worked by using the worksheet to query all records from the `users` table:
 
 ```sql
 SELECT * FROM users;
 ```
 
-### Step 6. Introspect your Snowflake database
+### Step 5. Introspect your Snowflake database
 
 ```sh title="Next, use the CLI to introspect your Snowflake database:"
 ddn connector introspect my_snowflake
@@ -108,7 +111,7 @@ After running this, you should see a representation of your database's schema in
 ddn connector show-resources my_snowflake
 ```
 
-### Step 7. Add your model
+### Step 6. Add your model
 
 ```sh title="Now, track the table from your Snowflake database as a model in your DDN metadata:"
 ddn model add my_snowflake DOCS.PUBLIC.USERS
@@ -118,7 +121,7 @@ Open the `app/metadata` directory and you'll find a newly-generated file: `DocsP
 this Hasura Metadata Language file to represent the `users` table from Snowflake in your API as a
 [model](/reference/metadata-reference/models.mdx).
 
-### Step 8. Create a new build
+### Step 7. Create a new build
 
 ```sh title="To create a local build, run:"
 ddn supergraph build local
@@ -126,7 +129,7 @@ ddn supergraph build local
 
 The build is stored as a set of JSON files in `engine/build`.
 
-### Step 9. Start your local services
+### Step 8. Start your local services
 
 ```sh title="Start your local Hasura DDN Engine and Snowflake connector:"
 ddn run docker-start
@@ -134,7 +137,7 @@ ddn run docker-start
 
 Your terminal will be taken over by logs for the different services.
 
-### Step 10. Run your first query
+### Step 9. Run your first query
 
 ```sh title="In a new terminal tab, open your local console:"
 ddn console --local
@@ -174,7 +177,7 @@ query {
 }
 ```
 
-### Step 11. Iterate on your Snowflake schema
+### Step 10. Iterate on your Snowflake schema
 
 ```sql title="Add a new table for posts:"
 CREATE TABLE posts (
@@ -207,7 +210,7 @@ JOIN
 
 You should see a list of posts returned with the author's information joined from the `users` table
 
-### Step 12. Refresh your metadata and rebuild your project
+### Step 11. Refresh your metadata and rebuild your project
 
 :::tip
 
@@ -216,7 +219,7 @@ modifying, or dropping tables.
 
 :::
 
-#### Step 12.1. Re-introspect your data source
+#### Step 11.1. Re-introspect your data source
 
 ```sh title="Run the introspection command again:"
 ddn connector introspect my_snowflake
@@ -225,25 +228,25 @@ ddn connector introspect my_snowflake
 In `app/connector/my_snowflake/configuration.json`, you'll see schema updated to include operations for the `posts`
 table. In `app/metadata/my_snowflake.hml`, you'll see `DOCS.PUBLIC.POSTS` present in the metadata as well.
 
-#### Step 12.2. Update your metadata
+#### Step 11.2. Update your metadata
 
 ```sh title="Add the posts model:"
 ddn model add my_snowflake "DOCS.PUBLIC.POSTS"
 ```
 
-#### Step 12.3. Create a new build
+#### Step 11.3. Create a new build
 
 ```sh title="Next, create a new build:"
 ddn supergraph build local
 ```
 
-#### Step 12.4. Restart your services
+#### Step 11.4. Restart your services
 
-```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
 ddn run docker-start
 ```
 
-### Step 13. Query your new build
+### Step 12. Query your new build
 
 ```graphql title="Head back to your console and query the posts model:"
 query GetPosts {

--- a/docs/how-to-build-with-ddn/with-snowflake.mdx
+++ b/docs/how-to-build-with-ddn/with-snowflake.mdx
@@ -23,8 +23,6 @@ This tutorial takes about twenty minutes to complete. You'll learn how to:
 - Generate Hasura metadata
 - Create a build
 - Run your first query
-- Create relationships
-- Mutate data
 
 Additionally, we'll familiarize you with the steps and workflows necessary to iterate on your API.
 

--- a/docs/how-to-build-with-ddn/with-snowflake.mdx
+++ b/docs/how-to-build-with-ddn/with-snowflake.mdx
@@ -64,7 +64,7 @@ jdbc:snowflake://<account-identifier.<region>.snowflakecomputing.com?user=YOUR_U
 :::info Generating Snowflake JDBC URLs
 
 From Snowflake's UI, you can click on the account menu in the Snowflake control panel and then select
-`Connect a tool to Snowflake` to get a generated JDBC string from the `Connector/Drivers` tab
+`Connect a tool to Snowflake` to get a generated JDBC string from the `Connector/Drivers` tab.
 
 To learn more about Snowflake's conventions for JDBC URLs, see their
 [docs](https://docs.snowflake.com/developer-guide/jdbc/jdbc-configure#jdbc-driver-connection-string).

--- a/docs/reference/connectors/index.mdx
+++ b/docs/reference/connectors/index.mdx
@@ -30,5 +30,6 @@ If you're getting started with a connector and want to connect it to your data s
 - [MySQL](/reference/connectors/mysql/index.mdx)
 - [Oracle](/reference/connectors/oracle/index.mdx)
 - [PostgreSQL](/reference/connectors/postgresql/index.mdx)
+- [Snowflake](/reference/connectors/snowflake/index.mdx)
 - [SQL Server](/reference/connectors/sqlserver/index.mdx)
 - [Trino](/reference/connectors/trino/index.mdx)

--- a/docs/reference/connectors/snowflake/_category_.json
+++ b/docs/reference/connectors/snowflake/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Snowflake",
+  "position": 7
+}
+

--- a/docs/reference/connectors/snowflake/configuration.mdx
+++ b/docs/reference/connectors/snowflake/configuration.mdx
@@ -53,7 +53,7 @@ This is a JSON object containing key-value pairs of additional properties to be 
 ### Property: Schemas
 
 This is an optional array of schema names to include in the introspection process. If not provided, all schemas will be
-included.
+included. **Any schema passed in the JDBC URL will take precedence.**
 
 Example:
 

--- a/docs/reference/connectors/snowflake/configuration.mdx
+++ b/docs/reference/connectors/snowflake/configuration.mdx
@@ -1,0 +1,209 @@
+---
+sidebar_position: 2
+sidebar_label: Configuration
+description:
+  "Reference documentation for the setup process for the Hasura Snowflake connector, including connection URI details,
+  and native queries."
+keywords:
+  - snowflake
+  - configuration
+---
+
+# Configuration Reference
+
+## Introduction
+
+The configuration is a metadata object that lists all the database entities — such as tables — that the data connector
+has to know about in order to serve queries. It never changes during the lifetime of the data connector service
+instance. When your database schema changes you will have to update the configuration accordingly, see
+[updating with introspection](#updating-with-introspection).
+
+## Structure
+
+The configuration object is a JSON object with the following fields:
+
+```json
+{
+  "jdbcUrl": "",
+  "jdbcProperties": {},
+  "schemas": [],
+  "tables": [],
+  "functions": [],
+  "nativeQueries": {}
+}
+```
+
+### Property: JDBC URL
+
+The JDBC connection URL to connect to the Snowflake instance. This is a required field.
+
+The value can either be a literal string, or a reference to an environment variable:
+
+```json
+{
+  "jdbcUrl": "jdbc:snowflake://<account-identifier.<region>.snowflakecomputing.com?user=YOUR_USERNAME&&password=YOUR_PASSWORD&db=YOUR_DATABASE&warehouse=YOUR_WAREHOUSE&schema=YOUR_SCHEMA&role=YOUR_ROLE",
+  "jdbcUrl": { "variable": "SNOWFLAKE_JDBC_URL" }
+}
+```
+
+### Property: JDBC Properties
+
+This is a JSON object containing key-value pairs of additional properties to be passed to the JDBC driver.
+
+### Property: Schemas
+
+This is an optional array of schema names to include in the introspection process. If not provided, all schemas will be
+included.
+
+Example:
+
+```json
+{
+  "schemas": ["PUBLIC", "OTHER_SCHEMA"]
+}
+```
+
+### Property: Tables
+
+This is an array of table definitions, generated automatically during introspection.
+
+Example:
+
+```json
+{
+  "tableName": "DOCS.PUBLIC.USERS",
+  "tableType": "TABLE",
+  "description": null,
+  "columns": [
+    {
+      "name": "AGE",
+      "description": null,
+      "type": "NUMBER",
+      "numeric_precision": 38,
+      "numeric_scale": 0,
+      "nullable": false,
+      "auto_increment": false,
+      "is_primarykey": null
+    },
+    {
+      "name": "NAME",
+      "description": null,
+      "type": "TEXT",
+      "numeric_precision": null,
+      "numeric_scale": null,
+      "nullable": false,
+      "auto_increment": false,
+      "is_primarykey": null
+    },
+    {
+      "name": "ID",
+      "description": null,
+      "type": "NUMBER",
+      "numeric_precision": 38,
+      "numeric_scale": 0,
+      "nullable": false,
+      "auto_increment": true,
+      "is_primarykey": null
+    }
+  ],
+  "pks": [],
+  "fks": null
+}
+```
+
+### Property: Functions
+
+This is an array of function definitions.
+
+Example:
+
+```json
+{
+  "function_catalog": "PUBLIC",
+  "function_schema": "PUBLIC",
+  "function_name": "add",
+  "argument_signature": "(N NUMBER, M NUMBER)",
+  "data_type": "TABLE (N NUMBER, M NUMBER)",
+  "comment": "Adds two numbers"
+}
+```
+
+### Property: Native Queries
+
+This is a JSON object containing key-value pairs of Native Queries to be used in the data connector.
+
+Two types of Native Queries are supported: **Inline** and **Parameterized**.
+
+Example:
+
+```json
+{
+  "native_query_inline": {
+    "sql": {
+      "parts": [
+        {
+          "type": "text",
+          "value": "SELECT 1 AS result FROM DUAL"
+        }
+      ]
+    },
+    "columns": {
+      "result": {
+        "type": "named",
+        "name": "INT"
+      }
+    },
+    "arguments": {},
+    "description": ""
+  },
+  "ArtistById_parameterized": {
+    "sql": {
+      "parts": [
+        {
+          "type": "text",
+          "value": "SELECT * FROM CHINOOK.ARTIST WHERE ARTISTID = "
+        },
+        {
+          "type": "parameter",
+          "value": "ARTISTID"
+        }
+      ]
+    },
+    "columns": {
+      "ARTISTID": {
+        "type": "named",
+        "name": "INT"
+      },
+      "NAME": {
+        "type": "nullable",
+        "underlying_type": {
+          "type": "named",
+          "name": "STRING"
+        }
+      }
+    },
+    "arguments": {
+      "ARTISTID": {
+        "description": null,
+        "type": {
+          "type": "named",
+          "name": "INT"
+        }
+      }
+    },
+    "description": null,
+    "isProcedure": false
+  }
+}
+```
+
+## Updating with introspection
+
+Whenever the schema of your database changes you will need to update your data connector configuration accordingly to
+reflect those changes.
+
+Running `update` in a configuration directory will do the following:
+
+- Connect to the database with the specified `jdbcUrl`, and then overwrite all data in the `tables` field
+
+- Fill in default values for any fields absent from the configuration

--- a/docs/reference/connectors/snowflake/index.mdx
+++ b/docs/reference/connectors/snowflake/index.mdx
@@ -1,0 +1,25 @@
+---
+title: Snowflake
+sidebar_position: 1
+description:
+  "Learn how to configure the Snowflake connector and utilize native operations to extend your API's capability."
+sidebar_label: Snowflake
+keywords:
+  - snowflake
+  - configuration
+  - connector
+seoFrontMatterUpdated: false
+---
+
+# Snowflake
+
+## Introduction
+
+Hasura DDN includes a Native Data Connector for Snowflake, providing integration with Snowflake instances. This
+connector allows you to leverage Snowflake’s powerful capabilities while taking advantage of Hasura’s metadata-driven
+approach. Here, we’ll explore the key features of the Snowflake connector and walk through the configuration process
+within a Hasura DDN project.
+
+## Snowflake docs
+
+- [Connector configuration](/reference/connectors/snowflake/configuration.mdx)

--- a/docs/reference/connectors/snowflake/index.mdx
+++ b/docs/reference/connectors/snowflake/index.mdx
@@ -20,6 +20,19 @@ connector allows you to leverage Snowflake’s powerful capabilities while takin
 approach. Here, we’ll explore the key features of the Snowflake connector and walk through the configuration process
 within a Hasura DDN project.
 
+:::info Important Considerations for Using Hasura DDN with Snowflake
+
+Snowflake is an analytical data source optimized for large-scale data analysis and complex queries. When integrating
+Snowflake with Hasura DDN, it’s essential to recognize that the performance of your API will be directly influenced by
+the query performance of Snowflake. As a result, response times may vary depending on the complexity and volume of the
+queries executed. **Use this connector and Snowflake for scenarios where analytical query performance is acceptable.**
+
+Snowflake is not designed for transactional use cases that require low-latency operations, high-frequency updates, or
+real-time responses. **Avoid using Hasura DDN with Snowflake for applications that require rapid transactional
+processing.**
+
+:::
+
 ## Snowflake docs
 
 - [Connector configuration](/reference/connectors/snowflake/configuration.mdx)


### PR DESCRIPTION
## Description 📝

Adds MVP docs for Snowflake. The getting-started guide has been tested as has the JDBC URL in the environment variables.

NB: The existing JVM-style Snowflake connector **does not** support relationships. The new one does; the final commit before opening this PR removes relationship-based information from the how-to-build guide.

## Quick Links 🚀

- [How-to guide](https://robdominguez-doc-2506-write.v3-docs-eny.pages.dev/how-to-build-with-ddn/with-snowflake/)
- [Connect to a source](https://robdominguez-doc-2506-write.v3-docs-eny.pages.dev/data-sources/connect-to-a-source/)
- [Configuration reference](https://robdominguez-doc-2506-write.v3-docs-eny.pages.dev/reference/connectors/snowflake/)