### PR TITLE
Docs: Write MVP for HTTP connector docs

### DIFF
--- a/docs/data-sources/connect-to-a-source.mdx
+++ b/docs/data-sources/connect-to-a-source.mdx
@@ -77,6 +77,15 @@ it requires:
 | `ELASTICSEARCH_INDEX_PATTERN` | `hasura*`                                                      | The pattern for matching Elasticsearch indices, potentially including wildcards, used by the connector                                                                     |
 
 </TabItem>
+<TabItem value="HTTP" label="HTTP">
+
+The HTTP connector won't prompt you for any environment variables. When you initialize the connector, a `config.yaml`
+will be generated where you can list valid specs for your API(s).
+
+Learn more [here](/reference/connectors/http/index.mdx).
+
+</TabItem>
+
 <TabItem value="MongoDB" label="MongoDB">
 
 | ENV            | Example                        | Description                                                                                             |

--- a/docs/how-to-build-with-ddn/with-http.mdx
+++ b/docs/how-to-build-with-ddn/with-http.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 sidebar_label: With HTTP
 description: "Learn the basics of Hasura DDN and how to get started with the HTTP connector."
 keywords:

--- a/docs/how-to-build-with-ddn/with-http.mdx
+++ b/docs/how-to-build-with-ddn/with-http.mdx
@@ -335,5 +335,6 @@ Here's what you just accomplished:
 
 Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
 
-Take a look at our HTTP connector docs to learn more about how to use Hasura DDN with existing HTTP APIs. Or, if you're
-ready, get started with adding [permissions](/auth/permissions/index.mdx) to control access to your API.
+Take a look at our [HTTP connector docs](/reference/connectors/http/index.mdx) to learn more about how to use Hasura DDN
+with existing HTTP APIs. Or, if you're ready, get started with adding [permissions](/auth/permissions/index.mdx) to
+control access to your API.

--- a/docs/how-to-build-with-ddn/with-http.mdx
+++ b/docs/how-to-build-with-ddn/with-http.mdx
@@ -90,7 +90,7 @@ ddn connector show-resources my_http
 
 The HTTP connector exposes each resource in the API's schema as a [command](/reference/metadata-reference/commands.mdx).
 
-```sh title="Let's track single command from the existing API:"
+```sh title="Let's track a single command from the existing API:"
 ddn command add my_http getUsers
 ```
 
@@ -149,7 +149,7 @@ query GET_USERS {
 
 ### Step 9. Add another command
 
-```sh title="Let's the command to query for posts:"
+```sh title="Let's add the command to query for posts:"
 ddn command add my_http getPosts
 ```
 
@@ -269,8 +269,9 @@ query GET_USERS_AND_POSTS {
             "title": "qui est esse",
             "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
           },
-        ...
-      ]
+          ...
+        ]
+      },
       ...
     ]
   }

