### PR TITLE
Fix broken link on recipes page

### DIFF
--- a/docs/recipes/project-config/index.mdx
+++ b/docs/recipes/project-config/index.mdx
@@ -19,7 +19,7 @@ In this section of recipes, we'll provide step-by-step guides for common pattern
 configuration.
 
 If you're unfamiliar with the local project configuration, [check out the
-docs](/project/configuration/overview.mdxbefore diving deeper into one of these recipes.
+docs](/project-configuration/overview.mdx) before diving deeper into one of these recipes.
 
 ## Recipes
 


### PR DESCRIPTION
## Description 📝
This just quickly fixes a broken link (markdown syntax was messed up) that I noticed.

## Quick Links 🚀

https://daniel-chambers-patch-1.v3-docs-eny.pages.dev/recipes/project-config/

