### PR TITLE
ddn: update byoc permission and support for vpc cidr (/16-/19)

### DIFF
--- a/docs/private-ddn/creating-a-data-plane/byoc.mdx
+++ b/docs/private-ddn/creating-a-data-plane/byoc.mdx
@@ -54,7 +54,7 @@ The setup involves creating an IAM role in your AWS account that establishes a t
 <details>
 
 <summary>cloudformation.yaml</summary>
-```bash
+```yaml
 Parameters:
   ExternalId:
     Type: String
@@ -175,12 +175,14 @@ Resources:
               - iam:CreateInstanceProfile
               - iam:CreatePolicy
               - iam:CreateRole
+              - iam:CreatePolicyVersion
               - iam:DeleteInstanceProfile
               - iam:DeleteOpenIDConnectProvider
               - iam:DeletePolicy
               - iam:DeleteRole
               - iam:DeleteServiceLinkedRole
               - iam:DetachRolePolicy
+              - iam:UpdateOpenIDConnectProviderThumbprint
               - iam:GetInstanceProfile
               - iam:GetOpenIDConnectProvider
               - iam:GetPolicy
@@ -331,7 +333,7 @@ Share the following with the Hasura team:
     --query "AvailabilityZones[?State=='available'] | [].{ZoneName: ZoneName, ZoneId: ZoneId}"
     ```
   - If you have specific zones which you'd like to use, please pass it along. Otherwise, Hasura will assign accordingly.
-- (Optional) VPC CIDR (/16 CIDR)
+- (Optional) VPC CIDR (/16-/19 CIDR)
   - If you have a specific CIDR in mind for the VPC setup, please pass it along. If not specified, Hasura will assign 10.0.0.0/16.
   - Note: If you are planning to use VPC Peering, this CIDR should not conflict with any networks on your side.
 - (Optional) Kubernetes Service CIDR (/16-20 CIDR)
@@ -426,7 +428,7 @@ Share the following with the Hasura team:
 - (Required) GCP Region
 - (Optional) Preferred Availability Zones
   - If you have specific zones which you'd like to use, please pass it along.  Otherwise, Hasura will assign accordingly.
-- (Optional) VPC CIDR (/16 CIDR)
+- (Optional) VPC CIDR (/16-/19 CIDR)
   - If you have a specific CIDR in mind for the VPC setup, please pass it along.  If not specified, Hasura will assign 10.0.0.0/16.
   - Note: If you are planning to use VPC Peering, this CIDR should not conflict with any networks on your side.
 

--- a/docs/private-ddn/creating-a-data-plane/dedicated.mdx
+++ b/docs/private-ddn/creating-a-data-plane/dedicated.mdx
@@ -197,7 +197,7 @@ Example output:
 Note: Replace `eastus` in the command with your desired region name.
 </details>
 
-- **VPC CIDR:** A /16 CIDR block that defines the IP address range for your Data Plane's Virtual Private Cloud (VPC). Default value: 10.0.0.0/16.
+- **VPC CIDR:** A /16-/19 CIDR block that defines the IP address range for your Data Plane's Virtual Private Cloud (VPC). Default value: 10.0.0.0/16.
 - **Kubernetes Service CIDR:** A /16-/20 CIDR block used for Kubernetes service cluster IP addresses in your Data Plane. This CIDR range is used internally by Kubernetes to assign IP addresses to services running in the cluster. Default value: 172.20.0.0/16.
 
 :::warning Important When choosing your VPC CIDR and Kubernetes Service CIDR:


### PR DESCRIPTION
## Description 📝

This pull request updates documentation in the `docs/private-ddn` directory to improve clarity and provide more accurate information about CIDR block ranges, IAM permissions, and YAML formatting.

### Documentation Updates:

#### CIDR Block Range Adjustments:
* Updated the optional VPC CIDR block range from `/16` to `/16-/19` in multiple sections of `byoc.mdx` and `dedicated.mdx` to provide more flexibility in IP address allocation. [[1]](diffhunk://#diff-4e65397b3c1d1f1985ff681841ddc06fbe6766c099cc5f84f94a709b5c1d55deL334-R336) [[2]](diffhunk://#diff-4e65397b3c1d1f1985ff681841ddc06fbe6766c099cc5f84f94a709b5c1d55deL429-R431) [[3]](diffhunk://#diff-b3858da8330bfc40c2b493b6b570a5f985d6f9a958c87d624a3bd544ca511a59L200-R200)

#### IAM Permissions:
* Added `iam:CreatePolicyVersion` and `iam:UpdateOpenIDConnectProviderThumbprint` permissions to the list of IAM actions required for creating a data plane.

#### Formatting Improvement:
* Changed the code block language from `bash` to `yaml` for the `cloudformation.yaml` example to ensure proper syntax highlighting.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->