--- a/docs/how-to-build-with-ddn/with-http.mdx
+++ b/docs/how-to-build-with-ddn/with-http.mdx
@@ -1,0 +1,338 @@
+---
+sidebar_position: 5
+sidebar_label: With HTTP
+description: "Learn the basics of Hasura DDN and how to get started with the HTTP connector."
+keywords:
+  - hasura ddn
+  - graphql api
+  - getting started
+  - guide
+  - http
+---
+
+import Prereqs from "@site/docs/_prereqs.mdx";
+
+# Get Started with Hasura DDN and HTTP APIs
+
+## Overview
+
+This tutorial takes about fifteen minutes to complete. You'll learn how to:
+
+- Set up a new Hasura DDN project
+- Connect it to an existing HTTP API
+- Generate Hasura metadata
+- Create a build
+- Run your first query
+
+Additionally, we'll familiarize you with the steps and workflows necessary to iterate on your API.
+
+This tutorial assumes you're starting from scratch. We'll connect to the
+[`{JSON} Placeholder` API](https://jsonplaceholder.typicode.com/); Hasura will never modify your source schema.
+
+<Prereqs />
+
+## Tutorial
+
+### Step 1. Authenticate your CLI
+
+```sh title="Before you can create a new Hasura DDN project, you need to authenticate your CLI:"
+ddn auth login
+```
+
+This will launch a browser window prompting you to log in or sign up for Hasura DDN. After you log in, the CLI will
+acknowledge your login, giving you access to Hasura Cloud resources.
+
+### Step 2. Scaffold out a new local project
+
+```sh title="Next, create a new local project:"
+ddn supergraph init my-project && cd my-project
+```
+
+Once you move into this directory, you'll see your project scaffolded out for you. You can view the structure by either
+running `ls` in your terminal, or by opening the directory in your preferred editor.
+
+### Step 3. Initialize your HTTP connector
+
+```sh title="In your project directory, run:"
+ddn connector init my_http -i
+```
+
+From the dropdown, select `hasura/http` (you can type to filter the list). The HTTP connector will not ask for any
+environment variables. Instead, you'll find a configuration file at `app/connector/my_http/config.yaml`.
+
+This configuration file allows you to adjust the settings of your connector and determine which APIs are included; the
+`files` array expects an array of configuration files in either YAML or JSON format.
+
+:::info What types of configuration files can I use?
+
+By default, the connector ships with the `{JSON} Placeholder` API's schema included. This is what we'll use in this
+guide.
+
+However, you can use any OpenAPI 2 or 3 specification files. A list of common schemas can be found
+[here](https://github.com/hasura/ndc-http-recipes/tree/main/recipes).
+
+:::
+
+### Step 4. Introspect your API's schema
+
+```sh title="Next, use the CLI to introspect your API's schema:"
+ddn connector introspect my_http
+```
+
+After running this, you should see a representation of your database's schema in the
+`app/connector/my_http/schema.output.json` file; you can view this using `cat` or open the file in your editor.
+
+```sh title="Additionally, you can check which resources are available — and their status — at any point using the CLI:"
+ddn connector show-resources my_http
+```
+
+### Step 5. Add your first command
+
+The HTTP connector exposes each resource in the API's schema as a [command](/reference/metadata-reference/commands.mdx).
+
+```sh title="Let's track single command from the existing API:"
+ddn command add my_http getUsers
+```
+
+### Step 6. Create a new build
+
+```sh title="To create a local build, run:"
+ddn supergraph build local
+```
+
+The build is stored as a set of JSON files in `engine/build`.
+
+### Step 7. Start your local services
+
+```sh title="Start your local Hasura DDN Engine and HTTP connector:"
+ddn run docker-start
+```
+
+Your terminal will be taken over by logs for the different services.
+
+### Step 8. Run your first query
+
+```sh title="In a new terminal tab, open your local console:"
+ddn console --local
+```
+
+```graphql title="In the GraphiQL explorer of the console, write this query:"
+query GET_USERS {
+  getUsers {
+    id
+    name
+  }
+}
+```
+
+```json title="You'll get the following response:"
+{
+  "data": {
+    "getUsers": [
+      {
+        "id": 1,
+        "name": "Leanne Graham"
+      },
+      {
+        "id": 2,
+        "name": "Ervin Howell"
+      },
+      {
+        "id": 3,
+        "name": "Clementine Bauch"
+      },
+      ...
+    ]
+  }
+}
+```
+
+### Step 9. Add another command
+
+```sh title="Let's the command to query for posts:"
+ddn command add my_http getPosts
+```
+
+### Step 10. Rebuild your project
+
+```sh title="Next, create a new build:"
+ddn supergraph build local
+```
+
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
+ddn run docker-start
+```
+
+### Step 11. Query your new build
+
+```graphql title="Head back to your console and query the posts:"
+query GET_POSTS {
+  getPosts {
+    id
+    userId
+    title
+    body
+  }
+}
+```
+
+```json title="You'll get a response like this:"
+{
+  "data": {
+    "getPosts": [
+      {
+        "id": 1,
+        "userId": 1,
+        "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+        "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+      },
+      {
+        "id": 2,
+        "userId": 1,
+        "title": "qui est esse",
+        "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
+      },
+      {
+        "id": 3,
+        "userId": 1,
+        "title": "ea molestias quasi exercitationem repellat qui ipsa sit aut",
+        "body": "et iusto sed quo iure\nvoluptatem occaecati omnis eligendi aut ad\nvoluptatem doloribus vel accusantium quis pariatur\nmolestiae porro eius odio et labore et velit aut"
+      },
+      ...
+    ]
+  }
+}
+```
+
+### Step 12. Create a relationship
+
+In your DDN metadata, you can create [relationships](/reference/metadata-reference/relationships.mdx) between resources
+in your API. Below, we'll define a relationship — with the assistance of the
+[VS Code Extension](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.Hasura) — between `users` and `posts`.
+
+```yaml title="Add the following to the end of the app/connector/my_http/metadata/getUsers.hml file:"
+---
+kind: Relationship
+version: v1
+definition:
+  name: posts
+  sourceType: User
+  target:
+    command:
+      name: GetPosts
+  mapping:
+    - source:
+        fieldPath:
+          - fieldName: id
+      target:
+        argument:
+          argumentName: userId
+```
+
+```sh title="Next, create a new build:"
+ddn supergraph build local
+```
+
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
+ddn run docker-start
+```
+
+```graphql title="Run the following query to return nested data about posts for each user:"
+query GET_USERS_AND_POSTS {
+  getUsers {
+    id
+    name
+    posts {
+      id
+      title
+      body
+    }
+  }
+}
+```
+
+```json title="You'll get a response like this:"
+{
+  "data": {
+    "getUsers": [
+      {
+        "id": 1,
+        "name": "Leanne Graham",
+        "posts": [
+          {
+            "id": 1,
+            "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+            "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+          },
+          {
+            "id": 2,
+            "title": "qui est esse",
+            "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
+          },
+        ...
+      ]
+      ...
+    ]
+  }
+}
+```
+
+:::info create relationships to your own data
+
+You can create relationships between resources in your connected HTTP API and data living in other data sources.
+
+:::
+
+### Step 13. Insert data
+
+We can also track existing insert, update, and delete operations available via the API.
+
+```sh title="Let's track this createPost command:"
+ddn command add my_http createPost
+```
+
+```sh title="Next, create a new build:"
+ddn supergraph build local
+```
+
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
+ddn run docker-start
+```
+
+```graphql title="Then, run the following mutation:"
+mutation INSERT_SINGLE_POST {
+  createPost(body: { body: "This is a new post!", title: "New Post" }) {
+    id
+    title
+  }
+}
+```
+
+```json title="You'll get a response like this:"
+{
+  "data": {
+    "createPost": {
+      "id": 101,
+      "title": "New Post"
+    }
+  }
+}
+```
+
+## Next steps
+
+Congratulations on completing your first Hasura DDN project with the HTTP connector! 🎉
+
+Here's what you just accomplished:
+
+- You started with a fresh project and connected it to the `{JSON} Placeholder` HTTP API.
+- You set up metadata to represent your tables and relationships, which acts as the blueprint for your API.
+- Then, you created a build — essentially compiling everything into a ready-to-use API — and successfully ran your first
+  GraphQL queries to fetch data.
+- Along the way, you learned how to iterate on your schema and refresh your metadata to reflect changes.
+- Finally, we looked at how to enable mutations and insert data using your new API.
+
+Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
+
+Take a look at our HTTP connector docs to learn more about how to use Hasura DDN with existing HTTP APIs. Or, if you're
+ready, get started with adding [permissions](/auth/permissions/index.mdx) to control access to your API.

--- a/docs/how-to-build-with-ddn/with-mongodb.mdx
+++ b/docs/how-to-build-with-ddn/with-mongodb.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 sidebar_label: With MongoDB
 description: "Learn the basics of Hasura DDN and how to get started with a MongoDB database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-mongodb.mdx
+++ b/docs/how-to-build-with-ddn/with-mongodb.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 sidebar_label: With MongoDB
 description: "Learn the basics of Hasura DDN and how to get started with a MongoDB database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-mysql.mdx
+++ b/docs/how-to-build-with-ddn/with-mysql.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 sidebar_label: With MySQL
 description: "Learn the basics of Hasura DDN and how to get started with a MySQL database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-mysql.mdx
+++ b/docs/how-to-build-with-ddn/with-mysql.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: With MySQL
 description: "Learn the basics of Hasura DDN and how to get started with a MySQL database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-openapi.mdx
+++ b/docs/how-to-build-with-ddn/with-openapi.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 9
 sidebar_label: With OpenAPI
 description: "Learn the basics of Hasura DDN and how to get started with HTTP APIs using OpenAPI."
 keywords:

--- a/docs/how-to-build-with-ddn/with-postgresql.mdx
+++ b/docs/how-to-build-with-ddn/with-postgresql.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: With PostgreSQL
 description: "Learn the basics of Hasura DDN and how to get started with a Postgres database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-postgresql.mdx
+++ b/docs/how-to-build-with-ddn/with-postgresql.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 sidebar_label: With PostgreSQL
 description: "Learn the basics of Hasura DDN and how to get started with a Postgres database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-qdrant.mdx
+++ b/docs/how-to-build-with-ddn/with-qdrant.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 11
 sidebar_label: With Qdrant
 description: "Learn the basics of Hasura DDN and how to get started with a Qdrant-hosted vector database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-qdrant.mdx
+++ b/docs/how-to-build-with-ddn/with-qdrant.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 sidebar_label: With Qdrant
 description: "Learn the basics of Hasura DDN and how to get started with a Qdrant-hosted vector database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-snowflake.mdx
+++ b/docs/how-to-build-with-ddn/with-snowflake.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 12
 sidebar_label: With Snowflake
 description: "Learn the basics of Hasura DDN and how to get started with a Snowflake instance."
 keywords:

--- a/docs/how-to-build-with-ddn/with-snowflake.mdx
+++ b/docs/how-to-build-with-ddn/with-snowflake.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 sidebar_label: With Snowflake
 description: "Learn the basics of Hasura DDN and how to get started with a Snowflake instance."
 keywords:

--- a/docs/how-to-build-with-ddn/with-storage.mdx
+++ b/docs/how-to-build-with-ddn/with-storage.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 13
 sidebar_label: With Storage
 description: "Learn the basics of Hasura DDN and how to get started with various storage solutions."
 keywords:

--- a/docs/how-to-build-with-ddn/with-storage.mdx
+++ b/docs/how-to-build-with-ddn/with-storage.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 sidebar_label: With Storage
 description: "Learn the basics of Hasura DDN and how to get started with various storage solutions."
 keywords:

--- a/docs/how-to-build-with-ddn/with-stripe.mdx
+++ b/docs/how-to-build-with-ddn/with-stripe.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 14
 sidebar_label: With Stripe
 description: "Learn the basics of Hasura DDN and how to get started with a Stripe account."
 keywords:

--- a/docs/how-to-build-with-ddn/with-stripe.mdx
+++ b/docs/how-to-build-with-ddn/with-stripe.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 sidebar_label: With Stripe
 description: "Learn the basics of Hasura DDN and how to get started with a Stripe account."
 keywords:

--- a/docs/how-to-build-with-ddn/with-trino.mdx
+++ b/docs/how-to-build-with-ddn/with-trino.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 15
 sidebar_label: With Trino
 description: "Learn the basics of Hasura DDN and how to get started with a Trino instance."
 keywords:

--- a/docs/how-to-build-with-ddn/with-trino.mdx
+++ b/docs/how-to-build-with-ddn/with-trino.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 sidebar_label: With Trino
 description: "Learn the basics of Hasura DDN and how to get started with a Trino instance."
 keywords:

--- a/docs/how-to-build-with-ddn/with-turso.mdx
+++ b/docs/how-to-build-with-ddn/with-turso.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 16
 sidebar_label: With Turso
 description: "Learn the basics of Hasura DDN and how to get started with a Turso-hosted database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-turso.mdx
+++ b/docs/how-to-build-with-ddn/with-turso.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 sidebar_label: With Turso
 description: "Learn the basics of Hasura DDN and how to get started with a Turso-hosted database."
 keywords:

--- a/docs/reference/connectors/http/_category_.json
+++ b/docs/reference/connectors/http/_category_.json
@@ -1,5 +1,4 @@
 {
   "label": "HTTP",
-  "position": 3
+  "position": 4
 }
-

--- a/docs/reference/connectors/http/_category_.json
+++ b/docs/reference/connectors/http/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "HTTP",
+  "position": 3
+}
+

--- a/docs/reference/connectors/http/auth.mdx
+++ b/docs/reference/connectors/http/auth.mdx
@@ -1,0 +1,250 @@
+---
+sidebar_position: 3
+sidebar_label: Authentication
+description: "Learn how to set up various auth providers with the HTTP connector."
+keywords:
+  - http
+  - configuration
+  - auth
+---
+
+# Authentication Configuration
+
+## Introduction
+
+The connector supports API key and auth token authentication schemes. The configuration is inspired from
+`securitySchemes` [with env variables](https://github.com/hasura/ndc-http/ndc-http-schema#authentication). The connector
+supports the following authentication strategies:
+
+- API Key
+- Basic Auth
+- Bearer Auth
+- Cookie
+- OAuth 2.0
+- Mutual TLS
+
+The configuration automatically generates environment variables for those security schemes.
+
+## API Key
+
+There is a `value` field with the environment variable to be replaced in runtime. The name of the variable is generated
+from the security scheme key. For example:
+
+```yaml
+securitySchemes:
+  api_key:
+    type: apiKey
+    value:
+      env: API_KEY # the constant case of api_key
+    in: header
+    name: api_key
+```
+
+```
+api_key: {{API_KEY}}
+```
+
+## Basic Auth
+
+Set `username` and `password` environment variables:
+
+```yaml
+securitySchemes:
+  basic:
+    type: basic
+    header: Authorization
+    username:
+      value: PET_STORE_USERNAME
+    password:
+      value: PET_STORE_PASSWORD
+```
+
+## Bearer Auth
+
+Configure the `value` environment variable, header name, and scheme. For example, the below configuration will inject
+the bearer token into incoming requests:
+
+```yaml
+securitySchemes:
+  bearer:
+    type: http
+    header: Authorization
+    value:
+      env: PET_STORE_BEARER_TOKEN
+    scheme: bearer
+```
+
+```
+Authorization: Bearer {{PET_STORE_BEARER_TOKEN}}
+```
+
+## OAuth 2.0
+
+The client credentials grant is built-in supported. You can set the tokenUrl, scopes, client ID, and client secret
+variables. The connector automatically refreshes access tokens and injects them into incoming requests.
+
+```yaml
+securitySchemes:
+  petstore_auth:
+    type: oauth2
+    flows:
+      clientCredentials:
+        tokenUrl:
+          value: http://localhost:4444/oauth2/token
+        clientId:
+          env: OAUTH2_CLIENT_ID
+        clientSecret:
+          env: OAUTH2_CLIENT_SECRET
+        scopes:
+          read:pets: read your pets
+          write:pets: modify pets in your account
+```
+
+For other OAuth 2.0 flows, you need to enable [headers forwarding](#headers-forwarding) from the Hasura DDN engine to
+the connector.
+
+## Cookie
+
+For Cookie authentication and OAuth 2.0, you need to enable [headers forwarding](#headers-forwarding) from the Hasura
+DDN engine to the connector.
+
+## Headers Forwarding
+
+Enable `forwardHeaders` in the configuration file.
+
+```yaml
+# ...
+forwardHeaders:
+  enabled: true
+  argumentField: headers
+```
+
+And configure in the DataConnectorLink metadata:
+
+```yaml
+kind: DataConnectorLink
+version: v1
+definition:
+  name: my_api
+  # ...
+  argumentPresets:
+    - argument: headers
+      value:
+        httpHeaders:
+          forward:
+            - Cookie
+          additional: {}
+```
+
+## Mutual TLS
+
+### Basic
+
+If the `mutualTLS` security scheme exists, the TLS configuration will be generated in the `settings` field.
+
+```yaml
+settings:
+  servers:
+    - url:
+        env: PET_STORE_URL
+  securitySchemes:
+    mtls:
+      type: mutualTLS
+  tls:
+    # Provide the certificate contents as a base64-encoded string.
+    certPem:
+      env: PET_STORE_CERT_PEM
+    # Provide the key contents as a base64-encoded string.
+    keyPem:
+      env: PET_STORE_KEY_PEM
+    # Provide the CA cert contents as a base64-encoded string.
+    caPem:
+      env: PET_STORE_CA_PEM
+    # Additionally you can configure TLS to be enabled but skip verifying the server's certificate chain (optional).
+    insecureSkipVerify:
+      env: PET_STORE_INSECURE_SKIP_VERIFY
+      value: false
+```
+
+### Full configuration
+
+```yaml title="Below, you'll find a complete configuration example:"
+settings:
+  servers:
+    - url:
+        env: PET_STORE_URL
+  securitySchemes:
+    mtls:
+      type: mutualTLS
+  tls:
+    # Path to the TLS cert to use for TLS required connections.
+    certFile:
+      env: PET_STORE_CERT_FILE
+    # Alternative to cert_file. Provide the certificate contents as a base64-encoded string instead of a filepath.
+    certPem:
+      env: PET_STORE_CERT_PEM
+    # Path to the TLS key to use for TLS required connections.
+    keyFile:
+      env: PET_STORE_KEY_FILE
+    # Alternative to key_file. Provide the key contents as a base64-encoded string instead of a filepath.
+    keyPem:
+      env: PET_STORE_KEY_PEM
+    # Path to the CA cert.
+    caFile:
+      env: PET_STORE_CA_FILE
+    # Alternative to ca_file. Provide the CA cert contents as a base64-encoded string instead of a filepath.
+    caPem:
+      env: PET_STORE_CA_PEM
+    # Additionally you can configure TLS to be enabled but skip verifying the server's certificate chain (optional).
+    insecureSkipVerify:
+      env: PET_STORE_INSECURE_SKIP_VERIFY
+      value: false
+    # Whether to load the system certificate authorities pool alongside the certificate authority (optional).
+    includeSystemCACertsPool:
+      env: PET_STORE_INCLUDE_SYSTEM_CA_CERT_POOL
+      value: false
+
+    ## ServerName requested by client for virtual hosting (optional).
+    serverName:
+      env: PET_STORE_SERVER_NAME
+
+    ## Minimum acceptable TLS version (optional).
+    minVersion: "1.0"
+
+    ## Maximum acceptable TLS version (optional).
+    maxVersion: "1.3"
+
+    ## Explicit cipher suites can be set. If left blank, a safe default list is used (optional).
+    # cipherSuites:
+    #   - TLS_AES_128_GCM_SHA256
+```
+
+:::info Encoding patterns
+
+It's recommended to use inline bases64-encoded PEM data `*_PEM` variables if you deploy the connector to Hasura Cloud.
+
+:::
+
+### Multiple certificates
+
+If the service has many servers, you can configure different TLS configurations for each server.
+
+```yaml
+settings:
+  servers:
+    - url:
+        env: PET_STORE_URL
+    - url:
+        env: PET_STORE_URL_2
+      tls:
+        certFile:
+          env: PET_STORE_CERT_FILE_2
+        # ...
+  securitySchemes:
+    mtls:
+      type: mutualTLS
+  tls:
+    certFile:
+      env: PET_STORE_CERT_FILE
+    # ...
+```

--- a/docs/reference/connectors/http/configuration.mdx
+++ b/docs/reference/connectors/http/configuration.mdx
@@ -63,6 +63,7 @@ files:
   - file: swagger.json
     spec: oas2
     timeout:
+      # The time in seconds to wait before timeout
       value: 30
     retry:
       times:

--- a/docs/reference/connectors/http/configuration.mdx
+++ b/docs/reference/connectors/http/configuration.mdx
@@ -1,0 +1,102 @@
+---
+sidebar_position: 2
+sidebar_label: Configuration
+description: "Reference documentation for the setup process for the HTTP connector"
+keywords:
+  - http
+  - configuration
+---
+
+# Configuration
+
+## Introduction
+
+The connector reads `config.{json,yaml}` file in the configuration folder.
+
+```yaml title="The file contains information about the schema file path and its specification:"
+files:
+  - file: swagger.json
+    spec: openapi2
+  - file: openapi.yaml
+    spec: openapi3
+    trimPrefix: /v1
+    envPrefix: PET_STORE
+  - file: schema.json
+    spec: ndc
+```
+
+The config of each element follows the
+[config schema](https://raw.githubusercontent.com/hasura/ndc-http/refs/heads/main/ndc-http-schema/config.example.yaml)
+of `ndc-http-schema`.
+
+You can add many API documentation files into the same connector.
+
+:::info Conflicting types
+
+Conflicting object and scalar types will be ignored. Only the type of the first file is kept in the schema.
+
+:::
+
+## Supported specs
+
+### OpenAPI
+
+The HTTP connector supports both OpenAPI 2 and 3 specifications.
+
+- `oas3`/`openapi3`: OpenAPI 3.0/3.1.
+- `oas2`/`openapi2`: OpenAPI 2.0.
+
+### HTTP Connector schema
+
+Enum: `ndc`
+
+HTTP schema is the native configuration schema which other specs will be converted to behind the scene. The schema
+extends the NDC Specification with HTTP configuration and can be converted from other specs by the
+[NDC HTTP schema CLI](https://github.com/hasura/ndc-http/tree/main/ndc-http-schema).
+
+## Timeout and retry
+
+The global timeout and retry strategy can be configured in each file:
+
+```yaml
+files:
+  - file: swagger.json
+    spec: oas2
+    timeout:
+      value: 30
+    retry:
+      times:
+        value: 1
+      delay:
+        # The default delay between each retry in milliseconds.
+        # The connector prefers the Retry-After header in the response if exists
+        value: 500
+      httpStatus: [429, 500, 502, 503]
+```
+
+## JSON patch
+
+You can add JSON patches to extend API documentation files. The HTTP connector supports `merge` and `json6902`
+strategies. JSON patches can be applied before or after the conversion from OpenAPI to HTTP schema configuration. It
+will be useful if you need to extend or fix some fields in the API documentation such as server URL.
+
+```yaml
+files:
+  - file: openapi.yaml
+    spec: oas3
+    patchBefore:
+      - path: patch-before.yaml
+        strategy: merge
+    patchAfter:
+      - path: patch-after.yaml
+        strategy: json6902
+```
+
+See [the example](https://github.com/hasura/ndc-http/tree/main/ndc-http-schema/command/testdata/patch) for more context.
+
+## Runtime settings
+
+### Stringify JSON (boolean)
+
+This setting treats the arbitrary JSON scalars as a JSON string. This setting is useful when, for example, making the
+schema compatible with [PromptQL](https://promptql.hasura.io).

--- a/docs/reference/connectors/http/index.mdx
+++ b/docs/reference/connectors/http/index.mdx
@@ -1,0 +1,72 @@
+---
+title: HTTP
+sidebar_position: 1
+description:
+  "Learn how to configure the HTTP connector and instantly integrate any existing endpoints in your supergraph."
+sidebar_label: HTTP
+keywords:
+  - http
+  - configuration
+  - connector
+seoFrontMatterUpdated: false
+---
+
+# HTTP
+
+## Introduction
+
+The HTTP connector enables you to connect any existing HTTP API into your Hasura DDN supergraph. Here we'll provide an
+overview of the features offered by the connector and guide you through the configuration process within a Hasura DDN
+project.
+
+## Features
+
+Below, you'll find feature matrices for the connector.
+
+### Supported request types
+
+| Request Type | Query | Path | Body | Headers |
+| ------------ | ----- | ---- | ---- | ------- |
+| GET          | ✅    | ✅   | NA   | ✅      |
+| POST         | ✅    | ✅   | ✅   | ✅      |
+| DELETE       | ✅    | ✅   | ✅   | ✅      |
+| PUT          | ✅    | ✅   | ✅   | ✅      |
+| PATCH        | ✅    | ✅   | ✅   | ✅      |
+
+### Supported content types
+
+| Content Type                      | Supported |
+| --------------------------------- | --------- |
+| application/json                  | ✅        |
+| application/xml                   | ✅        |
+| application/x-www-form-urlencoded | ✅        |
+| multipart/form-data               | ✅        |
+| application/octet-stream          | ✅ (\*)   |
+| text/\*                           | ✅        |
+| application/x-ndjson              | ✅        |
+| image/\*                          | ✅ (\*)   |
+
+\* Upload file content types are converted to `base64` encoding.
+
+### Supported authentication
+
+| Security scheme | Supported | Comment                                                                                                                                   |
+| --------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| API Key         | ✅        |                                                                                                                                           |
+| Basic Auth      | ✅        |                                                                                                                                           |
+| Bearer Auth     | ✅        |                                                                                                                                           |
+| Cookies         | ✅        | Require forwarding the `Cookie` header from the Hasura engine.                                                                            |
+| OAuth 2.0       | ✅        | Built-in support for the `client_credentials` grant. Other grant types require forwarding access tokens from headers by the Hasura engine |
+| mTLS            | ✅        |                                                                                                                                           |
+
+:::tip Looking to get started?
+
+If you've ended up here and aren't concerned about tweaking your configuration, and rather are looking to get started
+with the HTTP connector and Hasura DDN as quickly as possible, check out our
+[HTTP connector tutorial](/how-to-build-with-ddn/with-http.mdx).
+
+:::
+
+## HTTP docs
+
+- [Connector configuration](/reference/connectors/http/configuration.mdx)

--- a/docs/reference/connectors/mongodb/_category_.json
+++ b/docs/reference/connectors/mongodb/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "MongoDB",
-  "position": 3
+  "position": 4
 }

--- a/docs/reference/connectors/mongodb/_category_.json
+++ b/docs/reference/connectors/mongodb/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "MongoDB",
-  "position": 4
+  "position": 5
 }

--- a/docs/reference/connectors/mysql/_category_.json
+++ b/docs/reference/connectors/mysql/_category_.json
@@ -1,5 +1,4 @@
 {
   "label": "MySQL",
-  "position": 5
+  "position": 6
 }
-

--- a/docs/reference/connectors/mysql/_category_.json
+++ b/docs/reference/connectors/mysql/_category_.json
@@ -1,4 +1,5 @@
 {
   "label": "MySQL",
-  "position": 4
+  "position": 5
 }
+

--- a/docs/reference/connectors/openapi-lambda/_category_.json
+++ b/docs/reference/connectors/openapi-lambda/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "OpenAPI Lambda",
-  "position": 6
+  "position": 7
 }

--- a/docs/reference/connectors/oracle/_category_.json
+++ b/docs/reference/connectors/oracle/_category_.json
@@ -1,4 +1,5 @@
 {
   "label": "Oracle",
-  "position": 5
+  "position": 6
 }
+

--- a/docs/reference/connectors/oracle/_category_.json
+++ b/docs/reference/connectors/oracle/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Oracle",
-  "position": 7
+  "position": 8
 }

--- a/docs/reference/connectors/postgresql/_category_.json
+++ b/docs/reference/connectors/postgresql/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "PostgreSQL",
-  "position": 6
+  "position": 7
 }

--- a/docs/reference/connectors/postgresql/_category_.json
+++ b/docs/reference/connectors/postgresql/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "PostgreSQL",
-  "position": 8
+  "position": 9
 }

--- a/docs/reference/connectors/qdrant/_category_.json
+++ b/docs/reference/connectors/qdrant/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Qdrant",
-  "position": 9
+  "position": 10
 }

--- a/docs/reference/connectors/qdrant/_category_.json
+++ b/docs/reference/connectors/qdrant/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Qdrant",
-  "position": 7
+  "position": 8
 }

--- a/docs/reference/connectors/snowflake/_category_.json
+++ b/docs/reference/connectors/snowflake/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Snowflake",
-  "position": 10
+  "position": 11
 }

--- a/docs/reference/connectors/snowflake/_category_.json
+++ b/docs/reference/connectors/snowflake/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Snowflake",
-  "position": 8
+  "position": 9
 }

--- a/docs/reference/connectors/sqlserver/_category_.json
+++ b/docs/reference/connectors/sqlserver/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "SQL Server",
-  "position": 11
+  "position": 12
 }

--- a/docs/reference/connectors/sqlserver/_category_.json
+++ b/docs/reference/connectors/sqlserver/_category_.json
@@ -1,5 +1,4 @@
 {
   "label": "SQL Server",
-  "position": 9
+  "position": 10
 }
-

--- a/docs/reference/connectors/storage/_category_.json
+++ b/docs/reference/connectors/storage/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Storage",
-  "position": 12
+  "position": 13
 }

--- a/docs/reference/connectors/storage/_category_.json
+++ b/docs/reference/connectors/storage/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Storage",
-  "position": 8
+  "position": 11
 }

--- a/docs/reference/connectors/stripe/_category_.json
+++ b/docs/reference/connectors/stripe/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Stripe",
-  "position": 13
+  "position": 14
 }

--- a/docs/reference/connectors/stripe/_category_.json
+++ b/docs/reference/connectors/stripe/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Stripe",
-  "position": 8
+  "position": 12
 }

--- a/docs/reference/connectors/trino/_category_.json
+++ b/docs/reference/connectors/trino/_category_.json
@@ -1,5 +1,4 @@
 {
   "label": "Trino",
-  "position": 10
+  "position": 13
 }
-

--- a/docs/reference/connectors/trino/_category_.json
+++ b/docs/reference/connectors/trino/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Trino",
-  "position": 14
+  "position": 15
 }

--- a/docs/reference/connectors/turso/_category_.json
+++ b/docs/reference/connectors/turso/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Turso",
-  "position": 15
+  "position": 16
 }

--- a/docs/reference/connectors/turso/_category_.json
+++ b/docs/reference/connectors/turso/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Turso",
-  "position": 11
+  "position": 14
 }


### PR DESCRIPTION
## Description 📝

Adds MVP docs for the HTTP connector. The getting-started guide has been tested with the `{JSON}` Placeholder API.

## Quick Links 🚀
- [How-to guide](https://robdominguez-doc-2517-write.v3-docs-eny.pages.dev/how-to-build-with-ddn/with-http/)
- [Connect to a source](https://robdominguez-doc-2517-write.v3-docs-eny.pages.dev/data-sources/connect-to-a-source/#step-2-add-environment-variables)
- [Configuration reference](https://robdominguez-doc-2517-write.v3-docs-eny.pages.dev/reference/connectors/http/)