### PR TITLE
Reduce components to simplify UI

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -145,10 +145,6 @@ const config: Config = {
       apiKey: '10f3d9d2cd836eec903fcabbd6d50139',
       indexName: 'hasura',
     },
-    announcementBar: {
-      id: 'announcementBar-5', // Increment on change
-      content: `This is the documentation for Hasura DDN, the future of data delivery. <a target="_blank" rel="noopener noreferrer" href="https://hasura.io/docs/latest/index/">Click here for the Hasura v2.x docs</a>.`,
-    },
     navbar: {
       title: '',
       hideOnScroll: true,

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -12,7 +12,6 @@ import DocItemContent from '@theme/DocItem/Content';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import Unlisted from '@theme/Unlisted';
 import CustomFooter from '@site/src/components/CustomFooter';
-import HasuraBanner from '@site/src/components/HasuraBanner';
 import type { Props } from '@theme/DocItem/Layout';
 
 import styles from './styles.module.css';
@@ -57,7 +56,6 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
             <DocItemFooter />
           </article>
           <DocItemPaginator />
-          <HasuraBanner />
           <CustomFooter />
         </div>
       </div>

--- a/src/theme/DocRoot/Layout/index.js
+++ b/src/theme/DocRoot/Layout/index.js
@@ -6,9 +6,6 @@ import DocRootLayoutSidebar from '@theme/DocRoot/Layout/Sidebar';
 import DocRootLayoutMain from '@theme/DocRoot/Layout/Main';
 import styles from './styles.module.css';
 import useIsBrowser from '@docusaurus/useIsBrowser';
-import BrowserOnly from '@docusaurus/BrowserOnly';
-import { AiChatBot } from '@site/src/components/AiChatBot/AiChatBot';
-import fetchUser from '@theme/DocRoot/Layout/FetchUser';
 import posthog from 'posthog-js';
 import { initOpenReplay, startOpenReplayTracking } from '@site/src/components/OpenReplay/OpenReplay';
 

--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -11,8 +11,6 @@ import styles from './styles.module.css';
 // import { useColorMode } from '@docusaurus/theme-common';
 // import DocsLogoDark from '@site/static/img/docs-logo-dark.svg';
 import DocsLogoLight from '@site/static/img/docs-logo-light.svg';
-import BrowserOnly from '@docusaurus/BrowserOnly';
-import { AiChatBot } from '@site/src/components/AiChatBot/AiChatBot';
 
 function useNavbarItems() {
   // TODO temporary casting until ThemeConfig type is improved
@@ -48,7 +46,7 @@ function NavbarContentLayout({ left, right, searchBarItem }) {
           <SearchBar />
         </NavbarSearch>
       )}
-      <div className="navbar__items navbar__items--right">
+      {/* <div className="navbar__items navbar__items--right">
         {right}
         <a
           href="https://console.hasura.io/?pg=products&plcmt=header&cta=get_started&tech=default&utm_source=docsv3"
@@ -66,7 +64,7 @@ function NavbarContentLayout({ left, right, searchBarItem }) {
             />
           </svg>
         </a>
-      </div>
+      </div> */}
     </div>
   );
 }
@@ -103,9 +101,6 @@ export default function NavbarContent() {
         // TODO stop hardcoding items?
         // Ask the user to add the respective navbar items => more flexible
         <>
-          <a className="navbar__item navbar__link flex">
-            <BrowserOnly fallback={<div>Loading...</div>}>{() => <AiChatBot />}</BrowserOnly>
-          </a>
           <NavbarItems items={rightItems} />
         </>
       }


### PR DESCRIPTION
## Description 📝

- Reduce components to simplify UI
- Ditch the announcement banner @ top of screen
- Ditch the assistant
- Ditch the footer banner/CTA
- Simplify stylings for primary (Log in) (more styling changes in later issue)

## Quick Links 🚀

/

