### PR TITLE
[DX-881] Add `--apply` flag documentation to streamline supergraph build and apply process

### DIFF
--- a/docs/deployment/hasura-ddn/ci-cd.mdx
+++ b/docs/deployment/hasura-ddn/ci-cd.mdx
@@ -65,7 +65,7 @@ If your repository is private, you may need a
 [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
 or similar for your git provider to clone it.
 
-```
+```sh
 git clone https://username:<pat>@github.com/<your-account-or-org>/<repo>.git
 ```
 
@@ -86,8 +86,18 @@ You can now run any DDN CLI commands required in the CI/CD workflow. You will li
 them to projects.
 
 ```sh
-ddn supergraph build create --apply
+ddn supergraph build create
 ```
+
+```sh
+ddn supergraph build apply <build-id>
+```
+
+:::tip Optimize your CI/CD pipeline
+For a more efficient CI/CD workflow, you can create and apply the supergraph build in a single command using
+`ddn supergraph build create --apply`
+This reduces the number of CLI commands needed and simplifies your automation scripts.
+:::
 
 ## GitHub Actions Setup
 

--- a/docs/deployment/hasura-ddn/ci-cd.mdx
+++ b/docs/deployment/hasura-ddn/ci-cd.mdx
@@ -86,11 +86,7 @@ You can now run any DDN CLI commands required in the CI/CD workflow. You will li
 them to projects.
 
 ```sh
-ddn supergraph build create
-```
-
-```sh
-ddn supergraph build apply <build-id>
+ddn supergraph build create --apply
 ```
 
 ## GitHub Actions Setup

--- a/docs/deployment/hasura-ddn/deploy-to-ddn.mdx
+++ b/docs/deployment/hasura-ddn/deploy-to-ddn.mdx
@@ -74,6 +74,11 @@ ddn supergraph build apply 85b0961544
 This build is now the "official" applied API for the project and is accessible via the API URL in the output of the
 command, via the console, or any client accessing via the API URL.
 
+:::tip Simplify your deployment
+For a more efficient deployment process, you can create and apply the supergraph build in a single command using
+`ddn supergraph build create --apply`
+:::
+
 ## Summary
 
 There are many more options and configurations available for deploying your project to Hasura DDN and we have detailed

--- a/docs/deployment/hasura-ddn/incremental-builds.mdx
+++ b/docs/deployment/hasura-ddn/incremental-builds.mdx
@@ -70,6 +70,11 @@ ddn supergraph build apply <build-version>
 
 This will apply the build to the supergraph to become the active API.
 
+:::tip Optimize incremental deployments
+For a more efficient incremental deployment process, you can create and apply the supergraph build in a single command using
+`ddn supergraph build create --no-build-connectors --apply`
+:::
+
 :::info Resource Limits
 
 Connectors in Hasura DDN request specific memory and CPU allocations for their deployment. Resource limits can only be

--- a/docs/deployment/hasura-ddn/tutorial/01-create-a-project.mdx
+++ b/docs/deployment/hasura-ddn/tutorial/01-create-a-project.mdx
@@ -130,3 +130,8 @@ After the CLI returns the list of builds, you can apply one using its build vers
 ```bash title="Pass a build version to apply it:"
 ddn supergraph build apply <supergraph-build-version>
 ```
+
+:::tip Accelerate your first deployment
+For a faster initial deployment, you can create and apply the supergraph build in a single command using
+`ddn supergraph build create --apply`
+:::

--- a/docs/deployment/hasura-ddn/tutorial/04-deploy-your-supergraph.mdx
+++ b/docs/deployment/hasura-ddn/tutorial/04-deploy-your-supergraph.mdx
@@ -59,6 +59,11 @@ An _applied build_ is the default one that is served by your Hasura DDN project 
 ddn supergraph build apply <supergraph-build-version>
 ```
 
+:::tip Streamline your deployment
+For a more efficient deployment workflow, you can create and apply the supergraph build in a single command using
+`ddn supergraph build create --apply`
+:::
+
 :::info Your API is still private
 
 By default, all Hasura DDN projects are in `Private` API Access Mode and accessible only to project collaborators. In

--- a/docs/project-configuration/project-management/service-accounts.mdx
+++ b/docs/project-configuration/project-management/service-accounts.mdx
@@ -113,6 +113,11 @@ ddn supergraph build create [flags]
 ddn supergraph build apply <supergraph-build-version> [flags]
 ```
 
+:::tip Streamline CI/CD workflows
+For more efficient automation with service accounts, you can create and apply the supergraph build in a single command using
+`ddn supergraph build create [flags] --apply`
+:::
+
 ## How to regenerate service account token
 
 Navigate to the `Service Accounts` section and click the `Regenerate` button next to the service account for which you

--- a/docs/project-configuration/subgraphs/working-with-multiple-repositories.mdx
+++ b/docs/project-configuration/subgraphs/working-with-multiple-repositories.mdx
@@ -228,6 +228,11 @@ This finalizes the integration, making the changes available to all collaborator
 ddn subgraph build apply <subgraph-build-version>
 ```
 
+:::tip Simplify multi-team workflows
+For more efficient collaboration across repositories, you can create and apply the supergraph build in a single command using
+`ddn supergraph build create --subgraph-version <subgraph-name:build-version> --base-supergraph-version <parent-build-id> --apply`
+:::
+
 ## Build Summary
 
 ### Supergraph and all subgraphs

--- a/docs/project-configuration/tutorials/work-with-multiple-repositories.mdx
+++ b/docs/project-configuration/tutorials/work-with-multiple-repositories.mdx
@@ -270,6 +270,11 @@ before applying the build to the supergraph. In order to apply the build, you mu
 ddn supergraph build apply <supergraph-build-version>
 ```
 
+:::tip Streamline team collaboration
+For more efficient development across multiple repositories, you can create and apply the supergraph build in a single command using
+`ddn supergraph build create  --subgraph-version customers:<build-version> --base-supergraph-version <supergraph-build-id> --apply`
+:::
+
 :::warning Make sure to stop all running services
 
 As a multi-repository setup is intended to be utilized by multiple persons across teams, you're not likely to have
@@ -443,6 +448,11 @@ before applying the build to the supergraph. In order to apply the build, you mu
 ```sh
 ddn supergraph build apply <supergraph-build-version>
 ```
+
+:::tip Streamline team collaboration
+For more efficient development across multiple repositories, you can create and apply the supergraph build in a single command using
+`ddn supergraph build create --subgraph-version billing:<build-version> --base-supergraph-version <supergraph-build-id> --apply`
+:::
 
 :::warning Make sure to stop all running services
 


### PR DESCRIPTION
## Description 📝
 This PR adds documentation for the --apply flag across all relevant pages. The flag allows users to create and apply supergraph builds in a single command, eliminating the need for separate build and apply steps. Each page's tip has been customized to fit its specific context (deployment, CI/CD, multi-repository workflows, etc.) while maintaining consistent information about this efficiency improvement.
 
## Quick Links 🚀
- [CLI PR](https://github.com/hasura/v3-cli-go/pull/962)
- [Linear](https://linear.app/hasura/issue/DX-668)

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->