### PR TITLE
Docs: Write MVP for Prometheus docs

### DIFF
--- a/docs/data-sources/connect-to-a-source.mdx
+++ b/docs/data-sources/connect-to-a-source.mdx
@@ -98,6 +98,13 @@ it requires:
 | `CONNECTION_URI` | `postgresql://user:password@host:5432/dbname` | The full connection string used to connect to the PostgreSQL database. |
 
 </TabItem>
+<TabItem value="Prometheus" label="Prometheus">
+
+| ENV              | Example                 | Description                                                                                          |
+| ---------------- | ----------------------- | ---------------------------------------------------------------------------------------------------- |
+| `CONNECTION_URL` | `https://<host>:<port>` | The full connection string used to connect to the Prometheus server. By default, the port is `9090`. |
+
+</TabItem>
 <TabItem value="Qdrant" label="Qdrant">
 
 | ENV              | Example                                       | Description                                                                                                                                          |

--- a/docs/how-to-build-with-ddn/with-prometheus.mdx
+++ b/docs/how-to-build-with-ddn/with-prometheus.mdx
@@ -150,7 +150,7 @@ Your terminal will be taken over by logs for the different services.
 ddn console --local
 ```
 
-We'll write a GraphQL query that's the equivalent of this PrompQL query:
+We'll write a GraphQL query that's the equivalent of this PromQL query:
 
 ```plaintext
 sum(rate(prometheus_http_requests_total{job="prometheus"}[1m]))

--- a/docs/how-to-build-with-ddn/with-prometheus.mdx
+++ b/docs/how-to-build-with-ddn/with-prometheus.mdx
@@ -191,7 +191,7 @@ For the most accurate results, change the date value to a recent date.
 ### Step 10. Add another model
 
 ```sh title="Add the process_cpu_seconds_total counter metric:"
-ddn command add my_prometheus process_cpu_seconds_total
+ddn model add my_prometheus process_cpu_seconds_total
 ```
 
 In `app/metadata` you'll find a newly-generated file: `ProcessCpuSecondsTotal.hml`. This will be used to expose the

