### PR TITLE
Add note about correct `_in` operator array syntax

### DIFF
--- a/docs/graphql-api/queries/filters/comparison-operators.mdx
+++ b/docs/graphql-api/queries/filters/comparison-operators.mdx
@@ -472,6 +472,20 @@ Fetch a list of articles rated 1, 3 or 5:
 }`}
 />
 
+:::caution Using _in operator with multiple values
+When using the `_in` operator with multiple values in GraphiQL or your application code, always use proper array syntax with square brackets:
+```
+where: { rating: { _in: [1, 3, 5] } }   // CORRECT
+```
+
+Do not use comma-separated strings, as this will not work correctly:
+```
+where: { rating: { _in: "1, 3, 5" } }   // INCORRECT
+```
+
+While GraphiQL may sometimes auto-generate queries using the incorrect string format, these queries will not function properly when executed against the GraphQL server.
+:::
+
 ## Filter or check for null values (\_is_null)
 
 Checking for null values can be achieved using the `_is_null` operator.


### PR DESCRIPTION
## Description 📝

Added a caution note in the comparison operators documentation to clarify the correct syntax when using the `_in` operator with multiple values. This helps prevent a common mistake where users might use comma-separated strings instead of proper array syntax.

The note includes:
- Correct array syntax example
- Incorrect string syntax example
- Warning about GraphiQL auto-generated queries

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->