### PR TITLE
Docs: Make copy updates to fix typos

### DIFF
--- a/docs/how-to-build-with-ddn/with-duckdb.mdx
+++ b/docs/how-to-build-with-ddn/with-duckdb.mdx
@@ -261,7 +261,7 @@ ddn supergraph build local
 
 #### Step 11.4. Restart your services
 
-```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
 ddn run docker-start
 ```
 
@@ -336,7 +336,7 @@ This will create a relationship that maps the `userId` for any post to the `id` 
 ddn supergraph build local
 ```
 
-```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
 ddn run docker-start
 ```
 

--- a/docs/how-to-build-with-ddn/with-mysql.mdx
+++ b/docs/how-to-build-with-ddn/with-mysql.mdx
@@ -285,7 +285,7 @@ ddn supergraph build local
 
 #### Step 12.4. Restart your services
 
-```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
 ddn run docker-start
 ```
 
@@ -345,7 +345,7 @@ relationship between `posts` and `users`.
 ddn supergraph build local
 ```
 
-```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
 ddn run docker-start
 ```
 

--- a/docs/how-to-build-with-ddn/with-postgresql.mdx
+++ b/docs/how-to-build-with-ddn/with-postgresql.mdx
@@ -253,7 +253,7 @@ ddn supergraph build local
 
 #### Step 12.4. Restart your services
 
-```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
 ddn run docker-start
 ```
 
@@ -313,7 +313,7 @@ relationship between `posts` and `users`.
 ddn supergraph build local
 ```
 
-```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
 ddn run docker-start
 ```
 
@@ -399,7 +399,7 @@ and delete operations.
 ddn supergraph build local
 ```
 
-```sh title="Bring down the servies by pressing CTRL+C and start them back up:"
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
 ddn run docker-start
 ```
 
@@ -409,7 +409,7 @@ ddn run docker-start
 mutation InsertSinglePost {
   insertPosts(
     objects: {
-      content: "I am an expert in Bird Law and I demand satisfcation."
+      content: "I am an expert in Bird Law and I demand satisfaction."
       title: "Charlie has more to say"
       userId: "3"
     }


### PR DESCRIPTION
## Description 📝

Makes copy updates to fix typos in existing guides.