--- a/docs/how-to-build-with-ddn/with-prometheus.mdx
+++ b/docs/how-to-build-with-ddn/with-prometheus.mdx
@@ -1,0 +1,252 @@
+---
+sidebar_position: 7
+sidebar_label: With Prometheus
+description: "Learn the basics of Hasura DDN and how to get started with Prometheus metrics."
+keywords:
+  - hasura ddn
+  - graphql api
+  - getting started
+  - guide
+  - prometheus
+---
+
+import Prereqs from "@site/docs/_prereqs.mdx";
+
+# Get Started with Hasura DDN and Prometheus
+
+## Overview
+
+This tutorial takes about twenty minutes to complete. You'll learn how to:
+
+- Set up a new Hasura DDN project
+- Connect it to a Prometheus instance
+- Generate Hasura metadata
+- Create a build
+- Run your first query
+
+Additionally, we'll familiarize you with the steps and workflows necessary to iterate on your API.
+
+This tutorial assumes you're starting from scratch; you'll connect a locally-running Prometheus instance — set up to
+scrape metrics from itself — to Hasura, but you can easily follow the steps if you already have an existing Prometheus
+server. Hasura will never modify your source schema.
+
+<Prereqs />
+
+## Tutorial
+
+### Step 1. Authenticate your CLI
+
+```sh title="Before you can create a new Hasura DDN project, you need to authenticate your CLI:"
+ddn auth login
+```
+
+This will launch a browser window prompting you to log in or sign up for Hasura DDN. After you log in, the CLI will
+acknowledge your login, giving you access to Hasura Cloud resources.
+
+### Step 2. Scaffold out a new local project
+
+```sh title="Next, create a new local project:"
+ddn supergraph init my-project && cd my-project
+```
+
+Once you move into this directory, you'll see your project scaffolded out for you. You can view the structure by either
+running `ls` in your terminal, or by opening the directory in your preferred editor.
+
+### Step 3. Initialize your Prometheus connector
+
+```sh title="In your project directory, run:"
+ddn connector init my_prometheus -i
+```
+
+From the dropdown, select `hasura/prometheus` (you can type to filter the list). Then, enter the following connection
+string when prompted:
+
+```plaintext
+http://local.hasura.dev:9090
+```
+
+### Step 4. Start the local Prometheus instance
+
+```sh title="Begin by creating a compose file for the Prometheus server:"
+touch app/connector/my_prometheus/compose.prometheus.yaml
+```
+
+```yaml title="Then, open the file and add the following:"
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+```
+
+```sh title="In the same directory, create a Prometheus configuration file:"
+touch app/connector/my_prometheus/prometheus.yml
+```
+
+```yaml title="Then, open the file and add the following:"
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["local.hasura.dev:9090"]
+```
+
+```sh title="Run the container:"
+docker compose -f app/connector/my_prometheus/compose.prometheus.yaml up -d
+```
+
+You can open Prometheus by visiting: [`http://localhost:9090`](http://localhost:9090). Go ahead and navigate here and
+poke around...we'll need some requests against the server for our queries later!
+
+### Step 5. Introspect your Prometheus server
+
+```sh title="Next, use the CLI to introspect your Prometheus server:"
+ddn connector introspect my_prometheus
+```
+
+After running this, you should see a representation of your Prometheus server's schema in the
+`app/connector/my_prometheus/configuration.yaml` file; you can view this using `cat` or open the file in your editor.
+
+```sh title="Additionally, you can check which resources are available — and their status — at any point using the CLI:"
+ddn connector show-resources my_prometheus
+```
+
+### Step 6. Add your model
+
+```sh title="Now, let's track a common counter metric as a model in your DDN metadata:"
+ddn model add my_prometheus prometheus_http_requests_total
+```
+
+Open the `app/metadata` directory and you'll find a newly-generated file: `PrometheusHttpRequestsTotal.hml`. The DDN CLI
+will use this Hasura Metadata Language file to represent the `prometheus_http_requests_total` metric from Prometheus in
+your API as a [model](/reference/metadata-reference/models.mdx).
+
+### Step 7. Create a new build
+
+```sh title="To create a local build, run:"
+ddn supergraph build local
+```
+
+The build is stored as a set of JSON files in `engine/build`.
+
+### Step 8. Start your local services
+
+```sh title="Start your local Hasura DDN Engine and Prometheus connector:"
+ddn run docker-start
+```
+
+Your terminal will be taken over by logs for the different services.
+
+### Step 9. Run your first query
+
+```sh title="In a new terminal tab, open your local console:"
+ddn console --local
+```
+
+We'll write a GraphQL query that's the equivalent of this PrompQL query:
+
+```plaintext
+sum(rate(prometheus_http_requests_total{job="prometheus"}[1m]))
+```
+
+```graphql title="In the GraphiQL explorer of the console, write this query:"
+query GET_REQUESTS_PER_SECOND {
+  prometheusHttpRequestsTotal(
+    args: { fn: [{ rate: "1m" }, { sum: [] }] }
+    where: { timestamp: { _gt: "2025-03-26" }, job: { _eq: "prometheus" } }
+  ) {
+    timestamp
+    value
+  }
+}
+```
+
+:::tip Change the `_gt` value
+
+For the most accurate results, change the date value to a recent date.
+
+:::
+
+```json title="You'll get a response that looks like this:"
+{
+  "data": {
+    "prometheusHttpRequestsTotal": [
+      {
+        "job": "prometheus",
+        "timestamp": 1743004075,
+        "value": 0.08889283968176363
+      }
+    ]
+  }
+}
+```
+
+### Step 10. Add another model
+
+```sh title="Add the process_cpu_seconds_total counter metric:"
+ddn command add my_prometheus process_cpu_seconds_total
+```
+
+In `app/metadata` you'll find a newly-generated file: `ProcessCpuSecondsTotal.hml`. This will be used to expose the
+counter metric via your supergraph API.
+
+### Step 11. Rebuild your project
+
+```sh title="Next, create a new build:"
+ddn supergraph build local
+```
+
+```sh title="Bring down the services by pressing CTRL+C and start them back up:"
+ddn run docker-start
+```
+
+### Step 12. Query your new build
+
+```graphql title="Head back to your console and query the new model:"
+query GET_CPU_PROCESS_TOTAL {
+  processCpuSecondsTotal(
+    args: { fn: [{ rate: "1m" }, { sum: [] }] }
+    where: { timestamp: { _gt: "2025-03-26" }, job: { _eq: "prometheus" } }
+  ) {
+    timestamp
+    value
+  }
+}
+```
+
+```json title="You'll get a response that looks like this:"
+{
+  "data": {
+    "processCpuSecondsTotal": [
+      {
+        "timestamp": 1743010998,
+        "value": 0.002222123461179495
+      }
+    ]
+  }
+}
+```
+
+## Next steps
+
+Congratulations on completing your first Hasura DDN project with Prometheus! 🎉
+
+Here's what you just accomplished:
+
+- You started with a fresh project and connected it to a local Prometheus server.
+- You set up metadata to represent your counter metrics, which acts as the blueprint for your API.
+- Then, you created a build — essentially compiling everything into a ready-to-use API — and successfully ran your first
+  GraphQL queries to fetch data.
+- Along the way, you learned how to iterate on your schema and refresh your metadata to reflect changes.
+
+Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
+
+Take a look at our Prometheus docs to learn more about how to use Hasura DDN with Prometheus. Or, if you're ready, get
+started with adding [permissions](/auth/permissions/index.mdx) to control access to your API.

--- a/docs/how-to-build-with-ddn/with-prometheus.mdx
+++ b/docs/how-to-build-with-ddn/with-prometheus.mdx
@@ -248,5 +248,6 @@ Here's what you just accomplished:
 
 Now, you're equipped to connect and expose your data, empowering you to iterate and scale with confidence. Great work!
 
-Take a look at our Prometheus docs to learn more about how to use Hasura DDN with Prometheus. Or, if you're ready, get
-started with adding [permissions](/auth/permissions/index.mdx) to control access to your API.
+Take a look at our [Prometheus docs](/reference/connectors/prometheus/index.mdx) to learn more about how to use Hasura
+DDN with Prometheus. Or, if you're ready, get started with adding [permissions](/auth/permissions/index.mdx) to control
+access to your API.

--- a/docs/how-to-build-with-ddn/with-prometheus.mdx
+++ b/docs/how-to-build-with-ddn/with-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 11
 sidebar_label: With Prometheus
 description: "Learn the basics of Hasura DDN and how to get started with Prometheus metrics."
 keywords:

--- a/docs/how-to-build-with-ddn/with-qdrant.mdx
+++ b/docs/how-to-build-with-ddn/with-qdrant.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 sidebar_label: With Qdrant
 description: "Learn the basics of Hasura DDN and how to get started with a Qdrant-hosted vector database."
 keywords:

--- a/docs/how-to-build-with-ddn/with-snowflake.mdx
+++ b/docs/how-to-build-with-ddn/with-snowflake.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 sidebar_label: With Snowflake
 description: "Learn the basics of Hasura DDN and how to get started with a Snowflake instance."
 keywords:

--- a/docs/how-to-build-with-ddn/with-storage.mdx
+++ b/docs/how-to-build-with-ddn/with-storage.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 sidebar_label: With Storage
 description: "Learn the basics of Hasura DDN and how to get started with various storage solutions."
 keywords:

--- a/docs/how-to-build-with-ddn/with-stripe.mdx
+++ b/docs/how-to-build-with-ddn/with-stripe.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 sidebar_label: With Stripe
 description: "Learn the basics of Hasura DDN and how to get started with a Stripe account."
 keywords:

--- a/docs/how-to-build-with-ddn/with-trino.mdx
+++ b/docs/how-to-build-with-ddn/with-trino.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 sidebar_label: With Trino
 description: "Learn the basics of Hasura DDN and how to get started with a Trino instance."
 keywords:

--- a/docs/how-to-build-with-ddn/with-turso.mdx
+++ b/docs/how-to-build-with-ddn/with-turso.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 sidebar_label: With Turso
 description: "Learn the basics of Hasura DDN and how to get started with a Turso-hosted database."
 keywords:

--- a/docs/reference/connectors/index.mdx
+++ b/docs/reference/connectors/index.mdx
@@ -32,6 +32,7 @@ If you're getting started with a connector and want to connect it to your data s
 - [MySQL](/reference/connectors/mysql/index.mdx)
 - [Oracle](/reference/connectors/oracle/index.mdx)
 - [PostgreSQL](/reference/connectors/postgresql/index.mdx)
+- [Prometheus](/reference/connectors/prometheus/index.mdx)
 - [Qdrant](/reference/connectors/qdrant/index.mdx)
 - [Snowflake](/reference/connectors/snowflake/index.mdx)
 - [Storage](/reference/connectors/storage/index.mdx)

--- a/docs/reference/connectors/prometheus/_category_.json
+++ b/docs/reference/connectors/prometheus/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Prometheus",
+  "position": 7
+}

