### PR TITLE
Fix: toc contents top sticky position

### DIFF
--- a/src/theme/TOC/styles.module.css
+++ b/src/theme/TOC/styles.module.css
@@ -1,7 +1,8 @@
 .tableOfContents {
   height: calc(100vh - var(--ifm-navbar-height) + 80px);
   position: sticky;
-  top: calc(var(--ifm-navbar-height));
+  /* top: calc(var(--ifm-navbar-height)); */
+  top: 0;
   border-left: 1px solid var(--primary-neutral-200);
   overflow-y: auto;
 }


### PR DESCRIPTION
## Description 📝

- Fixed the TOC on the right side to stay sticky at the top-right position

<img width="756" alt="Screenshot 2025-03-25 at 3 22 29 PM" src="https://github.com/user-attachments/assets/95932c59-6ac9-450b-8fc0-14fe0878c168" />

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->