### PR TITLE
Add a note clarifying remote relationships across subgraphs are not supported in permission filters

### DIFF
--- a/docs/auth/permissions/model-permissions.mdx
+++ b/docs/auth/permissions/model-permissions.mdx
@@ -33,6 +33,10 @@ This filter expression can reference
 - Relationship predicates
 - `null`
 
+:::info Remote Relationships in Permissions
+Remote relationships (relationships between different data connectors) across subgraphs are not supported in permission filters.
+:::
+
 To make a new `ModelPermission` or role available in your supergraph, after updating your metadata, you'll need to
 [create a new build](/reference/cli/commands/ddn_supergraph_build_local.mdx) using the CLI.
 


### PR DESCRIPTION
## Description 📝
This PR updates the documentation to clarify that remote relationships across subgraphs are not supported permission filters.
## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->