### PR TITLE
Docs: Write MVP for DuckDB docs

### DIFF
--- a/docs/data-sources/connect-to-a-source.mdx
+++ b/docs/data-sources/connect-to-a-source.mdx
@@ -58,6 +58,13 @@ it requires:
 | `PASSWORD`          | `default`           | The database password.                                    |
 
 </TabItem>
+<TabItem value="DuckDB" label="DuckDB">
+
+| ENV          | Example             | Description                                                                              |
+| ------------ | ------------------- | ---------------------------------------------------------------------------------------- |
+| `DUCKDB_URL` | `/path/to/*.duckdb` | The path to the DuckDB database file which will be mounted to the connector's container. |
+
+</TabItem>
 <TabItem value="Elasticsearch" label="Elasticsearch">
 
 | ENV                           | Example                                                        | Description                                                                                                                                                                |

--- a/docs/how-to-build-with-ddn/with-duckdb.mdx
+++ b/docs/how-to-build-with-ddn/with-duckdb.mdx
@@ -1,0 +1,424 @@
+---
+sidebar_position: 7
+sidebar_label: With DuckDB
+description: "Learn the basics of Hasura DDN and how to get started with a DuckDB database."
+keywords:
+  - hasura ddn
+  - graphql api
+  - getting started
+  - guide
+  - duckdb
+---
+
+import Prereqs from "@site/docs/_prereqs.mdx";
+
+# Get Started with Hasura DDN and DuckDB
+
+## Overview
+
+This tutorial takes about twenty minutes to complete. You'll learn how to:
+
+- Set up a new Hasura DDN project
+- Connect it to a local DuckDB database
+- Generate Hasura metadata
+- Create a build
+- Run your first query
+- Create relationships
+
+Additionally, we'll familiarize you with the steps and workflows necessary to iterate on your API.
+
+This tutorial assumes you're starting from scratch; you'll connect a local DuckDB instance to Hasura, but you can easily
+follow the steps if you already have data seeded. Hasura will never modify your source schema.
+
+<Prereqs />
+
+## Tutorial
+
+### Step 1. Authenticate your CLI
+
+```sh title="Before you can create a new Hasura DDN project, you need to authenticate your CLI:"
+ddn auth login
+```
+
+This will launch a browser window prompting you to log in or sign up for Hasura DDN. After you log in, the CLI will
+acknowledge your login, giving you access to Hasura Cloud resources.
+
+### Step 2. Scaffold out a new local project
+
+```sh title="Next, create a new local project:"
+ddn supergraph init my-project && cd my-project
+```
+
+Once you move into this directory, you'll see your project scaffolded out for you. You can view the structure by either
+running `ls` in your terminal, or by opening the directory in your preferred editor.
+
+### Step 3. Initialize your DuckDB connector
+
+```sh title="In your project directory, run:"
+ddn connector init my_duckdb -i
+```
+
+From the dropdown, select `/hasura/duckdb` (you can type to filter the list). Then, enter the following file path:
+
+```plaintext
+/etc/connector/data.duckdb
+```
+
+:::info Why this path?
+
+When your DuckDB connector starts as a container, its directory in your project gets mounted. This will make the
+`data.duckdb` file accessible to the container and the connector. We'll create this file in the next step.
+
+:::
+
+### Step 4. Prepare an initial DuckDB file
+
+:::info Install the DuckDB CLI
+
+You'll need the DuckDB CLI installed on your machine to prepare the database file. You can install it
+[here](https://duckdb.org/docs/installation/?version=stable&environment=cli&platform=macos&download_method=direct).
+
+:::
+
+```sh itle="Next, from your project's root directory, using the DuckDB CLI run the following:"
+echo "
+-- Create a sequence since DuckDB doesn't support auto-incrementing
+CREATE SEQUENCE users_id_seq;
+-- Create the table using the sequence
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY DEFAULT nextval('users_id_seq'),
+  name VARCHAR(255) NOT NULL,
+  age INTEGER NOT NULL
+);
+-- Insert some data
+INSERT INTO users (name, age) VALUES ('Alice', 25);
+INSERT INTO users (name, age) VALUES ('Bob', 30);
+INSERT INTO users (name, age) VALUES ('Charlie', 35);
+" | duckdb app/connector/my_duckdb/data.duckdb
+```
+
+You can verify this worked by running the following command from the project's root to query all records from the
+`users` table:
+
+```sh
+duckdb app/connector/my_duckdb/data.duckdb "SELECT * FROM users;"
+```
+
+### Step 5. Introspect your DuckDB database
+
+```sh title="Next, use the CLI to introspect your DuckDB database:"
+ddn connector introspect my_duckdb
+```
+
+After running this, you should see a representation of your database's schema in the
+`app/connector/my_duckdb/configuration.json` file; you can view this using `cat` or open the file in your editor.
+
+```sh title="Additionally, you can check which resources are available — and their status — at any point using the CLI:"
+ddn connector show-resources my_duckdb
+```
+
+### Step 6. Add your model
+
+```sh title="Now, track the table from your DuckDB database as a model in your DDN metadata:"
+ddn models add my_duckdb "users"
+```
+
+Open the `app/metadata` directory and you'll find a newly-generated file: `Users.hml`. The DDN CLI will use this Hasura
+Metadata Language file to represent the `users` table from DuckDB in your API as a
+[model](/reference/metadata-reference/models.mdx).
+
+### Step 7. Create a new build
+
+```sh title="To create a local build, run:"
+ddn supergraph build local
+```
+
+The build is stored as a set of JSON files in `engine/build`.
+
+### Step 8. Start your local services
+
+```sh title="Start your local Hasura DDN Engine and DuckDB connector:"
+ddn run docker-start
+```
+
+Your terminal will be taken over by logs for the different services.
+
+### Step 9. Run your first query
+
+```sh title="In a new terminal tab, open your local console:"
+ddn console --local
+```
+
+```graphql title="In the GraphiQL explorer of the console, write this query:"
+query {
+  users {
+    id
+    name
+    age
+  }
+}
+```
+
+```json title="You'll get the following response:"
+{
+  "data": {
+    "users": [
+      {
+        "id": 1,
+        "name": "Alice",
+        "age": 25
+      },
+      {
+        "id": 2,
+        "name": "Bob",
+        "age": 30
+      },
+      {
+        "id": 3,
+        "name": "Charlie",
+        "age": 35
+      }
+    ]
+  }
+}
+```
+
+### Step 10. Iterate on your DuckDB schema
+
+```sh title="From the root of the project, use the DuckDB CLI to add a new table and insert some data to your DuckDB database:"
+echo "
+-- Create a sequence for posts
+CREATE SEQUENCE posts_id_seq;
+-- Create the posts table
+CREATE TABLE posts (
+  id INTEGER PRIMARY KEY DEFAULT nextval('posts_id_seq'),
+  user_id INTEGER NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+-- Insert some seed data
+INSERT INTO posts (user_id, title, content) VALUES
+  (1, 'My First Post', 'This is Alice''s first post.'),
+  (1, 'Another Post', 'Alice writes again!'),
+  (2, 'Bob''s Post', 'Bob shares his thoughts.'),
+  (3, 'Hello World', 'Charlie joins the conversation.');
+" | duckdb app/connector/my_duckdb/data.duckdb
+```
+
+```sh title="Verify this by running the following command:"
+echo "
+-- Fetch all posts with user information
+SELECT
+  posts.id AS post_id,
+  posts.title,
+  posts.content,
+  posts.created_at,
+  users.name AS author
+FROM
+  posts
+JOIN
+  users ON posts.user_id = users.id;
+" | duckdb app/connector/my_duckdb/data.duckdb
+```
+
+You should see a list of posts returned with the author's information joined from the `users` table
+
+### Step 11. Refresh your metadata and rebuild your project
+
+:::tip
+
+The following steps are necessary each time you make changes to your **source** schema. This includes, adding,
+modifying, or dropping tables.
+
+:::
+
+#### Step 11.1. Re-introspect your data source
+
+```plaintext title="First, bring down your running services:"
+CTRL + C
+```
+
+```sh title="Run the introspection command again:"
+ddn connector introspect my_duckdb
+```
+
+In `app/connector/my_duckdb/configuration.json`, you'll see schema updated to include operations for the `posts` table.
+In `app/metadata/my_duckdb.hml`, you'll see `posts` present in the metadata as well.
+
+#### Step 11.2. Update your metadata
+
+```sh title="Add the posts model:"
+ddn model add my_duckdb "posts"
+```
+
+#### Step 11.3. Create a new build
+
+```sh title="Next, create a new build:"
+ddn supergraph build local
+```
+
+#### Step 11.4. Restart your services
+
+```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+ddn run docker-start
+```
+
+### Step 12. Query your new build
+
+```graphql title="Head back to your console and query the posts model:"
+query GetPosts {
+  posts {
+    id
+    title
+    content
+  }
+}
+```
+
+```json title="You'll get a response like this:"
+{
+  "data": {
+    "posts": [
+      {
+        "id": 1,
+        "title": "My First Post",
+        "content": "This is Alice's first post."
+      },
+      {
+        "id": 2,
+        "title": "Another Post",
+        "content": "Alice writes again!"
+      },
+      {
+        "id": 3,
+        "title": "Bob's Post",
+        "content": "Bob shares his thoughts."
+      },
+      {
+        "id": 4,
+        "title": "Hello World",
+        "content": "Charlie joins the conversation."
+      }
+    ]
+  }
+}
+```
+
+### Step 13. Create a relationship
+
+```yaml title="Find the Posts.hml file in your connector's metadata directory and add the following relationship object to the bottom:"
+---
+kind: Relationship
+version: v1
+definition:
+  name: user
+  sourceType: Posts
+  target:
+    model:
+      name: Users
+      relationshipType: Object
+  mapping:
+    - source:
+        fieldPath:
+          - fieldName: userId
+      target:
+        modelField:
+          - fieldName: id
+```
+
+This will create a relationship that maps the `userId` for any post to the `id` of a user, allowing for nested queries.
+
+### Step 14. Rebuild your project
+
+```sh title="As your metadata has changed, create a new build:"
+ddn supergraph build local
+```
+
+```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+ddn run docker-start
+```
+
+### Step 15. Query using your relationship
+
+```graphql title="Now, execute a nested query using your relationship:"
+query GetPosts {
+  posts {
+    id
+    title
+    content
+    user {
+      id
+      name
+      age
+    }
+  }
+}
+```
+
+```json title="Which should return a result like this:"
+{
+  "data": {
+    "posts": [
+      {
+        "id": 1,
+        "title": "My First Post",
+        "content": "This is Alice's first post.",
+        "user": {
+          "id": 1,
+          "name": "Alice",
+          "age": 25
+        }
+      },
+      {
+        "id": 2,
+        "title": "Another Post",
+        "content": "Alice writes again!",
+        "user": {
+          "id": 1,
+          "name": "Alice",
+          "age": 25
+        }
+      },
+      {
+        "id": 3,
+        "title": "Bob's Post",
+        "content": "Bob shares his thoughts.",
+        "user": {
+          "id": 2,
+          "name": "Bob",
+          "age": 30
+        }
+      },
+      {
+        "id": 4,
+        "title": "Hello World",
+        "content": "Charlie joins the conversation.",
+        "user": {
+          "id": 3,
+          "name": "Charlie",
+          "age": 35
+        }
+      }
+    ]
+  }
+}
+```
+
+## Next steps
+
+Congratulations on completing your first Hasura DDN project with DuckDB! 🎉
+
+Here's what you just accomplished:
+
+- You started with a fresh project and connected it to a local DuckDB database.
+- You set up metadata to represent your tables and relationships, which acts as the blueprint for your API.
+- Then, you created a build — essentially compiling everything into a ready-to-use API — and successfully ran your first
+  GraphQL queries to fetch data.
+- Along the way, you learned how to iterate on your schema and refresh your metadata to reflect changes.
+
+Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
+
+Take a look at our DuckDB docs to learn more about how to use Hasura DDN with DuckDB. Or, if you're ready, get started
+with adding [permissions](/auth/permissions/index.mdx) to control access to your API.

--- a/docs/how-to-build-with-ddn/with-duckdb.mdx
+++ b/docs/how-to-build-with-ddn/with-duckdb.mdx
@@ -196,7 +196,7 @@ CREATE TABLE posts (
   title VARCHAR(255) NOT NULL,
   content TEXT NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  FOREIGN KEY (user_id) REFERENCES users(id)
 );
 -- Insert some seed data
 INSERT INTO posts (user_id, title, content) VALUES

--- a/docs/how-to-build-with-ddn/with-duckdb.mdx
+++ b/docs/how-to-build-with-ddn/with-duckdb.mdx
@@ -111,7 +111,7 @@ ddn connector introspect my_duckdb
 ```
 
 After running this, you should see a representation of your database's schema in the
-`app/connector/my_duckdb/configuration.json` file; you can view this using `cat` or open the file in your editor.
+`app/connector/my_duckdb/config.json` file; you can view this using `cat` or open the file in your editor.
 
 ```sh title="Additionally, you can check which resources are available — and their status — at any point using the CLI:"
 ddn connector show-resources my_duckdb
@@ -244,8 +244,8 @@ CTRL + C
 ddn connector introspect my_duckdb
 ```
 
-In `app/connector/my_duckdb/configuration.json`, you'll see schema updated to include operations for the `posts` table.
-In `app/metadata/my_duckdb.hml`, you'll see `posts` present in the metadata as well.
+In `app/connector/my_duckdb/config.json`, you'll see schema updated to include operations for the `posts` table. In
+`app/metadata/my_duckdb.hml`, you'll see `posts` present in the metadata as well.
 
 #### Step 11.2. Update your metadata
 

--- a/docs/reference/connectors/duckdb/_category_.json
+++ b/docs/reference/connectors/duckdb/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "DuckDB",
+  "position": 2
+}
+

--- a/docs/reference/connectors/duckdb/configuration.mdx
+++ b/docs/reference/connectors/duckdb/configuration.mdx
@@ -1,0 +1,198 @@
+---
+sidebar_position: 2
+sidebar_label: Configuration
+description:
+  "Reference documentation for the setup process for the Hasura DuckDB connector, including collection names, object
+  types, and native functions."
+keywords:
+  - duckdb
+  - configuration
+---
+
+# Configuration Reference
+
+## Introduction
+
+The configuration is a metadata object that lists all the database entities — such as collections — that the data
+connector has to know about in order to serve queries. It never changes during the lifetime of the data connector
+service instance. When your database schema changes you will have to update the configuration accordingly, see
+[updating with introspection](#updating-with-introspection).
+
+## Structure
+
+The configuration object is a JSON object with the following fields:
+
+```json
+{
+  "config": {
+    "collection_names": [],
+    "collection_aliases": {},
+    "object_types": {},
+    "functions": [],
+    "procedures": []
+  }
+}
+```
+
+### Property: Collection Names
+
+This is an array of collection names that the connector will expose for querying. This is a required field.
+
+Example:
+
+```json
+{
+  "collection_names": ["posts", "users"]
+}
+```
+
+### Property: Collection Aliases
+
+This is a JSON object mapping collection names to their full path in the database. This allows you to reference
+collections with simpler names.
+
+Example:
+
+```json
+{
+  "collection_aliases": {
+    "posts": "data.main.posts",
+    "users": "data.main.users"
+  }
+}
+```
+
+### Property: Object Types
+
+This is a JSON object containing definitions for each collection's structure, including fields and their types.
+
+Example:
+
+```json
+{
+  "object_types": {
+    "posts": {
+      "fields": {
+        "id": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "Int"
+            }
+          },
+          "description": "No description available"
+        },
+        "title": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "named",
+              "name": "String"
+            }
+          },
+          "description": "No description available"
+        }
+      },
+      "description": "No description available"
+    }
+  }
+}
+```
+
+Each field definition includes:
+
+- Field name
+- Type specification (including nullability)
+- Description
+
+Supported types include:
+
+- `Int`
+- `String`
+- `Timestamp`
+- `Boolean`
+- `Float`
+- `Double`
+- `Decimal`
+
+### Property: Functions
+
+This is an array of function definitions that can be called through the connector.
+
+Example:
+
+```json
+{
+  "functions": [
+    {
+      "name": "get_post_by_id",
+      "arguments": {
+        "post_id": {
+          "type": {
+            "type": "named",
+            "name": "Int"
+          },
+          "description": "The ID of the post to retrieve"
+        }
+      },
+      "return_type": {
+        "type": "object",
+        "name": "posts"
+      },
+      "description": "Retrieves a post by its ID"
+    }
+  ]
+}
+```
+
+### Property: Procedures
+
+This is an array of procedure definitions that can be executed through the connector.
+
+Example:
+
+```json
+{
+  "procedures": [
+    {
+      "name": "create_new_post",
+      "arguments": {
+        "user_id": {
+          "type": {
+            "type": "named",
+            "name": "Int"
+          },
+          "description": "The user ID for the new post"
+        },
+        "title": {
+          "type": {
+            "type": "named",
+            "name": "String"
+          },
+          "description": "The title of the new post"
+        },
+        "content": {
+          "type": {
+            "type": "named",
+            "name": "String"
+          },
+          "description": "The content of the new post"
+        }
+      },
+      "description": "Creates a new post in the database"
+    }
+  ]
+}
+```
+
+## Updating with introspection
+
+Whenever the schema of your database changes you will need to update your data connector configuration accordingly to
+reflect those changes.
+
+Running `update` in a configuration directory will do the following:
+
+- Connect to the DuckDB database and scan all available collections
+- Update the `collection_names`, `collection_aliases`, and `object_types` fields to reflect the current database schema
+- Preserve any custom functions and procedures defined in the configuration

--- a/docs/reference/connectors/duckdb/index.mdx
+++ b/docs/reference/connectors/duckdb/index.mdx
@@ -15,7 +15,7 @@ seoFrontMatterUpdated: false
 ## Introduction
 
 Hasura DDN includes a Native Data Connector for DuckDB, providing integration with DuckDB databases. This connector
-allows you to leverage DuckDB’s powerful relational database capabilities while taking advantage of Hasura’s
+allows you to leverage DuckDB’s powerful OLAP capabilities while taking advantage of Hasura’s
 metadata-driven approach. Here, we’ll explore the key features of the DuckDB connector and walk through the
 configuration process within a Hasura DDN project.
 

--- a/docs/reference/connectors/duckdb/index.mdx
+++ b/docs/reference/connectors/duckdb/index.mdx
@@ -1,0 +1,33 @@
+---
+title: DuckDB
+sidebar_position: 1
+description: "Learn how to configure the DuckDB connector for use with Hasura DDN."
+sidebar_label: DuckDB
+keywords:
+  - duckdb
+  - configuration
+  - connector
+seoFrontMatterUpdated: false
+---
+
+# DuckDB
+
+## Introduction
+
+Hasura DDN includes a Native Data Connector for DuckDB, providing integration with DuckDB databases. This connector
+allows you to leverage DuckDB’s powerful relational database capabilities while taking advantage of Hasura’s
+metadata-driven approach. Here, we’ll explore the key features of the DuckDB connector and walk through the
+configuration process within a Hasura DDN project.
+
+:::tip Looking to get started?
+
+If you've ended up here and aren't concerned about tweaking your configuration, and rather are looking to get started
+with DuckDB and Hasura DDN as quickly as possible, check out our
+[DuckDB tutorial](/how-to-build-with-ddn/with-duckdb.mdx) or
+[learn how to connect](/data-sources/connect-to-a-source.mdx) to a DuckDB instance.
+
+:::
+
+## DuckDB docs
+
+- [Connector configuration](/reference/connectors/duckdb/configuration.mdx)


### PR DESCRIPTION
## Description 📝

Adds MVP docs for DuckDB. The getting-started guide has been tested as has local mounting listed in the environment variables.

NB: The connector is having issues parsing connection strings from MotherDuck (the hosted DuckDB service). I'll clear those up in a subsequent PR or — if it's resolved quickly — as a follow-up commit here before merging.

## Quick Links 🚀

- [How-to guide](https://robdominguez-doc-2518-write.v3-docs-eny.pages.dev/how-to-build-with-ddn/with-duckdb/)
- [Connect to a source](https://robdominguez-doc-2518-write.v3-docs-eny.pages.dev/data-sources/connect-to-a-source/#step-2-add-environment-variables)
- [Configuration reference](https://robdominguez-doc-2518-write.v3-docs-eny.pages.dev/reference/connectors/duckdb/)