--- a/docs/reference/connectors/prometheus/_category_.json
+++ b/docs/reference/connectors/prometheus/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Prometheus",
-  "position": 7
+  "position": 10
 }

--- a/docs/reference/connectors/prometheus/auth.mdx
+++ b/docs/reference/connectors/prometheus/auth.mdx
@@ -1,0 +1,68 @@
+---
+sidebar_position: 3
+sidebar_label: Authentication
+description: "Reference documentation for authentication for the Hasura Prometheus connector."
+keywords:
+  - prometheus
+  - auth
+---
+
+# Authentication Configuration
+
+## Introduction
+
+The connector supports a wide array of authentication strategies which you can adjust in the connector's
+`configuration.yaml` file.
+
+### Basic Authentication
+
+```yaml
+connection_settings:
+  authentication:
+    basic:
+      username:
+        env: PROMETHEUS_USERNAME
+      password:
+        env: PROMETHEUS_PASSWORD
+```
+
+### HTTP Authorization
+
+```yaml
+connection_settings:
+  authentication:
+    authorization:
+      type:
+        value: Bearer
+      credentials:
+        env: PROMETHEUS_AUTH_TOKEN
+```
+
+### OAuth2
+
+```yaml
+connection_settings:
+  authentication:
+    oauth2:
+      token_url:
+        value: http://example.com/oauth2/token
+      client_id:
+        env: PROMETHEUS_OAUTH2_CLIENT_ID
+      client_secret:
+        env: PROMETHEUS_OAUTH2_CLIENT_SECRET
+```
+
+### Google Cloud
+
+The configuration accepts either the Google application credentials JSON string or file path. If the object is empty the
+client automatically loads the credential file from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+
+```yaml
+connection_settings:
+  authentication:
+    google:
+      # credentials:
+      #   env: GOOGLE_APPLICATION_CREDENTIALS_JSON
+      # credentials_file:
+      #   env: GOOGLE_APPLICATION_CREDENTIALS
+```

