### PR TITLE
Docs: Update permissions link on how-to-build pages

### DIFF
--- a/docs/how-to-build-with-ddn/with-clickhouse.mdx
+++ b/docs/how-to-build-with-ddn/with-clickhouse.mdx
@@ -442,4 +442,4 @@ Here's what you just accomplished:
 Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
 
 Take a look at our ClickHouse docs to learn more about how to use Hasura DDN with ClickHouse. Or, if you're ready, get
-started with adding [permissions](/reference/metadata-reference/permissions.mdx) to control access to your API.
+started with adding [permissions](/auth/permissions/index.mdx) to control access to your API.

--- a/docs/how-to-build-with-ddn/with-elasticsearch.mdx
+++ b/docs/how-to-build-with-ddn/with-elasticsearch.mdx
@@ -304,8 +304,8 @@ curl -X POST "http://localhost:9200/_bulk" -u elastic:elastic -H 'Content-Type: 
 
 :::tip
 
-The following steps are necessary each time you make changes to your **source** schema. This includes adding,
-modifying, or dropping tables.
+The following steps are necessary each time you make changes to your **source** schema. This includes adding, modifying,
+or dropping tables.
 
 :::
 
@@ -439,4 +439,4 @@ Here's what you just accomplished:
 Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
 
 Take a look at our Elasticsearch docs to learn more about how to use Hasura DDN with Elasticsearch. Or, if you're ready,
-get started with adding [permissions](/reference/metadata-reference/permissions.mdx) to control access to your API.
+get started with adding [permissions](/auth/permissions/index.mdx) to control access to your API.

--- a/docs/how-to-build-with-ddn/with-mongodb.mdx
+++ b/docs/how-to-build-with-ddn/with-mongodb.mdx
@@ -405,4 +405,4 @@ Here's what you just accomplished:
 Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
 
 Take a look at our MongoDB docs to learn more about how to use Hasura DDN with MongoDB. Or, if you're ready, get started
-with adding [permissions](/reference/metadata-reference/permissions.mdx) to control access to your API.
+with adding [permissions](/auth/permissions/index.mdx) to control access to your API.

--- a/docs/how-to-build-with-ddn/with-mysql.mdx
+++ b/docs/how-to-build-with-ddn/with-mysql.mdx
@@ -430,4 +430,4 @@ Here's what you just accomplished:
 Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
 
 Take a look at our MySQL docs to learn more about how to use Hasura DDN with MySQL. Or, if you're ready, get started
-with adding [permissions](/reference/metadata-reference/permissions.mdx) to control access to your API.
+with adding [permissions](/auth/permissions/index.mdx) to control access to your API.

--- a/docs/how-to-build-with-ddn/with-postgresql.mdx
+++ b/docs/how-to-build-with-ddn/with-postgresql.mdx
@@ -60,7 +60,8 @@ running `ls` in your terminal, or by opening the directory in your preferred edi
 ddn connector init my_pg -i
 ```
 
-From the dropdown, select `/hasura/postgres` (you can type to filter the list), then hit enter to accept the default of all the options.
+From the dropdown, select `/hasura/postgres` (you can type to filter the list), then hit enter to accept the default of
+all the options.
 
 The CLI will output something similar to this:
 
@@ -444,4 +445,4 @@ Here's what you just accomplished:
 Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
 
 Take a look at our PostgreSQL docs to learn more about how to use Hasura DDN with PostgreSQL. Or, if you're ready, get
-started with adding [permissions](/reference/metadata-reference/permissions.mdx) to control access to your API.
+started with adding [permissions](/auth/permissions/index.mdx) to control access to your API.


### PR DESCRIPTION
## Description 📝

Updates link to now point to Auth section instead of metadata reference.