### PR TITLE
ddn, byoc: add external id config

### DIFF
--- a/docs/private-ddn/creating-a-data-plane/byoc.mdx
+++ b/docs/private-ddn/creating-a-data-plane/byoc.mdx
@@ -60,6 +60,9 @@ Parameters:
     Type: String
     Default: hasura-cloud
     Description: External ID for the trust relationship with Hasura Cloud
+    MinLength: 2
+    MaxLength: 1224
+    AllowedPattern: "[A-Za-z0-9+=,.@:\\/-]*"
 
 Resources:
   BootstrapRole:
@@ -315,6 +318,8 @@ Share the following with the Hasura team:
   - The external ID used in the trust relationship between your AWS account and Hasura's AWS account
   - This is the value you specified for the `ExternalId` parameter in the CloudFormation template
   - If not specified, the default value "hasura-cloud" will be used
+  - Must have a minimum of 2 characters and a maximum of 1,224 characters
+  - Must be alphanumeric without white space, but can include the following symbols: plus (+), equal (=), comma (,), period (.), at (@), colon (:), forward slash (/), and hyphen (-)
   - **Important**: Make sure to provide this value to the Hasura team if you've customized it
 - (Optional) Preferred Availability Zones
   - Use AZ IDs (e.g., use1-az1, use1-az2) instead of AZ names (us-east-1a, us-east-1b)

--- a/docs/private-ddn/creating-a-data-plane/byoc.mdx
+++ b/docs/private-ddn/creating-a-data-plane/byoc.mdx
@@ -55,6 +55,12 @@ The setup involves creating an IAM role in your AWS account that establishes a t
 
 <summary>cloudformation.yaml</summary>
 ```bash
+Parameters:
+  ExternalId:
+    Type: String
+    Default: hasura-cloud
+    Description: External ID for the trust relationship with Hasura Cloud
+
 Resources:
   BootstrapRole:
     Type: AWS::IAM::Role
@@ -69,7 +75,7 @@ Resources:
             Action: sts:AssumeRole
             Condition:
               StringEquals:
-                sts:ExternalId: hasura-cloud
+                sts:ExternalId: !Ref ExternalId
   BootstrapPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -262,7 +268,8 @@ Outputs:
      aws cloudformation create-stack \
        --stack-name hasura-cloud-byoc \
        --template-body file://cloudformation.yaml \
-       --capabilities CAPABILITY_NAMED_IAM
+       --capabilities CAPABILITY_NAMED_IAM \
+       --parameters ParameterKey=ExternalId,ParameterValue=hasura-cloud
 
      # Wait for creation to complete
      aws cloudformation wait stack-create-complete \
@@ -275,7 +282,8 @@ Outputs:
      aws cloudformation update-stack \
        --stack-name hasura-cloud-byoc \
        --template-body file://cloudformation.yaml \
-       --capabilities CAPABILITY_NAMED_IAM
+       --capabilities CAPABILITY_NAMED_IAM \
+       --parameters ParameterKey=ExternalId,ParameterValue=hasura-cloud
 
      # Wait for update to complete
      aws cloudformation wait stack-update-complete \
@@ -303,6 +311,11 @@ Share the following with the Hasura team:
 
 - (Required) Role ARN (From output above)
 - (Required) AWS Region
+- (Optional) External ID
+  - The external ID used in the trust relationship between your AWS account and Hasura's AWS account
+  - This is the value you specified for the `ExternalId` parameter in the CloudFormation template
+  - If not specified, the default value "hasura-cloud" will be used
+  - **Important**: Make sure to provide this value to the Hasura team if you've customized it
 - (Optional) Preferred Availability Zones
   - Use AZ IDs (e.g., use1-az1, use1-az2) instead of AZ names (us-east-1a, us-east-1b)
   - You can get the AZ IDs by running:


### PR DESCRIPTION
## Description 📝

This pull request updates the CloudFormation template and associated documentation for creating a data plane with Bring Your Own Cloud (BYOC) in Hasura. The changes introduce a parameterized `ExternalId` to enhance flexibility and clarify its usage.

### CloudFormation Template Enhancements:
* Added a new `ExternalId` parameter for specifying the external ID in the trust relationship. The parameter includes a default value of "hasura-cloud" and a description. (`docs/private-ddn/creating-a-data-plane/byoc.mdx`, [docs/private-ddn/creating-a-data-plane/byoc.mdxR58-R63](diffhunk://#diff-4e65397b3c1d1f1985ff681841ddc06fbe6766c099cc5f84f94a709b5c1d55deR58-R63))
* Updated the `sts:ExternalId` condition in the `BootstrapRole` trust relationship to reference the `ExternalId` parameter instead of a hardcoded value. (`docs/private-ddn/creating-a-data-plane/byoc.mdx`, [docs/private-ddn/creating-a-data-plane/byoc.mdxL72-R78](diffhunk://#diff-4e65397b3c1d1f1985ff681841ddc06fbe6766c099cc5f84f94a709b5c1d55deL72-R78))

### Documentation Updates:
* Updated the CloudFormation stack creation and update commands to include the `ExternalId` parameter. (`docs/private-ddn/creating-a-data-plane/byoc.mdx`, [[1]](diffhunk://#diff-4e65397b3c1d1f1985ff681841ddc06fbe6766c099cc5f84f94a709b5c1d55deL265-R272) [[2]](diffhunk://#diff-4e65397b3c1d1f1985ff681841ddc06fbe6766c099cc5f84f94a709b5c1d55deL278-R286)
* Added instructions in the "Share the following with the Hasura team" section to specify the `ExternalId` if customized, emphasizing its importance. (`docs/private-ddn/creating-a-data-plane/byoc.mdx`, [docs/private-ddn/creating-a-data-plane/byoc.mdxR314-R318](diffhunk://#diff-4e65397b3c1d1f1985ff681841ddc06fbe6766c099cc5f84f94a709b5c1d55deR314-R318))

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->