--- a/docs/reference/connectors/prometheus/configuration.mdx
+++ b/docs/reference/connectors/prometheus/configuration.mdx
@@ -1,0 +1,189 @@
+---
+sidebar_position: 2
+sidebar_label: Configuration
+description: "Reference documentation for the setup process for the Hasura Prometheus connector."
+keywords:
+  - prometheus
+  - configuration
+---
+
+# Configuration Reference
+
+## Introduction
+
+The Prometheus connector gives you access to [time-series metrics](https://prometheus.io/docs/concepts/metric_types/)
+and [native APIs](https://prometheus.io/docs/prometheus/latest/querying/api/) on any running Prometheus server.
+
+## Schema
+
+As the schema for this connector is mapped to what Prometheus supports, the connector does not generate any local
+configuration files. Instead, when you introspect your data source,
+[this JSON schema](https://github.com/hasura/ndc-prometheus/blob/main/jsonschema/configuration.json) is used to generate
+a [`DataConnectorLink`](/reference/metadata-reference/data-connector-links.mdx) in your subgraph's metadata, complete
+with all the resources available via Prometheus.
+
+To explore this file, [try out the how-to guide for Prometheus](/how-to-build-with-ddn/with-prometheus.mdx) and — after
+introspecting — grep through the generated HML file for any metrics or API endpoints you desire.
+
+## How it works
+
+The connector can introspect and automatically transform available metrics on the Prometheus server to collection
+queries. Each metric has a common structure:
+
+```graphql
+{
+  <label_1>
+  <label_2>
+  # ...
+  timestamp
+  value
+  labels
+  values {
+    timestamp
+    value
+  }
+}
+```
+
+:::info Labels and metrics are introspected from the Prometheus server at the current time
+
+You need to introspect again whenever there are new labels or metrics.
+
+:::
+
+The configuration plugin introspects labels of each metric and defines them as collection columns that enable the
+ability of Hasura permissions and remote join. The connector supports basic comparison filters for labels.
+
+```graphql
+{
+  process_cpu_seconds_total(
+    where: {
+      timestamp: { _gt: "2024-09-24T10:00:00Z" }
+      job: {
+        _eq: "node"
+        _neq: "prometheus"
+        _in: ["node", "prometheus"]
+        _nin: ["ndc-prometheus"]
+        _regex: "prometheus.*"
+        _nregex: "foo.*"
+      }
+    }
+    args: { step: "5m", offset: "5m", timeout: "30s" }
+  ) {
+    job
+    instance
+    timestamp
+    value
+    values {
+      timestamp
+      value
+    }
+  }
+}
+```
+
+The connector can detect if you want to request an instant query or range query via the `timestamp` column:
+
+- `_eq`: instant query at the exact timestamp.
+- `_gt` < `_lt`: range query.
+
+The range query mode is default If none of the timestamp operators is set.
+
+The `timestamp` and `value` fields are the result of the instant query. If the request is a range query, `timestamp` and
+`value` are picked as the last item of the `values` series.
+
+### Common arguments
+
+- `step`: the query resolution step width in duration format or float number of seconds. The step should be explicitly
+  set for range queries. Even though the connector can estimate the approximate step width the result may be empty due
+  to too far interval.
+- `offset`: the offset modifier allows changing the time offset for individual instant and range vectors in a query.
+- `timeout`: the evaluation timeout of the request.
+- `fn`: the array of composable PromQL functions.
+- `flat`: flatten grouped values out of the root array. Use the runtime setting if the value is null.
+
+### Aggregation
+
+The `fn` argument is an array of [PromQL function](https://prometheus.io/docs/prometheus/latest/querying/functions/)
+parameters. You can set multiple functions that can be composed into the query. For example, with this PromQL query:
+
+```
+sum by (job) (rate(process_cpu_seconds_total[1m]))
+```
+
+The equivalent GraphQL query will be:
+
+```graphql
+{
+  process_cpu_seconds_total(
+    where: { timestamp: { _gt: "2024-09-24T10:00:00Z" } }
+    args: { step: "5m", fn: [{ rate: "5m" }, { sum: [job] }] }
+  ) {
+    job
+    timestamp
+    value
+    values {
+      timestamp
+      value
+    }
+  }
+}
+```
+
+## Prometheus APIs
+
+### Metadata APIs
+
+The following APIs are available.
+
+| Operation Name              | REST Prometheus API                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| prometheus_alertmanagers    | [/api/v1/alertmanagers](https://prometheus.io/docs/prometheus/latest/querying/api/#alertmanagers)                       |
+| prometheus_alerts           | [/api/v1/alerts](https://prometheus.io/docs/prometheus/latest/querying/api/#alerts)                                     |
+| prometheus_label_names      | [/api/v1/labels](https://prometheus.io/docs/prometheus/latest/querying/api/#getting-label-names)                        |
+| prometheus_label_values     | [/api/v1/label/\<label_name\>/values](https://prometheus.io/docs/prometheus/latest/querying/api/#querying-label-values) |
+| prometheus_rules            | [/api/v1/rules](https://prometheus.io/docs/prometheus/latest/querying/api/#rules)                                       |
+| prometheus_series           | [/api/v1/series](https://prometheus.io/docs/prometheus/latest/querying/api/#finding-series-by-label-matchers)           |
+| prometheus_targets          | [/api/v1/targets](https://prometheus.io/docs/prometheus/latest/querying/api/#targets)                                   |
+| prometheus_targets_metadata | [/api/v1/targets/metadata](https://prometheus.io/docs/prometheus/latest/querying/api/#querying-target-metadata)         |
+
+### Raw PromQL query
+
+Alternatively, you can execute a raw PromQL query directly. This API should only be used by the admin. The result
+contains labels and values only.
+
+```graphql
+{
+  promql_query(query: "process_cpu_seconds_total{job=\"node\"}", start: "2024-09-24T10:00:00Z", step: "5m") {
+    labels
+    values {
+      timestamp
+      value
+    }
+  }
+}
+```
+
+## Runtime settings
+
+```yaml
+runtime:
+  flat: false
+  unix_time_unit: s # enum: s, ms
+  format:
+    timestamp: rfc3339 # enum: rfc3339, unix
+    value: float64 # enum: string, float64
+```
+
+### Flatten values
+
+By default, values are grouped by the label set. If you want to flatten out the values array, set `flat=true`.
+
+### Unix timestamp's unit
+
+If you use integer values for duration and timestamp fields the connector will transform them with this Unix timestamp
+unit. Accept second (`s`) and millisecond (`ms`). The default unit is seconds.
+
+### Response format
+
+These settings specify the format of response timestamp and value.

--- a/docs/reference/connectors/prometheus/configuration.mdx
+++ b/docs/reference/connectors/prometheus/configuration.mdx
@@ -108,7 +108,7 @@ The `fn` argument is an array of [PromQL function](https://prometheus.io/docs/pr
 parameters. You can set multiple functions that can be composed into the query. For example, with this PromQL query:
 
 ```
-sum by (job) (rate(process_cpu_seconds_total[1m]))
+sum by (job) (rate(process_cpu_seconds_total[5m]))
 ```
 
 The equivalent GraphQL query will be:

--- a/docs/reference/connectors/prometheus/index.mdx
+++ b/docs/reference/connectors/prometheus/index.mdx
@@ -16,7 +16,7 @@ seoFrontMatterUpdated: false
 
 ## Introduction
 
-Hasura DDN includes a Native Data Connector for Prometheus. This connector allows you to time-series data about your
+Hasura DDN includes a Native Data Connector for Prometheus. This connector allows you to query time-series data about your
 applications while taking advantage of Hasura’s metadata-driven approach. Here, we’ll explore the key features of the
 Prometheus connector and walk through the configuration process within a Hasura DDN project.
 

--- a/docs/reference/connectors/prometheus/index.mdx
+++ b/docs/reference/connectors/prometheus/index.mdx
@@ -1,0 +1,25 @@
+---
+title: Prometheus
+sidebar_position: 1
+description:
+  "Learn how to configure the Prometheus connector and incorporate time-series data about your applications into your
+  supergraph API."
+sidebar_label: Prometheus
+keywords:
+  - prometheus
+  - configuration
+  - connector
+seoFrontMatterUpdated: false
+---
+
+# Prometheus
+
+## Introduction
+
+Hasura DDN includes a Native Data Connector for Prometheus. This connector allows you to time-series data about your
+applications while taking advantage of Hasura’s metadata-driven approach. Here, we’ll explore the key features of the
+Prometheus connector and walk through the configuration process within a Hasura DDN project.
+
+## Prometheus docs
+
+- [Connector configuration](/reference/connectors/prometheus/configuration.mdx)

--- a/docs/reference/connectors/prometheus/native-queries.mdx
+++ b/docs/reference/connectors/prometheus/native-queries.mdx
@@ -1,0 +1,56 @@
+---
+sidebar_position: 4
+sidebar_label: Native Queries
+description: "Reference documentation for the native queries for the Hasura Prometheus connector."
+keywords:
+  - prometheus
+  - native query
+---
+
+# Native Queries
+
+## Introduction
+
+When simple queries don't meet your need you can define native queries in the connector's `configuration.yaml` file with
+prepared variables with the `${<name>}` template. Native queries are defined as collections.
+
+```yaml
+metadata:
+  native_operations:
+    queries:
+      service_up:
+        query: up{job="${job}", instance="${instance}"}
+        labels:
+          instance: {}
+          job: {}
+        arguments:
+          instance:
+            type: String
+          job:
+            type: String
+```
+
+The native query is exposed as a read-only function with two required fields `job` and `instance`.
+
+```graphql
+{
+  service_up(
+    args: { step: "1m", job: "node", instance: "node-exporter:9100" }
+    where: { timestamp: { _gt: "2024-10-11T00:00:00Z" }, job: { _in: ["node"] } }
+  ) {
+    job
+    instance
+    values {
+      timestamp
+      value
+    }
+  }
+}
+```
+
+:::info Labels aren't automatically added.
+
+You need to define them manually. Additionally, label and value boolean expressions in `where` are used to filter
+results after the query is executed.
+
+:::

--- a/docs/reference/connectors/prometheus/native-queries.mdx
+++ b/docs/reference/connectors/prometheus/native-queries.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ## Introduction
 
-When simple queries don't meet your need you can define native queries in the connector's `configuration.yaml` file with
+When simple queries don't meet your needs you can define native queries in the connector's `configuration.yaml` file with
 prepared variables with the `${<name>}` template. Native queries are defined as collections.
 
 ```yaml

--- a/docs/reference/connectors/qdrant/_category_.json
+++ b/docs/reference/connectors/qdrant/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Qdrant",
-  "position": 10
+  "position": 11
 }

--- a/docs/reference/connectors/snowflake/_category_.json
+++ b/docs/reference/connectors/snowflake/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Snowflake",
-  "position": 11
+  "position": 12
 }

--- a/docs/reference/connectors/sqlserver/_category_.json
+++ b/docs/reference/connectors/sqlserver/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "SQL Server",
-  "position": 12
+  "position": 13
 }

--- a/docs/reference/connectors/sqlserver/_category_.json
+++ b/docs/reference/connectors/sqlserver/_category_.json
@@ -2,4 +2,3 @@
   "label": "SQL Server",
   "position": 11
 }
-

--- a/docs/reference/connectors/storage/_category_.json
+++ b/docs/reference/connectors/storage/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Storage",
-  "position": 13
+  "position": 14
 }

--- a/docs/reference/connectors/stripe/_category_.json
+++ b/docs/reference/connectors/stripe/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Stripe",
-  "position": 14
+  "position": 15
 }

--- a/docs/reference/connectors/trino/_category_.json
+++ b/docs/reference/connectors/trino/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Trino",
-  "position": 15
+  "position": 16
 }

--- a/docs/reference/connectors/trino/_category_.json
+++ b/docs/reference/connectors/trino/_category_.json
@@ -2,4 +2,3 @@
   "label": "Trino",
   "position": 14
 }
-

--- a/docs/reference/connectors/turso/_category_.json
+++ b/docs/reference/connectors/turso/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Turso",
-  "position": 16
+  "position": 17
 }


### PR DESCRIPTION
## Description 📝

Adds MVP docs for the Prometheus connector. The getting-started guide has been tested with a locally-running and self-scraping Prometheus server.

## Quick Links 🚀
- [How-to guide](https://robdominguez-doc-2519-write.v3-docs-eny.pages.dev/how-to-build-with-ddn/with-prometheus/)
- [Connect to a source](https://robdominguez-doc-2519-write.v3-docs-eny.pages.dev/data-sources/connect-to-a-source/#step-2-add-environment-variables)
- [Configuration reference](https://robdominguez-doc-2519-write.v3-docs-eny.pages.dev/reference/connectors/prometheus/)