### PR TITLE
CI: Add CanonicalUrl component

### DIFF
--- a/docs/reference/cli/commands/ddn.mdx
+++ b/docs/reference/cli/commands/ddn.mdx
@@ -2,6 +2,7 @@
 sidebar_label: ddn
 sidebar_position: 1
 description: DDN Command Line Interface using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_auth.mdx
+++ b/docs/reference/cli/commands/ddn_auth.mdx
@@ -2,6 +2,7 @@
 sidebar_label: ddn auth
 sidebar_position: 2
 description: Manage Hasura DDN CLI Auth using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_auth"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_auth_generate-promptql-secret-key.mdx
+++ b/docs/reference/cli/commands/ddn_auth_generate-promptql-secret-key.mdx
@@ -2,6 +2,7 @@
 sidebar_label: ddn auth generate-promptql-secret-key
 sidebar_position: 3
 description: Generates the project's PromptQL secret key and saves to global config using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_auth_generate-promptql-secret-key"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_auth_login.mdx
+++ b/docs/reference/cli/commands/ddn_auth_login.mdx
@@ -2,6 +2,7 @@
 sidebar_label: ddn auth login
 sidebar_position: 4
 description: Login to DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_auth_login"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_auth_logout.mdx
+++ b/docs/reference/cli/commands/ddn_auth_logout.mdx
@@ -2,6 +2,7 @@
 sidebar_label: ddn auth logout
 sidebar_position: 5
 description: Logout from DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_auth_logout"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_auth_print-access-token.mdx
+++ b/docs/reference/cli/commands/ddn_auth_print-access-token.mdx
@@ -2,6 +2,7 @@
 sidebar_label: ddn auth print-access-token
 sidebar_position: 6
 description: Prints the access token to STDOUT using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_auth_print-access-token"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_auth_print-promptql-secret-key.mdx
+++ b/docs/reference/cli/commands/ddn_auth_print-promptql-secret-key.mdx
@@ -2,6 +2,7 @@
 sidebar_label: ddn auth print-promptql-secret-key
 sidebar_position: 7
 description: Prints the project's PromptQL secret key to STDOUT using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_auth_print-promptql-secret-key"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod.mdx
+++ b/docs/reference/cli/commands/ddn_codemod.mdx
@@ -2,6 +2,7 @@
 sidebar_label: ddn codemod
 sidebar_position: 8
 description: Perform transformations on your Hasura project directory using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_configure-header-forwarding.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_configure-header-forwarding.mdx
@@ -2,6 +2,7 @@
 sidebar_label: ddn codemod configure-header-forwarding
 sidebar_position: 9
 description: Configure headers to be forwarded to your connector using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_configure-header-forwarding"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_fix-traces-env-var.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_fix-traces-env-var.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod fix-traces-env-var
-sidebar_position: 11
+sidebar_position: 10
 description: Fix env var used for configuring traces for connectors using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_fix-traces-env-var"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_rename-graphql-prefixes.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_rename-graphql-prefixes.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod rename-graphql-prefixes
-sidebar_position: 12
+sidebar_position: 11
 description: Rename GraphQL root field and type name prefixes in metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_rename-graphql-prefixes"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_upgrade-auth-config-to-v3.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_upgrade-auth-config-to-v3.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod upgrade-auth-config-to-v3
-sidebar_position: 13
+sidebar_position: 12
 description: Upgrade AuthConfig version from "v1"/"v2" to "v3" using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_upgrade-auth-config-to-v3"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_upgrade-context-v2-to-v3.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_upgrade-context-v2-to-v3.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod upgrade-context-v2-to-v3
-sidebar_position: 14
+sidebar_position: 13
 description: Upgrade project's context config from v2 to v3 using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_upgrade-context-v2-to-v3"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_upgrade-graphqlconfig-aggregate.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_upgrade-graphqlconfig-aggregate.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod upgrade-graphqlconfig-aggregate
-sidebar_position: 15
+sidebar_position: 14
 description: Upgrade GraphqlConfig to support aggregates using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_upgrade-graphqlconfig-aggregate"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_upgrade-graphqlconfig-subscriptions.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_upgrade-graphqlconfig-subscriptions.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod upgrade-graphqlconfig-subscriptions
-sidebar_position: 16
+sidebar_position: 15
 description: Upgrade GraphqlConfig to support subscriptions using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_upgrade-graphqlconfig-subscriptions"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_upgrade-model-v1-to-v2.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_upgrade-model-v1-to-v2.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod upgrade-model-v1-to-v2
-sidebar_position: 17
+sidebar_position: 16
 description: Upgrade model from "version" "v1" to "v2" in metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_upgrade-model-v1-to-v2"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_upgrade-object-boolean-expression-types.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_upgrade-object-boolean-expression-types.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod upgrade-object-boolean-expression-types
-sidebar_position: 18
+sidebar_position: 17
 description: Upgrade object boolean expression types metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_upgrade-object-boolean-expression-types"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_upgrade-project-config-v2-to-v3.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_upgrade-project-config-v2-to-v3.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod upgrade-project-config-v2-to-v3
-sidebar_position: 19
+sidebar_position: 18
 description: Upgrade project directory from version v2 to v3 using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_upgrade-project-config-v2-to-v3"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_codemod_upgrade-supergraph-config-v1-to-v2.mdx
+++ b/docs/reference/cli/commands/ddn_codemod_upgrade-supergraph-config-v1-to-v2.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn codemod upgrade-supergraph-config-v1-to-v2
-sidebar_position: 20
+sidebar_position: 19
 description: Upgrade all Supergraph config files at the root of the project directory from v1 to v2 using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_codemod_upgrade-supergraph-config-v1-to-v2"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_command.mdx
+++ b/docs/reference/cli/commands/ddn_command.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn command
-sidebar_position: 21
+sidebar_position: 20
 description: Perform Command-related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_command"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_command_add.mdx
+++ b/docs/reference/cli/commands/ddn_command_add.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn command add
-sidebar_position: 22
+sidebar_position: 21
 description: Add new Commands to the local metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_command_add"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_command_list.mdx
+++ b/docs/reference/cli/commands/ddn_command_list.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn command list
-sidebar_position: 23
+sidebar_position: 22
 description: Lists details about the functions/procedures of DataConnectorLink, and their corresponding Commands using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_command_list"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_command_remove.mdx
+++ b/docs/reference/cli/commands/ddn_command_remove.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn command remove
-sidebar_position: 24
+sidebar_position: 23
 description: Removes Commands (and related metadata) in the local metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_command_remove"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_command_show.mdx
+++ b/docs/reference/cli/commands/ddn_command_show.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn command show
-sidebar_position: 25
+sidebar_position: 24
 description: Show diff between the command and its corresponding ndc function/procedure using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_command_show"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_command_update.mdx
+++ b/docs/reference/cli/commands/ddn_command_update.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn command update
-sidebar_position: 26
+sidebar_position: 25
 description: Update Commands in the local metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_command_update"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector-link.mdx
+++ b/docs/reference/cli/commands/ddn_connector-link.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector-link
-sidebar_position: 43
+sidebar_position: 42
 description: Perform DataConnectorLink related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector-link"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector-link_add-resources.mdx
+++ b/docs/reference/cli/commands/ddn_connector-link_add-resources.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector-link add-resources
-sidebar_position: 45
+sidebar_position: 44
 description: Add all models, commands and relationships from a DataConnectorLink's schema using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector-link_add-resources"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector-link_add.mdx
+++ b/docs/reference/cli/commands/ddn_connector-link_add.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector-link add
-sidebar_position: 44
+sidebar_position: 43
 description: Add a new DataConnectorLink to a Subgraph using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector-link_add"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector-link_remove.mdx
+++ b/docs/reference/cli/commands/ddn_connector-link_remove.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector-link remove
-sidebar_position: 46
+sidebar_position: 45
 description: Remove a DataConnectorLink from a Subgraph using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector-link_remove"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector-link_show.mdx
+++ b/docs/reference/cli/commands/ddn_connector-link_show.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector-link show
-sidebar_position: 47
+sidebar_position: 46
 description: Show DataConnectorLink details using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector-link_show"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector-link_update.mdx
+++ b/docs/reference/cli/commands/ddn_connector-link_update.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector-link update
-sidebar_position: 48
+sidebar_position: 47
 description: Fetch NDC details from the Connector and update the DataConnectorLink using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector-link_update"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector.mdx
+++ b/docs/reference/cli/commands/ddn_connector.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector
-sidebar_position: 27
+sidebar_position: 26
 description: Perform Connector related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_build.mdx
+++ b/docs/reference/cli/commands/ddn_connector_build.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector build
-sidebar_position: 28
+sidebar_position: 27
 description: Perform ConnectorBuild-related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_build"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_build_create.mdx
+++ b/docs/reference/cli/commands/ddn_connector_build_create.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector build create
-sidebar_position: 29
+sidebar_position: 28
 description: Create a ConnectorBuild on Hasura DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_build_create"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_build_delete.mdx
+++ b/docs/reference/cli/commands/ddn_connector_build_delete.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector build delete
-sidebar_position: 30
+sidebar_position: 29
 description: Delete a ConnectorBuild from a Project using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_build_delete"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_build_get.mdx
+++ b/docs/reference/cli/commands/ddn_connector_build_get.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector build get
-sidebar_position: 31
+sidebar_position: 30
 description: List ConnectorBuilds or get details of a specific one from Hasura DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_build_get"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_build_logs.mdx
+++ b/docs/reference/cli/commands/ddn_connector_build_logs.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector build logs
-sidebar_position: 32
+sidebar_position: 31
 description: Get logs of a ConnectorBuild from Hasura DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_build_logs"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_env.mdx
+++ b/docs/reference/cli/commands/ddn_connector_env.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector env
-sidebar_position: 33
+sidebar_position: 32
 description: Manage environment variables for Connectors using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_env"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_env_add.mdx
+++ b/docs/reference/cli/commands/ddn_connector_env_add.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector env add
-sidebar_position: 34
+sidebar_position: 33
 description: Add environment variables and its corresponding mapping to a Connector using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_env_add"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_init.mdx
+++ b/docs/reference/cli/commands/ddn_connector_init.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector init
-sidebar_position: 35
+sidebar_position: 34
 description: Add a new Connector using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_init"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_introspect.mdx
+++ b/docs/reference/cli/commands/ddn_connector_introspect.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector introspect
-sidebar_position: 36
+sidebar_position: 35
 description: Introspect the Connector data source to update the Connector configuration using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_introspect"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_list.mdx
+++ b/docs/reference/cli/commands/ddn_connector_list.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector list
-sidebar_position: 37
+sidebar_position: 36
 description: List available versions of connectors using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_list"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_plugin.mdx
+++ b/docs/reference/cli/commands/ddn_connector_plugin.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector plugin
-sidebar_position: 38
+sidebar_position: 37
 description: Run a subcommand from a Connector plugin using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_plugin"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_remove.mdx
+++ b/docs/reference/cli/commands/ddn_connector_remove.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector remove
-sidebar_position: 39
+sidebar_position: 38
 description: Remove a Connector, its corresponding DataConnectorLink and all its associated metadata objects using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_remove"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_setenv.mdx
+++ b/docs/reference/cli/commands/ddn_connector_setenv.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector setenv
-sidebar_position: 40
+sidebar_position: 39
 description: Run specified command with environment variables set using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_setenv"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_show-resources.mdx
+++ b/docs/reference/cli/commands/ddn_connector_show-resources.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector show-resources
-sidebar_position: 41
+sidebar_position: 40
 description: Show resources of a Connector using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_show-resources"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_connector_upgrade.mdx
+++ b/docs/reference/cli/commands/ddn_connector_upgrade.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn connector upgrade
-sidebar_position: 42
+sidebar_position: 41
 description: Upgrade connector configuration using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_connector_upgrade"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_console.mdx
+++ b/docs/reference/cli/commands/ddn_console.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn console
-sidebar_position: 49
+sidebar_position: 48
 description: Open the DDN console using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_console"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_context.mdx
+++ b/docs/reference/cli/commands/ddn_context.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn context
-sidebar_position: 50
+sidebar_position: 49
 description: Perform context operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_context"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_context_create-context.mdx
+++ b/docs/reference/cli/commands/ddn_context_create-context.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn context create-context
-sidebar_position: 51
+sidebar_position: 50
 description: Create a new context using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_context_create-context"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_context_get-context.mdx
+++ b/docs/reference/cli/commands/ddn_context_get-context.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn context get-context
-sidebar_position: 53
+sidebar_position: 52
 description: List contexts or get details of a specific context using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_context_get-context"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_context_get-current-context.mdx
+++ b/docs/reference/cli/commands/ddn_context_get-current-context.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn context get-current-context
-sidebar_position: 54
+sidebar_position: 53
 description: Get name and contents of current context using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_context_get-current-context"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_context_get.mdx
+++ b/docs/reference/cli/commands/ddn_context_get.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn context get
-sidebar_position: 52
+sidebar_position: 51
 description: Get the value of a key in the context using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_context_get"
 keywords:
   - hasura
   - DDN
@@ -19,7 +20,7 @@ Get the value of a key in the context.
 Get the value of a key in the context
 
 ```bash
-ddn context get <key> (Allowed keys: project, supergraph, subgraph, localEnvFile, cloudEnvFile, selfHostedDataPlane, noBuildConnectors) [flags]
+ddn context get <key> (Allowed keys: cloudEnvFile, selfHostedDataPlane, noBuildConnectors, project, supergraph, subgraph, localEnvFile) [flags]
 ```
 
 ## Examples

--- a/docs/reference/cli/commands/ddn_context_set-current-context.mdx
+++ b/docs/reference/cli/commands/ddn_context_set-current-context.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn context set-current-context
-sidebar_position: 56
+sidebar_position: 55
 description: Set the current context using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_context_set-current-context"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_context_set.mdx
+++ b/docs/reference/cli/commands/ddn_context_set.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn context set
-sidebar_position: 55
+sidebar_position: 54
 description: Set the value of a key in the context using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_context_set"
 keywords:
   - hasura
   - DDN
@@ -19,7 +20,7 @@ Set the value of a key in the context.
 Set default value of keys to be used in DDN CLI commands.
 
 ```bash
-ddn context set <key> <value> (Allowed keys: noBuildConnectors, project, supergraph, subgraph, localEnvFile, cloudEnvFile, selfHostedDataPlane) [flags]
+ddn context set <key> <value> (Allowed keys: project, supergraph, subgraph, localEnvFile, cloudEnvFile, selfHostedDataPlane, noBuildConnectors) [flags]
 ```
 
 ## Examples

--- a/docs/reference/cli/commands/ddn_context_unset.mdx
+++ b/docs/reference/cli/commands/ddn_context_unset.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn context unset
-sidebar_position: 57
+sidebar_position: 56
 description: Unset the value of a key in the context using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_context_unset"
 keywords:
   - hasura
   - DDN
@@ -19,7 +20,7 @@ Unset the value of a key in the context.
 Unset the value of a key in the context
 
 ```bash
-ddn context unset <key> (Allowed keys: supergraph, subgraph, localEnvFile, cloudEnvFile, selfHostedDataPlane, noBuildConnectors, project) [flags]
+ddn context unset <key> (Allowed keys: localEnvFile, cloudEnvFile, selfHostedDataPlane, noBuildConnectors, project, supergraph, subgraph) [flags]
 ```
 
 ## Examples

--- a/docs/reference/cli/commands/ddn_doctor.mdx
+++ b/docs/reference/cli/commands/ddn_doctor.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn doctor
-sidebar_position: 59
+sidebar_position: 58
 description: Check if the dependencies of DDN CLI are present using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_doctor"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_model.mdx
+++ b/docs/reference/cli/commands/ddn_model.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn model
-sidebar_position: 63
+sidebar_position: 62
 description: Perform Model-related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_model"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_model_add.mdx
+++ b/docs/reference/cli/commands/ddn_model_add.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn model add
-sidebar_position: 64
+sidebar_position: 63
 description: Add new Models to the local metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_model_add"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_model_list.mdx
+++ b/docs/reference/cli/commands/ddn_model_list.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn model list
-sidebar_position: 65
+sidebar_position: 64
 description: Lists details about the collections of DataConnectorLink, and their corresponding Models using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_model_list"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_model_remove.mdx
+++ b/docs/reference/cli/commands/ddn_model_remove.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn model remove
-sidebar_position: 66
+sidebar_position: 65
 description: Removes Models (and related metadata) in the local metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_model_remove"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_model_show.mdx
+++ b/docs/reference/cli/commands/ddn_model_show.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn model show
-sidebar_position: 67
+sidebar_position: 66
 description: Show diff between the model and its corresponding ndc collection using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_model_show"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_model_update.mdx
+++ b/docs/reference/cli/commands/ddn_model_update.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn model update
-sidebar_position: 68
+sidebar_position: 67
 description: Update Models in the local metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_model_update"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_plugins.mdx
+++ b/docs/reference/cli/commands/ddn_plugins.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn plugins
-sidebar_position: 69
+sidebar_position: 68
 description: Manage plugins for the CLI using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_plugins"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_plugins_install.mdx
+++ b/docs/reference/cli/commands/ddn_plugins_install.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn plugins install
-sidebar_position: 70
+sidebar_position: 69
 description: Install a plugin from the index using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_plugins_install"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_plugins_list.mdx
+++ b/docs/reference/cli/commands/ddn_plugins_list.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn plugins list
-sidebar_position: 71
+sidebar_position: 70
 description: List all available plugins with index, versions and installation status using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_plugins_list"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_plugins_uninstall.mdx
+++ b/docs/reference/cli/commands/ddn_plugins_uninstall.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn plugins uninstall
-sidebar_position: 72
+sidebar_position: 71
 description: Uninstall a plugin using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_plugins_uninstall"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_plugins_upgrade.mdx
+++ b/docs/reference/cli/commands/ddn_plugins_upgrade.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn plugins upgrade
-sidebar_position: 73
+sidebar_position: 72
 description: Upgrade a plugin to a newer version using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_plugins_upgrade"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project.mdx
+++ b/docs/reference/cli/commands/ddn_project.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project
-sidebar_position: 74
+sidebar_position: 73
 description: Manage Hasura DDN Project using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_create.mdx
+++ b/docs/reference/cli/commands/ddn_project_create.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project create
-sidebar_position: 75
+sidebar_position: 74
 description: Create an empty Project on Hasura DDN. See 'ddn project init' to create a Project, create subgraphs, and configure the local directory to use the Project. using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_create"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_delete.mdx
+++ b/docs/reference/cli/commands/ddn_project_delete.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project delete
-sidebar_position: 76
+sidebar_position: 75
 description: Delete a Project on Hasura DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_delete"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_get.mdx
+++ b/docs/reference/cli/commands/ddn_project_get.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project get
-sidebar_position: 77
+sidebar_position: 76
 description: List Hasura DDN Projects or get details of a specific one using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_get"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_init.mdx
+++ b/docs/reference/cli/commands/ddn_project_init.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project init
-sidebar_position: 78
+sidebar_position: 77
 description: Configure the local directory to use a Hasura DDN project, creating a DDN project and subgraphs as necessary using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_init"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_set-api-access-mode.mdx
+++ b/docs/reference/cli/commands/ddn_project_set-api-access-mode.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project set-api-access-mode
-sidebar_position: 79
+sidebar_position: 78
 description: Set the API access mode for a Project on Hasura DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_set-api-access-mode"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_set-self-hosted-engine-url.mdx
+++ b/docs/reference/cli/commands/ddn_project_set-self-hosted-engine-url.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project set-self-hosted-engine-url
-sidebar_position: 80
+sidebar_position: 79
 description: Set the engine's URL for a project in a self hosted data plane. using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_set-self-hosted-engine-url"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_subgraph.mdx
+++ b/docs/reference/cli/commands/ddn_project_subgraph.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project subgraph
-sidebar_position: 81
+sidebar_position: 80
 description: Manage Subgraphs in a Hasura DDN Project using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_subgraph"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_subgraph_create.mdx
+++ b/docs/reference/cli/commands/ddn_project_subgraph_create.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project subgraph create
-sidebar_position: 82
+sidebar_position: 81
 description: Create a new Subgraph in a Hasura DDN Project using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_subgraph_create"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_subgraph_delete.mdx
+++ b/docs/reference/cli/commands/ddn_project_subgraph_delete.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project subgraph delete
-sidebar_position: 83
+sidebar_position: 82
 description: Delete a Subgraph from a Project using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_subgraph_delete"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_project_subgraph_get.mdx
+++ b/docs/reference/cli/commands/ddn_project_subgraph_get.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn project subgraph get
-sidebar_position: 84
+sidebar_position: 83
 description: List Subgraphs for a Hasura DDN Project or get details of a specific one using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_project_subgraph_get"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_relationship.mdx
+++ b/docs/reference/cli/commands/ddn_relationship.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn relationship
-sidebar_position: 85
+sidebar_position: 84
 description: Perform Relationship related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_relationship"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_relationship_add.mdx
+++ b/docs/reference/cli/commands/ddn_relationship_add.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn relationship add
-sidebar_position: 86
+sidebar_position: 85
 description: Adds Relationships from foreign keys on collection-name or targeting collection-name using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_relationship_add"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_relationship_list.mdx
+++ b/docs/reference/cli/commands/ddn_relationship_list.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn relationship list
-sidebar_position: 87
+sidebar_position: 86
 description: Lists Relationships for a given DataConnectorLink using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_relationship_list"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_run.mdx
+++ b/docs/reference/cli/commands/ddn_run.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn run
-sidebar_position: 88
+sidebar_position: 87
 description: Run specific script from project's context config using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_run"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_subgraph.mdx
+++ b/docs/reference/cli/commands/ddn_subgraph.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn subgraph
-sidebar_position: 89
+sidebar_position: 88
 description: Perform Subgraph-related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_subgraph"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_subgraph_add.mdx
+++ b/docs/reference/cli/commands/ddn_subgraph_add.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn subgraph add
-sidebar_position: 90
+sidebar_position: 89
 description: Add a Subgraph config file to Supergraph config file using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_subgraph_add"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_subgraph_build.mdx
+++ b/docs/reference/cli/commands/ddn_subgraph_build.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn subgraph build
-sidebar_position: 91
+sidebar_position: 90
 description: Perform SubgraphBuild-related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_subgraph_build"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_subgraph_build_apply.mdx
+++ b/docs/reference/cli/commands/ddn_subgraph_build_apply.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn subgraph build apply
-sidebar_position: 92
+sidebar_position: 91
 description: Apply a Subgraph build on Hasura DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_subgraph_build_apply"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_subgraph_build_create.mdx
+++ b/docs/reference/cli/commands/ddn_subgraph_build_create.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn subgraph build create
-sidebar_position: 93
+sidebar_position: 92
 description: Create a SubgraphBuild on Hasura DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_subgraph_build_create"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_subgraph_build_get.mdx
+++ b/docs/reference/cli/commands/ddn_subgraph_build_get.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn subgraph build get
-sidebar_position: 94
+sidebar_position: 93
 description: List SubgraphBuilds or get details of a specific one using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_subgraph_build_get"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_subgraph_delete.mdx
+++ b/docs/reference/cli/commands/ddn_subgraph_delete.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn subgraph delete
-sidebar_position: 95
+sidebar_position: 94
 description: Delete a Subgraph, its corresponding Connectors and all its associated metadata objects from local project metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_subgraph_delete"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_subgraph_init.mdx
+++ b/docs/reference/cli/commands/ddn_subgraph_init.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn subgraph init
-sidebar_position: 96
+sidebar_position: 95
 description: Initialize a new Subgraph in local metadata using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_subgraph_init"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph
-sidebar_position: 97
+sidebar_position: 96
 description: Perform Supergraph-related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_build.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_build.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph build
-sidebar_position: 98
+sidebar_position: 97
 description: Perform SupergraphBuild-related operations using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_build"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_build_apply.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_build_apply.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph build apply
-sidebar_position: 99
+sidebar_position: 98
 description: Apply a SupergraphBuild to its Project on Hasura DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_build_apply"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_build_create.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_build_create.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph build create
-sidebar_position: 100
+sidebar_position: 99
 description: Create a SupergraphBuild on Hasura DDN using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_build_create"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_build_delete.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_build_delete.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph build delete
-sidebar_position: 101
+sidebar_position: 100
 description: Delete a SupergraphBuild from a Project using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_build_delete"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_build_diff.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_build_diff.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph build diff
-sidebar_position: 102
+sidebar_position: 101
 description: See changes made to the GraphQL schema from one build version to another. using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_build_diff"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_build_export-descriptions.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_build_export-descriptions.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph build export-descriptions
-sidebar_position: 103
+sidebar_position: 102
 description: Export descriptions for a specific supergraph build using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_build_export-descriptions"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_build_get.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_build_get.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph build get
-sidebar_position: 104
+sidebar_position: 103
 description: List SupergraphBuilds or get details of a specific one using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_build_get"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_build_local.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_build_local.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph build local
-sidebar_position: 105
+sidebar_position: 104
 description: Build the Supergraph and generate assets to run the local Engine using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_build_local"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_build_set-self-hosted-engine-url.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_build_set-self-hosted-engine-url.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph build set-self-hosted-engine-url
-sidebar_position: 106
+sidebar_position: 105
 description: Set the engine's URL for a build for a project in a self hosted data plane. using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_build_set-self-hosted-engine-url"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_init.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_init.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph init
-sidebar_position: 107
+sidebar_position: 106
 description: Initialize a new Supergraph project directory using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_init"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/commands/ddn_supergraph_prune.mdx
+++ b/docs/reference/cli/commands/ddn_supergraph_prune.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_label: ddn supergraph prune
-sidebar_position: 108
+sidebar_position: 107
 description: Removes unused metadata of the Supergraph using the DDN CLI
+canonicalUrl: "https://promptql.io/docs/reference/cli/commands/ddn_supergraph_prune"
 keywords:
   - hasura
   - DDN

--- a/docs/reference/cli/index.mdx
+++ b/docs/reference/cli/index.mdx
@@ -16,6 +16,7 @@ keywords:
   - data source tunneling
 hide_table_of_contents: true
 seoFrontMatterUpdated: true
+canonicalUrl: "https://promptql.io/docs/reference/cli/"
 ---
 
 # Hasura CLI

--- a/docs/reference/cli/installation.mdx
+++ b/docs/reference/cli/installation.mdx
@@ -17,6 +17,7 @@ keywords:
   - hasura for linux
 seoFrontMatterUpdated: true
 toc_max_heading_level: 3
+canonicalUrl: "https://promptql.io/docs/reference/cli/installation/"
 ---
 
 import InstallTheCli from "@site/docs/_install-the-cli.mdx";

--- a/docs/reference/metadata-reference/aggregate-expressions.mdx
+++ b/docs/reference/metadata-reference/aggregate-expressions.mdx
@@ -15,6 +15,7 @@ keywords:
   - aggregate
 toc_max_heading_level: 4
 seoFrontMatterUpdated: false
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/aggregate-expressions/"
 ---
 
 # Aggregate Expressions
@@ -158,18 +159,17 @@ definition:
 
 ## Metadata structure
 
-
 ### AggregateExpression {#aggregateexpression-aggregateexpression}
 
 Definition of an aggregate expression on an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `AggregateExpression` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [AggregateExpressionV1](#aggregateexpression-aggregateexpressionv1) | true | Definition of how to aggregate over a particular operand type |
+| Key          | Value                                                               | Required | Description                                                   |
+| ------------ | ------------------------------------------------------------------- | -------- | ------------------------------------------------------------- |
+| `kind`       | `AggregateExpression`                                               | true     |                                                               |
+| `version`    | `v1`                                                                | true     |                                                               |
+| `definition` | [AggregateExpressionV1](#aggregateexpression-aggregateexpressionv1) | true     | Definition of how to aggregate over a particular operand type |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: AggregateExpression
@@ -187,244 +187,198 @@ definition:
   description: Aggregate over Invoices
 ```
 
-
 #### AggregateExpressionV1 {#aggregateexpression-aggregateexpressionv1}
 
 Definition of how to aggregate over a particular operand type
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [AggregateExpressionName](#aggregateexpression-aggregateexpressionname) | true | The name of the aggregate expression. |
-| `operand` | [AggregateOperand](#aggregateexpression-aggregateoperand) | true | The type this aggregation expression aggregates over, and its associated configuration |
-| `count` | [AggregateCountDefinition](#aggregateexpression-aggregatecountdefinition) / null | false | Configuration for the count aggregate function used over the operand |
-| `countDistinct` | [AggregateCountDefinition](#aggregateexpression-aggregatecountdefinition) / null | false | Configuration for the count distinct aggregate function used over the operand |
-| `graphql` | [AggregateExpressionGraphQlDefinition](#aggregateexpression-aggregateexpressiongraphqldefinition) / null | false | Configuration for how this command should appear in the GraphQL schema. |
-| `description` | string / null | false | The description of the aggregate expression. Gets added to the description of the command's root field in the GraphQL schema. |
-
-
+| Key             | Value                                                                                                    | Required | Description                                                                                                                   |
+| --------------- | -------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `name`          | [AggregateExpressionName](#aggregateexpression-aggregateexpressionname)                                  | true     | The name of the aggregate expression.                                                                                         |
+| `operand`       | [AggregateOperand](#aggregateexpression-aggregateoperand)                                                | true     | The type this aggregation expression aggregates over, and its associated configuration                                        |
+| `count`         | [AggregateCountDefinition](#aggregateexpression-aggregatecountdefinition) / null                         | false    | Configuration for the count aggregate function used over the operand                                                          |
+| `countDistinct` | [AggregateCountDefinition](#aggregateexpression-aggregatecountdefinition) / null                         | false    | Configuration for the count distinct aggregate function used over the operand                                                 |
+| `graphql`       | [AggregateExpressionGraphQlDefinition](#aggregateexpression-aggregateexpressiongraphqldefinition) / null | false    | Configuration for how this command should appear in the GraphQL schema.                                                       |
+| `description`   | string / null                                                                                            | false    | The description of the aggregate expression. Gets added to the description of the command's root field in the GraphQL schema. |
 
 #### AggregateExpressionGraphQlDefinition {#aggregateexpression-aggregateexpressiongraphqldefinition}
 
 The definition of how an aggregate expression should appear in the GraphQL API.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `selectTypeName` | [GraphQlTypeName](#aggregateexpression-graphqltypename) | true | The type name to use for the aggregate selection type |
-| `deprecated` | [Deprecated](#aggregateexpression-deprecated) / null | false | Whether this command root field is deprecated. If set, this will be added to the graphql schema as a deprecated field. |
+| Key              | Value                                                   | Required | Description                                                                                                            |
+| ---------------- | ------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `selectTypeName` | [GraphQlTypeName](#aggregateexpression-graphqltypename) | true     | The type name to use for the aggregate selection type                                                                  |
+| `deprecated`     | [Deprecated](#aggregateexpression-deprecated) / null    | false    | Whether this command root field is deprecated. If set, this will be added to the graphql schema as a deprecated field. |
 
- **Example:**
+**Example:**
 
 ```yaml
 selectTypeName: Invoice_aggregate_fields
 ```
 
-
 #### Deprecated {#aggregateexpression-deprecated}
 
-OpenDd configuration to indicate whether an object type field, relationship, model root field or command root field is deprecated.
+OpenDd configuration to indicate whether an object type field, relationship, model root field or command root field is
+deprecated.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `reason` | string / null | false | The reason for deprecation. |
-
-
+| Key      | Value         | Required | Description                 |
+| -------- | ------------- | -------- | --------------------------- |
+| `reason` | string / null | false    | The reason for deprecation. |
 
 #### GraphQlTypeName {#aggregateexpression-graphqltypename}
 
 The name of a GraphQL type.
 
-
 **Value:** string
-
 
 #### AggregateCountDefinition {#aggregateexpression-aggregatecountdefinition}
 
 Definition of a count aggregation function
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `enable` | boolean | true | Whether or not the aggregate function is available for use or not |
-| `description` | string / null | false | A description of the aggregation function. Gets added to the description of the field in the GraphQL schema. |
-| `returnType` | [TypeName](#aggregateexpression-typename) / null | false | The scalar type that the count aggregation function returns. Must be an integer type. If omitted, Int is used as the default. |
-
-
+| Key           | Value                                            | Required | Description                                                                                                                   |
+| ------------- | ------------------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `enable`      | boolean                                          | true     | Whether or not the aggregate function is available for use or not                                                             |
+| `description` | string / null                                    | false    | A description of the aggregation function. Gets added to the description of the field in the GraphQL schema.                  |
+| `returnType`  | [TypeName](#aggregateexpression-typename) / null | false    | The scalar type that the count aggregation function returns. Must be an integer type. If omitted, Int is used as the default. |
 
 #### AggregateOperand {#aggregateexpression-aggregateoperand}
 
 Definition of an aggregate expression's operand
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `object` | [ObjectAggregateOperand](#aggregateexpression-objectaggregateoperand) | false | Definition of an aggregate over an object-typed operand |
-| `scalar` | [ScalarAggregateOperand](#aggregateexpression-scalaraggregateoperand) | false | Definition of an aggregate over a scalar-typed operand |
-
-
+| Key      | Value                                                                 | Required | Description                                             |
+| -------- | --------------------------------------------------------------------- | -------- | ------------------------------------------------------- |
+| `object` | [ObjectAggregateOperand](#aggregateexpression-objectaggregateoperand) | false    | Definition of an aggregate over an object-typed operand |
+| `scalar` | [ScalarAggregateOperand](#aggregateexpression-scalaraggregateoperand) | false    | Definition of an aggregate over a scalar-typed operand  |
 
 #### ScalarAggregateOperand {#aggregateexpression-scalaraggregateoperand}
 
 Definition of an aggregate over a scalar-typed operand
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `aggregatedType` | [TypeName](#aggregateexpression-typename) | true | The name of the scalar type the aggregate expression is aggregating |
-| `aggregationFunctions` | [[AggregationFunctionDefinition](#aggregateexpression-aggregationfunctiondefinition)] | true | The aggregation functions that operate over the scalar type |
-| `dataConnectorAggregationFunctionMapping` | [[DataConnectorAggregationFunctionMapping](#aggregateexpression-dataconnectoraggregationfunctionmapping)] | true | Mapping of aggregation functions to corresponding aggregation functions in various data connectors |
-
-
+| Key                                       | Value                                                                                                     | Required | Description                                                                                        |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `aggregatedType`                          | [TypeName](#aggregateexpression-typename)                                                                 | true     | The name of the scalar type the aggregate expression is aggregating                                |
+| `aggregationFunctions`                    | [[AggregationFunctionDefinition](#aggregateexpression-aggregationfunctiondefinition)]                     | true     | The aggregation functions that operate over the scalar type                                        |
+| `dataConnectorAggregationFunctionMapping` | [[DataConnectorAggregationFunctionMapping](#aggregateexpression-dataconnectoraggregationfunctionmapping)] | true     | Mapping of aggregation functions to corresponding aggregation functions in various data connectors |
 
 #### DataConnectorAggregationFunctionMapping {#aggregateexpression-dataconnectoraggregationfunctionmapping}
 
 Definition of how to map an aggregate expression's aggregation functions to data connector aggregation functions.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `dataConnectorName` | [DataConnectorName](#aggregateexpression-dataconnectorname) | true | The data connector being mapped to |
-| `dataConnectorScalarType` | [DataConnectorScalarType](#aggregateexpression-dataconnectorscalartype) | true | The matching scalar type in the data connector for the operand scalar type |
-| `functionMapping` | [AggregationFunctionMappings](#aggregateexpression-aggregationfunctionmappings) | true | Mapping from Open DD aggregation function to data connector aggregation function |
-
-
+| Key                       | Value                                                                           | Required | Description                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `dataConnectorName`       | [DataConnectorName](#aggregateexpression-dataconnectorname)                     | true     | The data connector being mapped to                                               |
+| `dataConnectorScalarType` | [DataConnectorScalarType](#aggregateexpression-dataconnectorscalartype)         | true     | The matching scalar type in the data connector for the operand scalar type       |
+| `functionMapping`         | [AggregationFunctionMappings](#aggregateexpression-aggregationfunctionmappings) | true     | Mapping from Open DD aggregation function to data connector aggregation function |
 
 #### AggregationFunctionMappings {#aggregateexpression-aggregationfunctionmappings}
 
 Mapping of aggregation functions to their matching aggregation functions in the data connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [AggregateFunctionMapping](#aggregateexpression-aggregatefunctionmapping) | false | Definition of how to map the aggregation function to a function in the data connector |
-
-
+| Key           | Value                                                                     | Required | Description                                                                           |
+| ------------- | ------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------- |
+| `<customKey>` | [AggregateFunctionMapping](#aggregateexpression-aggregatefunctionmapping) | false    | Definition of how to map the aggregation function to a function in the data connector |
 
 #### AggregateFunctionMapping {#aggregateexpression-aggregatefunctionmapping}
 
 Definition of how to map the aggregation function to a function in the data connector
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [DataConnectorAggregationFunctionName](#aggregateexpression-dataconnectoraggregationfunctionname) | true | The name of the aggregation function in the data connector |
-
-
+| Key    | Value                                                                                             | Required | Description                                                |
+| ------ | ------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------- |
+| `name` | [DataConnectorAggregationFunctionName](#aggregateexpression-dataconnectoraggregationfunctionname) | true     | The name of the aggregation function in the data connector |
 
 #### DataConnectorAggregationFunctionName {#aggregateexpression-dataconnectoraggregationfunctionname}
 
 The name of an aggregation function in a data connector
 
-
 **Value:** string
-
 
 #### DataConnectorScalarType {#aggregateexpression-dataconnectorscalartype}
 
 The name of a scalar type in a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorName {#aggregateexpression-dataconnectorname}
 
 The name of a data connector.
 
-
 **Value:** string
-
 
 #### AggregationFunctionDefinition {#aggregateexpression-aggregationfunctiondefinition}
 
 Definition of an aggregation function
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [AggregationFunctionName](#aggregateexpression-aggregationfunctionname) | true | The name of the aggregation function |
-| `description` | string / null | false | A description of the aggregation function. Gets added to the description of the field in the GraphQL schema. |
-| `returnType` | [TypeReference](#aggregateexpression-typereference) | true |  |
-
-
+| Key           | Value                                                                   | Required | Description                                                                                                  |
+| ------------- | ----------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `name`        | [AggregationFunctionName](#aggregateexpression-aggregationfunctionname) | true     | The name of the aggregation function                                                                         |
+| `description` | string / null                                                           | false    | A description of the aggregation function. Gets added to the description of the field in the GraphQL schema. |
+| `returnType`  | [TypeReference](#aggregateexpression-typereference)                     | true     |                                                                                                              |
 
 #### TypeReference {#aggregateexpression-typereference}
 
-A reference to an Open DD type including nullable values and arrays.
-Suffix '!' to indicate a non-nullable reference, and wrap in '[]' to indicate an array.
-Eg: '[String!]!' is a non-nullable array of non-nullable strings.
-
+A reference to an Open DD type including nullable values and arrays. Suffix '!' to indicate a non-nullable reference,
+and wrap in '[]' to indicate an array. Eg: '[String!]!' is a non-nullable array of non-nullable strings.
 
 **Value:** string
-
 
 #### AggregationFunctionName {#aggregateexpression-aggregationfunctionname}
 
 The name of an aggregation function.
 
-
 **Value:** string
-
 
 #### TypeName {#aggregateexpression-typename}
 
 The name of the scalar type the aggregate expression is aggregating
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| [InbuiltType](#aggregateexpression-inbuilttype) | An inbuilt primitive OpenDD type. |
-| [CustomTypeName](#aggregateexpression-customtypename) |  |
-
-
+| Value                                                 | Description                       |
+| ----------------------------------------------------- | --------------------------------- |
+| [InbuiltType](#aggregateexpression-inbuilttype)       | An inbuilt primitive OpenDD type. |
+| [CustomTypeName](#aggregateexpression-customtypename) |                                   |
 
 #### InbuiltType {#aggregateexpression-inbuilttype}
 
 An inbuilt primitive OpenDD type.
 
-
 **Value:** `ID` / `Int` / `Float` / `Boolean` / `String`
-
 
 #### ObjectAggregateOperand {#aggregateexpression-objectaggregateoperand}
 
 Definition of an aggregate over an object-typed operand
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `aggregatedType` | [CustomTypeName](#aggregateexpression-customtypename) | true | The name of the object type the aggregate expression is aggregating |
-| `aggregatableFields` | [[AggregatableFieldDefinition](#aggregateexpression-aggregatablefielddefinition)] | true | The fields on the object that are aggregatable |
-
-
+| Key                  | Value                                                                             | Required | Description                                                         |
+| -------------------- | --------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------- |
+| `aggregatedType`     | [CustomTypeName](#aggregateexpression-customtypename)                             | true     | The name of the object type the aggregate expression is aggregating |
+| `aggregatableFields` | [[AggregatableFieldDefinition](#aggregateexpression-aggregatablefielddefinition)] | true     | The fields on the object that are aggregatable                      |
 
 #### AggregatableFieldDefinition {#aggregateexpression-aggregatablefielddefinition}
 
 Definition of an aggregatable field on an object type
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [FieldName](#aggregateexpression-fieldname) | true | The name of the field on the operand aggregated type that is aggregatable |
-| `description` | string / null | false | A description of the aggregatable field. Gets added to the description of the field in the GraphQL schema. |
-| `aggregateExpression` | [AggregateExpressionName](#aggregateexpression-aggregateexpressionname) | true | The aggregate expression used to aggregate the type of the field |
-
-
+| Key                   | Value                                                                   | Required | Description                                                                                                |
+| --------------------- | ----------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `fieldName`           | [FieldName](#aggregateexpression-fieldname)                             | true     | The name of the field on the operand aggregated type that is aggregatable                                  |
+| `description`         | string / null                                                           | false    | A description of the aggregatable field. Gets added to the description of the field in the GraphQL schema. |
+| `aggregateExpression` | [AggregateExpressionName](#aggregateexpression-aggregateexpressionname) | true     | The aggregate expression used to aggregate the type of the field                                           |
 
 #### FieldName {#aggregateexpression-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### CustomTypeName {#aggregateexpression-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
-
 
 #### AggregateExpressionName {#aggregateexpression-aggregateexpressionname}
 
 The name of an aggregate expression.
 
-
 **Value:** string
+

--- a/docs/reference/metadata-reference/auth-config.mdx
+++ b/docs/reference/metadata-reference/auth-config.mdx
@@ -4,6 +4,7 @@ description: "Configure the authentication configuration used by the API server 
 seoFrontMatterUpdated: true
 toc_max_heading_level: 4
 sidebar_position: 14
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/auth-config/"
 ---
 
 # AuthConfig
@@ -110,83 +111,70 @@ definition:
         headers:
           additional:
             user-agent: "Hasura DDN"
-
 ```
 
-| **Field** | **Description**                                                                                                                                                                       | **Reference**                                                          |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `url`     | The URL of the authentication webhook that will be called to validate authentication. This can be a static URL or an environment variable.                                            | [EnvironmentValue](#authconfig-environmentvalue)                       |
-| `method`  | The HTTP method (`GET` or `POST`) that will be used to make the request to the auth hook.                                                                                             | [AuthHookConfigV3](#authconfig-authhookconfigv3)                       |
+| **Field**             | **Description**                                                                                                                                                           | **Reference**                                                          |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `url`                 | The URL of the authentication webhook that will be called to validate authentication. This can be a static URL or an environment variable.                                | [EnvironmentValue](#authconfig-environmentvalue)                       |
+| `method`              | The HTTP method (`GET` or `POST`) that will be used to make the request to the auth hook.                                                                                 | [AuthHookConfigV3](#authconfig-authhookconfigv3)                       |
 | `customHeadersConfig` | Configuration for the headers and body to be sent to the auth hook. This can be used to forward headers from the client request or add additional headers to the request. | [AuthHookConfigV3POSTHeaders](#authconfig-authhookconfigv3postheaders) |
 
 ---
 
 ## Metadata structure
 
-
 #### AuthConfig {#authconfig-authconfig}
 
 Definition of the authentication configuration used by the API server.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
+| Value                                  | Description                                                                |
+| -------------------------------------- | -------------------------------------------------------------------------- |
 | [AuthConfig1](#authconfig-authconfig1) | Definition of the authentication configuration v1, used by the API server. |
 | [AuthConfig2](#authconfig-authconfig2) | Definition of the authentication configuration v2, used by the API server. |
-| [AuthConfig3](#authconfig-authconfig3) |  |
-
-
+| [AuthConfig3](#authconfig-authconfig3) |                                                                            |
 
 #### AuthConfig3 {#authconfig-authconfig3}
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `AuthConfig` | true |  |
-| `version` | `v3` | true |  |
-| `definition` | [AuthConfigV3](#authconfig-authconfigv3) | true | Definition of the authentication configuration v3, used by the API server. |
-
-
+| Key          | Value                                    | Required | Description                                                                |
+| ------------ | ---------------------------------------- | -------- | -------------------------------------------------------------------------- |
+| `kind`       | `AuthConfig`                             | true     |                                                                            |
+| `version`    | `v3`                                     | true     |                                                                            |
+| `definition` | [AuthConfigV3](#authconfig-authconfigv3) | true     | Definition of the authentication configuration v3, used by the API server. |
 
 #### AuthConfigV3 {#authconfig-authconfigv3}
 
 Definition of the authentication configuration v3, used by the API server.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `mode` | [AuthModeConfigV3](#authconfig-authmodeconfigv3) | true | The configuration for the authentication mode to use - webhook, JWT or NoAuth. |
-
-
+| Key    | Value                                            | Required | Description                                                                    |
+| ------ | ------------------------------------------------ | -------- | ------------------------------------------------------------------------------ |
+| `mode` | [AuthModeConfigV3](#authconfig-authmodeconfigv3) | true     | The configuration for the authentication mode to use - webhook, JWT or NoAuth. |
 
 #### AuthModeConfigV3 {#authconfig-authmodeconfigv3}
 
 The configuration for the authentication mode to use - webhook, JWT or NoAuth.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `webhook` | [AuthHookConfigV3](#authconfig-authhookconfigv3) | false | The configuration of the authentication webhook. |
-| `jwt` | [JWTConfig](#authconfig-jwtconfig) | false |  |
-| `noAuth` | [NoAuthConfig](#authconfig-noauthconfig) | false |  |
-
-
+| Key       | Value                                            | Required | Description                                      |
+| --------- | ------------------------------------------------ | -------- | ------------------------------------------------ |
+| `webhook` | [AuthHookConfigV3](#authconfig-authhookconfigv3) | false    | The configuration of the authentication webhook. |
+| `jwt`     | [JWTConfig](#authconfig-jwtconfig)               | false    |                                                  |
+| `noAuth`  | [NoAuthConfig](#authconfig-noauthconfig)         | false    |                                                  |
 
 #### AuthHookConfigV3 {#authconfig-authhookconfigv3}
 
 The configuration of the authentication webhook.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| [AuthHookConfigV3GET](#authconfig-authhookconfigv3get) | The configuration of the GET authentication webhook. |
+| Value                                                    | Description                                           |
+| -------------------------------------------------------- | ----------------------------------------------------- |
+| [AuthHookConfigV3GET](#authconfig-authhookconfigv3get)   | The configuration of the GET authentication webhook.  |
 | [AuthHookConfigV3POST](#authconfig-authhookconfigv3post) | The configuration of the POST authentication webhook. |
 
- **Example:**
+**Example:**
 
 ```yaml
 method: GET
@@ -200,25 +188,24 @@ customHeadersConfig:
       user-agent: hasura-ddn
 ```
 
-
 #### AuthHookConfigV3POST {#authconfig-authhookconfigv3post}
 
 The configuration of the POST authentication webhook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `method` | `POST` | true |  |
-| `url` | [EnvironmentValue](#authconfig-environmentvalue) | true | The URL of the POST authentication webhook. |
-| `customHeadersConfig` | [AuthHookConfigV3POSTHeaders](#authconfig-authhookconfigv3postheaders) / null | false | The configuration for the headers to be sent to the POST auth hook. |
+| Key                   | Value                                                                         | Required | Description                                                         |
+| --------------------- | ----------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------- |
+| `method`              | `POST`                                                                        | true     |                                                                     |
+| `url`                 | [EnvironmentValue](#authconfig-environmentvalue)                              | true     | The URL of the POST authentication webhook.                         |
+| `customHeadersConfig` | [AuthHookConfigV3POSTHeaders](#authconfig-authhookconfigv3postheaders) / null | false    | The configuration for the headers to be sent to the POST auth hook. |
 
- **Example:**
+**Example:**
 
 ```yaml
 url:
   value: http://auth_hook:3050/validate-request
 customHeadersConfig:
   headers:
-    forward: '*'
+    forward: "*"
     additional:
       user-agent: hasura-ddn
   body:
@@ -228,21 +215,20 @@ customHeadersConfig:
       additional: {}
 ```
 
-
 #### AuthHookConfigV3POSTHeaders {#authconfig-authhookconfigv3postheaders}
 
 The configuration for the headers and body to be sent to the POST auth hook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `headers` | [AuthHookConfigV3Headers](#authconfig-authhookconfigv3headers) / null | false | The configuration for the headers to be sent to the POST auth hook. |
-| `body` | [AuthHookConfigV3Body](#authconfig-authhookconfigv3body) / null | false | The configuration for the body to be sent to the POST auth hook. |
+| Key       | Value                                                                 | Required | Description                                                         |
+| --------- | --------------------------------------------------------------------- | -------- | ------------------------------------------------------------------- |
+| `headers` | [AuthHookConfigV3Headers](#authconfig-authhookconfigv3headers) / null | false    | The configuration for the headers to be sent to the POST auth hook. |
+| `body`    | [AuthHookConfigV3Body](#authconfig-authhookconfigv3body) / null       | false    | The configuration for the body to be sent to the POST auth hook.    |
 
- **Example:**
+**Example:**
 
 ```yaml
 headers:
-  forward: '*'
+  forward: "*"
   additional:
     user-agent: hasura-ddn
 body:
@@ -252,16 +238,15 @@ body:
     additional: {}
 ```
 
-
 #### AuthHookConfigV3Body {#authconfig-authhookconfigv3body}
 
 The configuration for the body to be sent to the POST auth hook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `headers` | [AuthHookConfigV3Headers](#authconfig-authhookconfigv3headers) / null | false | The configuration for the headers to be sent as part of the body to the POST auth hook. |
+| Key       | Value                                                                 | Required | Description                                                                             |
+| --------- | --------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `headers` | [AuthHookConfigV3Headers](#authconfig-authhookconfigv3headers) / null | false    | The configuration for the headers to be sent as part of the body to the POST auth hook. |
 
- **Example:**
+**Example:**
 
 ```yaml
 headers:
@@ -270,18 +255,17 @@ headers:
   additional: {}
 ```
 
-
 #### AuthHookConfigV3GET {#authconfig-authhookconfigv3get}
 
 The configuration of the GET authentication webhook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `method` | `GET` | true |  |
-| `url` | [EnvironmentValue](#authconfig-environmentvalue) | true | The URL of the GET authentication webhook. |
-| `customHeadersConfig` | [AuthHookConfigV3GETHeaders](#authconfig-authhookconfigv3getheaders) / null | false | The configuration for the headers to be sent to the GET auth hook. |
+| Key                   | Value                                                                       | Required | Description                                                        |
+| --------------------- | --------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------ |
+| `method`              | `GET`                                                                       | true     |                                                                    |
+| `url`                 | [EnvironmentValue](#authconfig-environmentvalue)                            | true     | The URL of the GET authentication webhook.                         |
+| `customHeadersConfig` | [AuthHookConfigV3GETHeaders](#authconfig-authhookconfigv3getheaders) / null | false    | The configuration for the headers to be sent to the GET auth hook. |
 
- **Example:**
+**Example:**
 
 ```yaml
 url:
@@ -294,16 +278,15 @@ customHeadersConfig:
       user-agent: hasura-ddn
 ```
 
-
 #### AuthHookConfigV3GETHeaders {#authconfig-authhookconfigv3getheaders}
 
 The configuration for the headers to be sent to the GET auth hook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `headers` | [AuthHookConfigV3Headers](#authconfig-authhookconfigv3headers) / null | false |  |
+| Key       | Value                                                                 | Required | Description |
+| --------- | --------------------------------------------------------------------- | -------- | ----------- |
+| `headers` | [AuthHookConfigV3Headers](#authconfig-authhookconfigv3headers) / null | false    |             |
 
- **Example:**
+**Example:**
 
 ```yaml
 headers:
@@ -313,17 +296,16 @@ headers:
     user-agent: hasura-ddn
 ```
 
-
 #### AuthHookConfigV3Headers {#authconfig-authhookconfigv3headers}
 
 The configuration for the headers to be sent to the auth hook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `forward` | [AllOrList](#authconfig-allorlist) | false | The headers to be forwarded from the client request. |
-| `additional` | [AdditionalHeaders](#authconfig-additionalheaders) | false | The additional headers to be sent to the auth hook. |
+| Key          | Value                                              | Required | Description                                          |
+| ------------ | -------------------------------------------------- | -------- | ---------------------------------------------------- |
+| `forward`    | [AllOrList](#authconfig-allorlist)                 | false    | The headers to be forwarded from the client request. |
+| `additional` | [AdditionalHeaders](#authconfig-additionalheaders) | false    | The additional headers to be sent to the auth hook.  |
 
- **Example:**
+**Example:**
 
 ```yaml
 forward:
@@ -332,146 +314,125 @@ additional:
   user-agent: hasura-ddn
 ```
 
-
 #### AdditionalHeaders {#authconfig-additionalheaders}
 
 The additional headers to be sent to the auth hook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | string | false |  |
-
-
+| Key           | Value  | Required | Description |
+| ------------- | ------ | -------- | ----------- |
+| `<customKey>` | string | false    |             |
 
 #### AllOrList {#authconfig-allorlist}
 
 A list of items or a wildcard.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
+| Value                  | Description               |
+| ---------------------- | ------------------------- |
 | [All](#authconfig-all) | Wildcard: match all items |
-| [string] |  |
+| [string]               |                           |
 
- **Example:**
+**Example:**
 
 ```yaml
-'*'
+"*"
 ```
-
 
 #### All {#authconfig-all}
 
 Wildcard: match all items
 
-
 **Value:** `*`
-
 
 #### AuthConfig2 {#authconfig-authconfig2}
 
 Definition of the authentication configuration v2, used by the API server.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `AuthConfig` | true |  |
-| `version` | `v2` | true |  |
-| `definition` | [AuthConfigV2](#authconfig-authconfigv2) | true | Definition of the authentication configuration v2, used by the API server. |
-
-
+| Key          | Value                                    | Required | Description                                                                |
+| ------------ | ---------------------------------------- | -------- | -------------------------------------------------------------------------- |
+| `kind`       | `AuthConfig`                             | true     |                                                                            |
+| `version`    | `v2`                                     | true     |                                                                            |
+| `definition` | [AuthConfigV2](#authconfig-authconfigv2) | true     | Definition of the authentication configuration v2, used by the API server. |
 
 #### AuthConfigV2 {#authconfig-authconfigv2}
 
 Definition of the authentication configuration v2, used by the API server.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `mode` | [AuthModeConfig](#authconfig-authmodeconfig) | true |  |
-
-
+| Key    | Value                                        | Required | Description |
+| ------ | -------------------------------------------- | -------- | ----------- |
+| `mode` | [AuthModeConfig](#authconfig-authmodeconfig) | true     |             |
 
 #### AuthConfig1 {#authconfig-authconfig1}
 
 Definition of the authentication configuration v1, used by the API server.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `AuthConfig` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [AuthConfigV1](#authconfig-authconfigv1) | true | Definition of the authentication configuration v1, used by the API server. |
-
-
+| Key          | Value                                    | Required | Description                                                                |
+| ------------ | ---------------------------------------- | -------- | -------------------------------------------------------------------------- |
+| `kind`       | `AuthConfig`                             | true     |                                                                            |
+| `version`    | `v1`                                     | true     |                                                                            |
+| `definition` | [AuthConfigV1](#authconfig-authconfigv1) | true     | Definition of the authentication configuration v1, used by the API server. |
 
 #### AuthConfigV1 {#authconfig-authconfigv1}
 
 Definition of the authentication configuration v1, used by the API server.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `allowRoleEmulationBy` | [Role](#authconfig-role) / null | false |  |
-| `mode` | [AuthModeConfig](#authconfig-authmodeconfig) | true | The configuration for the authentication mode to use - webhook, JWT or NoAuth. |
-
-
+| Key                    | Value                                        | Required | Description                                                                    |
+| ---------------------- | -------------------------------------------- | -------- | ------------------------------------------------------------------------------ |
+| `allowRoleEmulationBy` | [Role](#authconfig-role) / null              | false    |                                                                                |
+| `mode`                 | [AuthModeConfig](#authconfig-authmodeconfig) | true     | The configuration for the authentication mode to use - webhook, JWT or NoAuth. |
 
 #### AuthModeConfig {#authconfig-authmodeconfig}
 
 The configuration for the authentication mode to use - webhook, JWT or NoAuth.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `webhook` | [AuthHookConfig](#authconfig-authhookconfig) | false | The configuration of the authentication webhook. |
-| `jwt` | [JWTConfig](#authconfig-jwtconfig) | false | JWT config according to which the incoming JWT will be verified and decoded to extract the session variable claims. |
-| `noAuth` | [NoAuthConfig](#authconfig-noauthconfig) | false | Configuration used when running engine without authentication |
-
-
+| Key       | Value                                        | Required | Description                                                                                                         |
+| --------- | -------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `webhook` | [AuthHookConfig](#authconfig-authhookconfig) | false    | The configuration of the authentication webhook.                                                                    |
+| `jwt`     | [JWTConfig](#authconfig-jwtconfig)           | false    | JWT config according to which the incoming JWT will be verified and decoded to extract the session variable claims. |
+| `noAuth`  | [NoAuthConfig](#authconfig-noauthconfig)     | false    | Configuration used when running engine without authentication                                                       |
 
 #### NoAuthConfig {#authconfig-noauthconfig}
 
 Configuration used when running engine without authentication
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `role` | [Role](#authconfig-role) | true | role to assume whilst running the engine |
-| `sessionVariables` | [SessionVariables](#authconfig-sessionvariables) | true | static session variables to use whilst running the engine |
+| Key                | Value                                            | Required | Description                                               |
+| ------------------ | ------------------------------------------------ | -------- | --------------------------------------------------------- |
+| `role`             | [Role](#authconfig-role)                         | true     | role to assume whilst running the engine                  |
+| `sessionVariables` | [SessionVariables](#authconfig-sessionvariables) | true     | static session variables to use whilst running the engine |
 
- **Example:**
+**Example:**
 
 ```yaml
 role: admin
 sessionVariables:
-  x-hasura-user-id: '100'
+  x-hasura-user-id: "100"
 ```
-
 
 #### SessionVariables {#authconfig-sessionvariables}
 
 static session variables to use whilst running the engine
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` |  | false | JSON value of a session variable |
-
-
+| Key           | Value | Required | Description                      |
+| ------------- | ----- | -------- | -------------------------------- |
+| `<customKey>` |       | false    | JSON value of a session variable |
 
 #### JWTConfig {#authconfig-jwtconfig}
 
 JWT config according to which the incoming JWT will be verified and decoded to extract the session variable claims.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `audience` | [string] / null | false | Optional validation to check that the `aud` field is a member of the `audience` received, otherwise will throw error. |
-| `issuer` | string / null | false | Optional validation to check that the `iss` field is a member of the `iss` received, otherwise will throw error. |
-| `allowedSkew` | integer / null | false | Allowed leeway (in seconds) to the `exp` validation to account for clock skew. |
-| `claimsConfig` | [JWTClaimsConfig](#authconfig-jwtclaimsconfig) | true | Claims config. Either specified via `claims_mappings` or `claims_namespace_path` |
-| `tokenLocation` | [JWTTokenLocation](#authconfig-jwttokenlocation) | true | Source of the JWT authentication token. |
-| `key` | [JWTKey](#authconfig-jwtkey) | true | Mode according to which the JWT auth is configured. |
+| Key             | Value                                            | Required | Description                                                                                                           |
+| --------------- | ------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `audience`      | [string] / null                                  | false    | Optional validation to check that the `aud` field is a member of the `audience` received, otherwise will throw error. |
+| `issuer`        | string / null                                    | false    | Optional validation to check that the `iss` field is a member of the `iss` received, otherwise will throw error.      |
+| `allowedSkew`   | integer / null                                   | false    | Allowed leeway (in seconds) to the `exp` validation to account for clock skew.                                        |
+| `claimsConfig`  | [JWTClaimsConfig](#authconfig-jwtclaimsconfig)   | true     | Claims config. Either specified via `claims_mappings` or `claims_namespace_path`                                      |
+| `tokenLocation` | [JWTTokenLocation](#authconfig-jwttokenlocation) | true     | Source of the JWT authentication token.                                                                               |
+| `key`           | [JWTKey](#authconfig-jwtkey)                     | true     | Mode according to which the JWT auth is configured.                                                                   |
 
- **Example:**
+**Example:**
 
 ```yaml
 audience: null
@@ -490,219 +451,181 @@ key:
       value: token
 ```
 
-
 #### JWTKey {#authconfig-jwtkey}
 
 JWT key configuration according to which the incoming JWT will be decoded.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fixed` | [JWTKeyConfig](#authconfig-jwtkeyconfig) | false | JWT Secret config according to which the incoming JWT will be decoded. |
-| `jwkFromUrl` | string | false |  |
-
-
+| Key          | Value                                    | Required | Description                                                            |
+| ------------ | ---------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| `fixed`      | [JWTKeyConfig](#authconfig-jwtkeyconfig) | false    | JWT Secret config according to which the incoming JWT will be decoded. |
+| `jwkFromUrl` | string                                   | false    |                                                                        |
 
 #### JWTKeyConfig {#authconfig-jwtkeyconfig}
 
 JWT Secret config according to which the incoming JWT will be decoded.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `algorithm` | [JWTAlgorithm](#authconfig-jwtalgorithm) | true | The algorithm used to decode the JWT. |
-| `key` | [EnvironmentValue](#authconfig-environmentvalue) | true | The key to use for decoding the JWT. |
-
-
+| Key         | Value                                            | Required | Description                           |
+| ----------- | ------------------------------------------------ | -------- | ------------------------------------- |
+| `algorithm` | [JWTAlgorithm](#authconfig-jwtalgorithm)         | true     | The algorithm used to decode the JWT. |
+| `key`       | [EnvironmentValue](#authconfig-environmentvalue) | true     | The key to use for decoding the JWT.  |
 
 #### EnvironmentValue {#authconfig-environmentvalue}
 
 Either a literal string or a reference to a Hasura secret
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `value` | string | false |  |
-| `valueFromEnv` | string | false |  |
-
-
+| Key            | Value  | Required | Description |
+| -------------- | ------ | -------- | ----------- |
+| `value`        | string | false    |             |
+| `valueFromEnv` | string | false    |             |
 
 #### JWTAlgorithm {#authconfig-jwtalgorithm}
 
 The algorithm used to decode the JWT.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| `HS256` | HMAC using SHA-256 |
-| `HS384` | HMAC using SHA-384 |
-| `HS512` | HMAC using SHA-512 |
-| `ES256` | ECDSA using SHA-256 |
-| `ES384` | ECDSA using SHA-384 |
-| `RS256` | RSASSA-PKCS1-v1_5 using SHA-256 |
-| `RS384` | RSASSA-PKCS1-v1_5 using SHA-384 |
-| `RS512` | RSASSA-PKCS1-v1_5 using SHA-512 |
-| `PS256` | RSASSA-PSS using SHA-256 |
-| `PS384` | RSASSA-PSS using SHA-384 |
-| `PS512` | RSASSA-PSS using SHA-512 |
+| Value   | Description                                       |
+| ------- | ------------------------------------------------- |
+| `HS256` | HMAC using SHA-256                                |
+| `HS384` | HMAC using SHA-384                                |
+| `HS512` | HMAC using SHA-512                                |
+| `ES256` | ECDSA using SHA-256                               |
+| `ES384` | ECDSA using SHA-384                               |
+| `RS256` | RSASSA-PKCS1-v1_5 using SHA-256                   |
+| `RS384` | RSASSA-PKCS1-v1_5 using SHA-384                   |
+| `RS512` | RSASSA-PKCS1-v1_5 using SHA-512                   |
+| `PS256` | RSASSA-PSS using SHA-256                          |
+| `PS384` | RSASSA-PSS using SHA-384                          |
+| `PS512` | RSASSA-PSS using SHA-512                          |
 | `EdDSA` | Edwards-curve Digital Signature Algorithm (EdDSA) |
-
-
 
 #### JWTTokenLocation {#authconfig-jwttokenlocation}
 
 Source of the Authorization token
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| [JWTBearerAuthorizationLocation](#authconfig-jwtbearerauthorizationlocation) | Get the bearer token from the `Authorization` header. |
-| [JWTCookieLocation](#authconfig-jwtcookielocation) | Get the token from the Cookie header under the specified cookie name. |
-| [JWTHeaderLocation](#authconfig-jwtheaderlocation) | Custom header from where the header should be parsed from. |
-
-
+| Value                                                                        | Description                                                           |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [JWTBearerAuthorizationLocation](#authconfig-jwtbearerauthorizationlocation) | Get the bearer token from the `Authorization` header.                 |
+| [JWTCookieLocation](#authconfig-jwtcookielocation)                           | Get the token from the Cookie header under the specified cookie name. |
+| [JWTHeaderLocation](#authconfig-jwtheaderlocation)                           | Custom header from where the header should be parsed from.            |
 
 #### JWTHeaderLocation {#authconfig-jwtheaderlocation}
 
 Custom header from where the header should be parsed from.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `type` | `Header` | true |  |
-| `name` | string | true |  |
-
-
+| Key    | Value    | Required | Description |
+| ------ | -------- | -------- | ----------- |
+| `type` | `Header` | true     |             |
+| `name` | string   | true     |             |
 
 #### JWTCookieLocation {#authconfig-jwtcookielocation}
 
 Get the token from the Cookie header under the specified cookie name.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `type` | `Cookie` | true |  |
-| `name` | string | true |  |
-
-
+| Key    | Value    | Required | Description |
+| ------ | -------- | -------- | ----------- |
+| `type` | `Cookie` | true     |             |
+| `name` | string   | true     |             |
 
 #### JWTBearerAuthorizationLocation {#authconfig-jwtbearerauthorizationlocation}
 
 Get the bearer token from the `Authorization` header.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `type` | `BearerAuthorization` | true |  |
-
-
+| Key    | Value                 | Required | Description |
+| ------ | --------------------- | -------- | ----------- |
+| `type` | `BearerAuthorization` | true     |             |
 
 #### JWTClaimsConfig {#authconfig-jwtclaimsconfig}
 
 Config to describe how/where the engine should look for the claims within the decoded token.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `locations` | [JWTClaimsMap](#authconfig-jwtclaimsmap) | false | Can be used when Hasura claims are not all present in the single object, but individual claims are provided a JSON pointer within the decoded JWT and optionally a default value. |
-| `namespace` | [JWTClaimsNamespace](#authconfig-jwtclaimsnamespace) | false | Used when all of the Hasura claims are present in a single object within the decoded JWT. |
-
-
+| Key         | Value                                                | Required | Description                                                                                                                                                                       |
+| ----------- | ---------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `locations` | [JWTClaimsMap](#authconfig-jwtclaimsmap)             | false    | Can be used when Hasura claims are not all present in the single object, but individual claims are provided a JSON pointer within the decoded JWT and optionally a default value. |
+| `namespace` | [JWTClaimsNamespace](#authconfig-jwtclaimsnamespace) | false    | Used when all of the Hasura claims are present in a single object within the decoded JWT.                                                                                         |
 
 #### JWTClaimsNamespace {#authconfig-jwtclaimsnamespace}
 
 Used when all of the Hasura claims are present in a single object within the decoded JWT.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `claimsFormat` | [JWTClaimsFormat](#authconfig-jwtclaimsformat) | true | Format in which the Hasura claims will be present. |
-| `location` | string | true | Pointer to lookup the Hasura claims within the decoded claims. |
-
-
+| Key            | Value                                          | Required | Description                                                    |
+| -------------- | ---------------------------------------------- | -------- | -------------------------------------------------------------- |
+| `claimsFormat` | [JWTClaimsFormat](#authconfig-jwtclaimsformat) | true     | Format in which the Hasura claims will be present.             |
+| `location`     | string                                         | true     | Pointer to lookup the Hasura claims within the decoded claims. |
 
 #### JWTClaimsFormat {#authconfig-jwtclaimsformat}
 
 Format in which the Hasura claims will be present.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| `Json` | Claims will be in the JSON format. |
+| Value             | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| `Json`            | Claims will be in the JSON format.             |
 | `StringifiedJson` | Claims will be in the Stringified JSON format. |
-
-
 
 #### JWTClaimsMap {#authconfig-jwtclaimsmap}
 
-Can be used when Hasura claims are not all present in the single object, but individual claims are provided a JSON pointer within the decoded JWT and optionally a default value.
+Can be used when Hasura claims are not all present in the single object, but individual claims are provided a JSON
+pointer within the decoded JWT and optionally a default value.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `x-hasura-default-role` | [JWTClaimsMappingEntry](#authconfig-jwtclaimsmappingentry) | true | JSON pointer to lookup the default role within the decoded JWT. |
-| `x-hasura-allowed-roles` | [JWTClaimsMappingEntry](#authconfig-jwtclaimsmappingentry) | true | JSON pointer to lookup the allowed roles within the decoded JWT. |
-| `<customKey>` | [JWTClaimsMappingEntry](#authconfig-jwtclaimsmappingentry) | false |  |
-
-
+| Key                      | Value                                                      | Required | Description                                                      |
+| ------------------------ | ---------------------------------------------------------- | -------- | ---------------------------------------------------------------- |
+| `x-hasura-default-role`  | [JWTClaimsMappingEntry](#authconfig-jwtclaimsmappingentry) | true     | JSON pointer to lookup the default role within the decoded JWT.  |
+| `x-hasura-allowed-roles` | [JWTClaimsMappingEntry](#authconfig-jwtclaimsmappingentry) | true     | JSON pointer to lookup the allowed roles within the decoded JWT. |
+| `<customKey>`            | [JWTClaimsMappingEntry](#authconfig-jwtclaimsmappingentry) | false    |                                                                  |
 
 #### JWTClaimsMappingEntry {#authconfig-jwtclaimsmappingentry}
 
 JSON pointer to lookup the default role within the decoded JWT.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` | [Role](#authconfig-role) | false |  |
-| `path` | [JWTClaimsMappingPathEntry](#authconfig-jwtclaimsmappingpathentry) | false | Entry to lookup the Hasura claims at the specified JSON Pointer |
-
-
+| Key       | Value                                                              | Required | Description                                                     |
+| --------- | ------------------------------------------------------------------ | -------- | --------------------------------------------------------------- |
+| `literal` | [Role](#authconfig-role)                                           | false    |                                                                 |
+| `path`    | [JWTClaimsMappingPathEntry](#authconfig-jwtclaimsmappingpathentry) | false    | Entry to lookup the Hasura claims at the specified JSON Pointer |
 
 #### JWTClaimsMappingPathEntry {#authconfig-jwtclaimsmappingpathentry}
 
 Entry to lookup the Hasura claims at the specified JSON Pointer
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `path` | string | true | JSON pointer to find the particular claim in the decoded JWT token. |
-| `default` | [Role](#authconfig-role) / null | false | Default value to be used when no value is found when looking up the value using the `path`. |
-
-
+| Key       | Value                           | Required | Description                                                                                 |
+| --------- | ------------------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `path`    | string                          | true     | JSON pointer to find the particular claim in the decoded JWT token.                         |
+| `default` | [Role](#authconfig-role) / null | false    | Default value to be used when no value is found when looking up the value using the `path`. |
 
 #### AuthHookConfig {#authconfig-authhookconfig}
 
 The configuration of the authentication webhook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `url` | string | true | The URL of the authentication webhook. |
-| `method` | [AuthHookMethod](#authconfig-authhookmethod) | true | The HTTP method to be used to make the request to the auth hook. |
+| Key      | Value                                        | Required | Description                                                      |
+| -------- | -------------------------------------------- | -------- | ---------------------------------------------------------------- |
+| `url`    | string                                       | true     | The URL of the authentication webhook.                           |
+| `method` | [AuthHookMethod](#authconfig-authhookmethod) | true     | The HTTP method to be used to make the request to the auth hook. |
 
- **Example:**
+**Example:**
 
 ```yaml
 url: http://auth_hook:3050/validate-request
 method: Post
 ```
 
-
 #### AuthHookMethod {#authconfig-authhookmethod}
 
 The HTTP method to be used to make the request to the auth hook.
 
-
 **Value:** `Get` / `Post`
-
 
 #### Role {#authconfig-role}
 
-
 **Value:** string
+

--- a/docs/reference/metadata-reference/boolean-expressions.mdx
+++ b/docs/reference/metadata-reference/boolean-expressions.mdx
@@ -14,6 +14,7 @@ keywords:
   - boolean expressions
 toc_max_heading_level: 4
 seoFrontMatterUpdated: false
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/boolean-expressions/"
 ---
 
 # Boolean Expressions
@@ -137,18 +138,17 @@ The above would let us write filters on `Album` types like:
 
 ## Metadata structure
 
-
 ### BooleanExpressionType {#booleanexpressiontype-booleanexpressiontype}
 
 Definition of a type representing a boolean expression on an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `BooleanExpressionType` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [BooleanExpressionTypeV1](#booleanexpressiontype-booleanexpressiontypev1) | true | Definition of a type representing a boolean expression on an OpenDD object type. |
+| Key          | Value                                                                     | Required | Description                                                                      |
+| ------------ | ------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `kind`       | `BooleanExpressionType`                                                   | true     |                                                                                  |
+| `version`    | `v1`                                                                      | true     |                                                                                  |
+| `definition` | [BooleanExpressionTypeV1](#booleanexpressiontype-booleanexpressiontypev1) | true     | Definition of a type representing a boolean expression on an OpenDD object type. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: BooleanExpressionType
@@ -176,249 +176,202 @@ definition:
     typeName: App_Album_bool_exp
 ```
 
-
 #### BooleanExpressionTypeV1 {#booleanexpressiontype-booleanexpressiontypev1}
 
 Definition of a type representing a boolean expression on an OpenDD object type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [CustomTypeName](#booleanexpressiontype-customtypename) | true | The name to give this boolean expression type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph. |
-| `operand` | [BooleanExpressionOperand](#booleanexpressiontype-booleanexpressionoperand) | true | The type that this boolean expression applies to. |
-| `logicalOperators` | [BooleanExpressionLogicalOperators](#booleanexpressiontype-booleanexpressionlogicaloperators) | true | Whether to enable _and / _or / _not |
-| `isNull` | [BooleanExpressionIsNull](#booleanexpressiontype-booleanexpressionisnull) | true | Whether to enable _is_null |
-| `graphql` | [BooleanExpressionTypeGraphQlConfiguration](#booleanexpressiontype-booleanexpressiontypegraphqlconfiguration) / null | false | Configuration for how this object type should appear in the GraphQL schema. |
-
-
+| Key                | Value                                                                                                                | Required | Description                                                                                                                                             |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`             | [CustomTypeName](#booleanexpressiontype-customtypename)                                                              | true     | The name to give this boolean expression type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph. |
+| `operand`          | [BooleanExpressionOperand](#booleanexpressiontype-booleanexpressionoperand)                                          | true     | The type that this boolean expression applies to.                                                                                                       |
+| `logicalOperators` | [BooleanExpressionLogicalOperators](#booleanexpressiontype-booleanexpressionlogicaloperators)                        | true     | Whether to enable \_and / \_or / \_not                                                                                                                  |
+| `isNull`           | [BooleanExpressionIsNull](#booleanexpressiontype-booleanexpressionisnull)                                            | true     | Whether to enable \_is_null                                                                                                                             |
+| `graphql`          | [BooleanExpressionTypeGraphQlConfiguration](#booleanexpressiontype-booleanexpressiontypegraphqlconfiguration) / null | false    | Configuration for how this object type should appear in the GraphQL schema.                                                                             |
 
 #### BooleanExpressionTypeGraphQlConfiguration {#booleanexpressiontype-booleanexpressiontypegraphqlconfiguration}
 
 GraphQL configuration of an OpenDD boolean expression type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `typeName` | [GraphQlTypeName](#booleanexpressiontype-graphqltypename) | true | The name to use for the GraphQL type representation of this boolean expression type. |
-
-
+| Key        | Value                                                     | Required | Description                                                                          |
+| ---------- | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `typeName` | [GraphQlTypeName](#booleanexpressiontype-graphqltypename) | true     | The name to use for the GraphQL type representation of this boolean expression type. |
 
 #### GraphQlTypeName {#booleanexpressiontype-graphqltypename}
 
 The name of a GraphQL type.
 
-
 **Value:** string
-
 
 #### BooleanExpressionIsNull {#booleanexpressiontype-booleanexpressionisnull}
 
 Configuration for is_null in boolean expressions
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `enable` | boolean | true |  |
-
-
+| Key      | Value   | Required | Description |
+| -------- | ------- | -------- | ----------- |
+| `enable` | boolean | true     |             |
 
 #### BooleanExpressionLogicalOperators {#booleanexpressiontype-booleanexpressionlogicaloperators}
 
 Configuration for logical operators in boolean expressions
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `enable` | boolean | true |  |
-
-
+| Key      | Value   | Required | Description |
+| -------- | ------- | -------- | ----------- |
+| `enable` | boolean | true     |             |
 
 #### BooleanExpressionOperand {#booleanexpressiontype-booleanexpressionoperand}
 
 Configuration for object or scalar boolean expression
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `object` | [BooleanExpressionObjectOperand](#booleanexpressiontype-booleanexpressionobjectoperand) | false | Definition of an object type representing a boolean expression on an OpenDD object type. |
-| `scalar` | [BooleanExpressionScalarOperand](#booleanexpressiontype-booleanexpressionscalaroperand) | false | Definition of a scalar type representing a boolean expression on an OpenDD scalar type. |
-
-
+| Key      | Value                                                                                   | Required | Description                                                                              |
+| -------- | --------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------- |
+| `object` | [BooleanExpressionObjectOperand](#booleanexpressiontype-booleanexpressionobjectoperand) | false    | Definition of an object type representing a boolean expression on an OpenDD object type. |
+| `scalar` | [BooleanExpressionScalarOperand](#booleanexpressiontype-booleanexpressionscalaroperand) | false    | Definition of a scalar type representing a boolean expression on an OpenDD scalar type.  |
 
 #### BooleanExpressionScalarOperand {#booleanexpressiontype-booleanexpressionscalaroperand}
 
 Definition of a scalar type representing a boolean expression on an OpenDD scalar type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `type` | [TypeName](#booleanexpressiontype-typename) | true | The OpenDD type name of the scalar type that this boolean expression applies to. |
-| `comparisonOperators` | [[ComparisonOperator](#booleanexpressiontype-comparisonoperator)] | true | The list of comparison operators that can used on this scalar type |
-| `dataConnectorOperatorMapping` | [[DataConnectorOperatorMapping](#booleanexpressiontype-dataconnectoroperatormapping)] | true | The list of mappings between OpenDD operator names and the names used in the data connector schema |
-
-
+| Key                            | Value                                                                                 | Required | Description                                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `type`                         | [TypeName](#booleanexpressiontype-typename)                                           | true     | The OpenDD type name of the scalar type that this boolean expression applies to.                   |
+| `comparisonOperators`          | [[ComparisonOperator](#booleanexpressiontype-comparisonoperator)]                     | true     | The list of comparison operators that can used on this scalar type                                 |
+| `dataConnectorOperatorMapping` | [[DataConnectorOperatorMapping](#booleanexpressiontype-dataconnectoroperatormapping)] | true     | The list of mappings between OpenDD operator names and the names used in the data connector schema |
 
 #### DataConnectorOperatorMapping {#booleanexpressiontype-dataconnectoroperatormapping}
 
 Mapping between OpenDD operator names and the names used in the data connector schema
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `dataConnectorName` | [DataConnectorName](#booleanexpressiontype-dataconnectorname) | true | Name of the data connector this mapping applies to |
-| `dataConnectorScalarType` | [DataConnectorScalarType](#booleanexpressiontype-dataconnectorscalartype) | true | Name of the scalar type according to the data connector's schema |
-| `operatorMapping` | [operator_mapping](#booleanexpressiontype-operator_mapping) | true | Mapping between OpenDD operator names and the data connector's operator names Defaults to the same operator name (e.g. "_eq: _eq") if no explicit mapping is present. |
-
-
+| Key                       | Value                                                                     | Required | Description                                                                                                                                                             |
+| ------------------------- | ------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataConnectorName`       | [DataConnectorName](#booleanexpressiontype-dataconnectorname)             | true     | Name of the data connector this mapping applies to                                                                                                                      |
+| `dataConnectorScalarType` | [DataConnectorScalarType](#booleanexpressiontype-dataconnectorscalartype) | true     | Name of the scalar type according to the data connector's schema                                                                                                        |
+| `operatorMapping`         | [operator_mapping](#booleanexpressiontype-operator_mapping)               | true     | Mapping between OpenDD operator names and the data connector's operator names Defaults to the same operator name (e.g. "\_eq: \_eq") if no explicit mapping is present. |
 
 #### operator_mapping {#booleanexpressiontype-operator_mapping}
 
-Mapping between OpenDD operator names and the data connector's operator names Defaults to the same operator name (e.g. "_eq: _eq") if no explicit mapping is present.
+Mapping between OpenDD operator names and the data connector's operator names Defaults to the same operator name (e.g.
+"\_eq: \_eq") if no explicit mapping is present.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [DataConnectorOperatorName](#booleanexpressiontype-dataconnectoroperatorname) | false | The name of an operator in a data connector. |
-
-
+| Key           | Value                                                                         | Required | Description                                  |
+| ------------- | ----------------------------------------------------------------------------- | -------- | -------------------------------------------- |
+| `<customKey>` | [DataConnectorOperatorName](#booleanexpressiontype-dataconnectoroperatorname) | false    | The name of an operator in a data connector. |
 
 #### DataConnectorOperatorName {#booleanexpressiontype-dataconnectoroperatorname}
 
 The name of an operator in a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorScalarType {#booleanexpressiontype-dataconnectorscalartype}
 
 The name of a scalar type in a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorName {#booleanexpressiontype-dataconnectorname}
 
 The name of a data connector.
 
-
 **Value:** string
-
 
 #### ComparisonOperator {#booleanexpressiontype-comparisonoperator}
 
 Definition of a comparison operator for a scalar type
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [OperatorName](#booleanexpressiontype-operatorname) | true | Name you want to give the operator in OpenDD / GraphQL |
-| `argumentType` | [TypeReference](#booleanexpressiontype-typereference) | true | An OpenDD type |
-
-
+| Key            | Value                                                 | Required | Description                                            |
+| -------------- | ----------------------------------------------------- | -------- | ------------------------------------------------------ |
+| `name`         | [OperatorName](#booleanexpressiontype-operatorname)   | true     | Name you want to give the operator in OpenDD / GraphQL |
+| `argumentType` | [TypeReference](#booleanexpressiontype-typereference) | true     | An OpenDD type                                         |
 
 #### TypeReference {#booleanexpressiontype-typereference}
 
-A reference to an Open DD type including nullable values and arrays.
-Suffix '!' to indicate a non-nullable reference, and wrap in '[]' to indicate an array.
-Eg: '[String!]!' is a non-nullable array of non-nullable strings.
-
+A reference to an Open DD type including nullable values and arrays. Suffix '!' to indicate a non-nullable reference,
+and wrap in '[]' to indicate an array. Eg: '[String!]!' is a non-nullable array of non-nullable strings.
 
 **Value:** string
-
 
 #### OperatorName {#booleanexpressiontype-operatorname}
 
 The name of an operator
 
-
 **Value:** string
-
 
 #### TypeName {#booleanexpressiontype-typename}
 
 The OpenDD type name of the scalar type that this boolean expression applies to.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| [InbuiltType](#booleanexpressiontype-inbuilttype) | An inbuilt primitive OpenDD type. |
-| [CustomTypeName](#booleanexpressiontype-customtypename) |  |
-
-
+| Value                                                   | Description                       |
+| ------------------------------------------------------- | --------------------------------- |
+| [InbuiltType](#booleanexpressiontype-inbuilttype)       | An inbuilt primitive OpenDD type. |
+| [CustomTypeName](#booleanexpressiontype-customtypename) |                                   |
 
 #### InbuiltType {#booleanexpressiontype-inbuilttype}
 
 An inbuilt primitive OpenDD type.
 
-
 **Value:** `ID` / `Int` / `Float` / `Boolean` / `String`
-
 
 #### BooleanExpressionObjectOperand {#booleanexpressiontype-booleanexpressionobjectoperand}
 
 Definition of an object type representing a boolean expression on an OpenDD object type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `type` | [CustomTypeName](#booleanexpressiontype-customtypename) | true | The name of the object type that this boolean expression applies to. |
-| `comparableFields` | [[BooleanExpressionComparableField](#booleanexpressiontype-booleanexpressioncomparablefield)] | true | The list of fields of the object type that can be used for comparison when evaluating this boolean expression. |
-| `comparableRelationships` | [[BooleanExpressionComparableRelationship](#booleanexpressiontype-booleanexpressioncomparablerelationship)] | true | The list of relationships of the object type that can be used for comparison when evaluating this boolean expression. |
-
-
+| Key                       | Value                                                                                                       | Required | Description                                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `type`                    | [CustomTypeName](#booleanexpressiontype-customtypename)                                                     | true     | The name of the object type that this boolean expression applies to.                                                  |
+| `comparableFields`        | [[BooleanExpressionComparableField](#booleanexpressiontype-booleanexpressioncomparablefield)]               | true     | The list of fields of the object type that can be used for comparison when evaluating this boolean expression.        |
+| `comparableRelationships` | [[BooleanExpressionComparableRelationship](#booleanexpressiontype-booleanexpressioncomparablerelationship)] | true     | The list of relationships of the object type that can be used for comparison when evaluating this boolean expression. |
 
 #### BooleanExpressionComparableRelationship {#booleanexpressiontype-booleanexpressioncomparablerelationship}
 
 Definition of a relationship that can be used for a comparison
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `relationshipName` | [RelationshipName](#booleanexpressiontype-relationshipname) | true | The name of the relationship to use for comparison |
-| `booleanExpressionType` | [CustomTypeName](#booleanexpressiontype-customtypename) / null | false | The boolean expression type to use for comparison. This is optional for relationships to models, and defaults to the filterExpressionType of the model |
-
-
+| Key                     | Value                                                          | Required | Description                                                                                                                                            |
+| ----------------------- | -------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `relationshipName`      | [RelationshipName](#booleanexpressiontype-relationshipname)    | true     | The name of the relationship to use for comparison                                                                                                     |
+| `booleanExpressionType` | [CustomTypeName](#booleanexpressiontype-customtypename) / null | false    | The boolean expression type to use for comparison. This is optional for relationships to models, and defaults to the filterExpressionType of the model |
 
 #### RelationshipName {#booleanexpressiontype-relationshipname}
 
 The name of the GraphQL relationship field.
 
-
 **Value:** string
-
 
 #### BooleanExpressionComparableField {#booleanexpressiontype-booleanexpressioncomparablefield}
 
 Comparison configuration definition for a field that can be used for a comparison
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [FieldName](#booleanexpressiontype-fieldname) | true | The name of the field that can be compared. |
-| `booleanExpressionType` | [CustomTypeName](#booleanexpressiontype-customtypename) | true | The boolean expression type that can be used for comparison against the type of the field. |
-
-
+| Key                     | Value                                                   | Required | Description                                                                                |
+| ----------------------- | ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `fieldName`             | [FieldName](#booleanexpressiontype-fieldname)           | true     | The name of the field that can be compared.                                                |
+| `booleanExpressionType` | [CustomTypeName](#booleanexpressiontype-customtypename) | true     | The boolean expression type that can be used for comparison against the type of the field. |
 
 #### FieldName {#booleanexpressiontype-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### CustomTypeName {#booleanexpressiontype-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
+
 ### ObjectBooleanExpressionType {#objectbooleanexpressiontype-objectbooleanexpressiontype}
 
 Definition of a type representing a boolean expression on an Open DD object type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `ObjectBooleanExpressionType` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [ObjectBooleanExpressionTypeV1](#objectbooleanexpressiontype-objectbooleanexpressiontypev1) | true | Definition of a type representing a boolean expression on an Open DD object type. Deprecated in favour of `BooleanExpressionType`. |
+| Key          | Value                                                                                       | Required | Description                                                                                                                        |
+| ------------ | ------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `kind`       | `ObjectBooleanExpressionType`                                                               | true     |                                                                                                                                    |
+| `version`    | `v1`                                                                                        | true     |                                                                                                                                    |
+| `definition` | [ObjectBooleanExpressionTypeV1](#objectbooleanexpressiontype-objectbooleanexpressiontypev1) | true     | Definition of a type representing a boolean expression on an Open DD object type. Deprecated in favour of `BooleanExpressionType`. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: ObjectBooleanExpressionType
@@ -442,100 +395,81 @@ definition:
     typeName: Author_bool_exp
 ```
 
-
 #### ObjectBooleanExpressionTypeV1 {#objectbooleanexpressiontype-objectbooleanexpressiontypev1}
 
-Definition of a type representing a boolean expression on an Open DD object type. Deprecated in favour of `BooleanExpressionType`.
+Definition of a type representing a boolean expression on an Open DD object type. Deprecated in favour of
+`BooleanExpressionType`.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [CustomTypeName](#objectbooleanexpressiontype-customtypename) | true | The name to give this object boolean expression type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph. |
-| `objectType` | [CustomTypeName](#objectbooleanexpressiontype-customtypename) | true | The name of the object type that this boolean expression applies to. |
-| `dataConnectorName` | [DataConnectorName](#objectbooleanexpressiontype-dataconnectorname) | true | The data connector this boolean expression type is based on. |
-| `dataConnectorObjectType` | [DataConnectorObjectType](#objectbooleanexpressiontype-dataconnectorobjecttype) | true | The object type in the data connector's schema this boolean expression type is based on. |
-| `comparableFields` | [[ComparableField](#objectbooleanexpressiontype-comparablefield)] | true | The list of fields of the object type that can be used for comparison when evaluating this boolean expression. |
-| `graphql` | [ObjectBooleanExpressionTypeGraphQlConfiguration](#objectbooleanexpressiontype-objectbooleanexpressiontypegraphqlconfiguration) / null | false | Configuration for how this object type should appear in the GraphQL schema. |
-
-
+| Key                       | Value                                                                                                                                  | Required | Description                                                                                                                                                    |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                    | [CustomTypeName](#objectbooleanexpressiontype-customtypename)                                                                          | true     | The name to give this object boolean expression type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph. |
+| `objectType`              | [CustomTypeName](#objectbooleanexpressiontype-customtypename)                                                                          | true     | The name of the object type that this boolean expression applies to.                                                                                           |
+| `dataConnectorName`       | [DataConnectorName](#objectbooleanexpressiontype-dataconnectorname)                                                                    | true     | The data connector this boolean expression type is based on.                                                                                                   |
+| `dataConnectorObjectType` | [DataConnectorObjectType](#objectbooleanexpressiontype-dataconnectorobjecttype)                                                        | true     | The object type in the data connector's schema this boolean expression type is based on.                                                                       |
+| `comparableFields`        | [[ComparableField](#objectbooleanexpressiontype-comparablefield)]                                                                      | true     | The list of fields of the object type that can be used for comparison when evaluating this boolean expression.                                                 |
+| `graphql`                 | [ObjectBooleanExpressionTypeGraphQlConfiguration](#objectbooleanexpressiontype-objectbooleanexpressiontypegraphqlconfiguration) / null | false    | Configuration for how this object type should appear in the GraphQL schema.                                                                                    |
 
 #### ObjectBooleanExpressionTypeGraphQlConfiguration {#objectbooleanexpressiontype-objectbooleanexpressiontypegraphqlconfiguration}
 
 GraphQL configuration of an Open DD boolean expression type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `typeName` | [GraphQlTypeName](#objectbooleanexpressiontype-graphqltypename) | true | The name to use for the GraphQL type representation of this boolean expression type. |
-
-
+| Key        | Value                                                           | Required | Description                                                                          |
+| ---------- | --------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `typeName` | [GraphQlTypeName](#objectbooleanexpressiontype-graphqltypename) | true     | The name to use for the GraphQL type representation of this boolean expression type. |
 
 #### GraphQlTypeName {#objectbooleanexpressiontype-graphqltypename}
 
 The name of a GraphQL type.
 
-
 **Value:** string
-
 
 #### ComparableField {#objectbooleanexpressiontype-comparablefield}
 
 A field of an object type that can be used for comparison when evaluating a boolean expression.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [FieldName](#objectbooleanexpressiontype-fieldname) | true |  |
-| `operators` | [EnableAllOrSpecific](#objectbooleanexpressiontype-enableallorspecific) | true | Enable all or specific values. |
-
-
+| Key         | Value                                                                   | Required | Description                    |
+| ----------- | ----------------------------------------------------------------------- | -------- | ------------------------------ |
+| `fieldName` | [FieldName](#objectbooleanexpressiontype-fieldname)                     | true     |                                |
+| `operators` | [EnableAllOrSpecific](#objectbooleanexpressiontype-enableallorspecific) | true     | Enable all or specific values. |
 
 #### EnableAllOrSpecific {#objectbooleanexpressiontype-enableallorspecific}
 
 Enable all or specific values.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `enableAll` | boolean | false |  |
-| `enableSpecific` | [[OperatorName](#objectbooleanexpressiontype-operatorname)] | false |  |
-
-
+| Key              | Value                                                       | Required | Description |
+| ---------------- | ----------------------------------------------------------- | -------- | ----------- |
+| `enableAll`      | boolean                                                     | false    |             |
+| `enableSpecific` | [[OperatorName](#objectbooleanexpressiontype-operatorname)] | false    |             |
 
 #### OperatorName {#objectbooleanexpressiontype-operatorname}
 
 The name of an operator
 
-
 **Value:** string
-
 
 #### FieldName {#objectbooleanexpressiontype-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### DataConnectorObjectType {#objectbooleanexpressiontype-dataconnectorobjecttype}
 
 The name of an object type in a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorName {#objectbooleanexpressiontype-dataconnectorname}
 
 The name of a data connector.
 
-
 **Value:** string
-
 
 #### CustomTypeName {#objectbooleanexpressiontype-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
+

--- a/docs/reference/metadata-reference/build-configs.mdx
+++ b/docs/reference/metadata-reference/build-configs.mdx
@@ -6,6 +6,7 @@ description:
 seoFrontMatterUpdated: true
 toc_max_heading_level: 4
 sidebar_position: 3
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/build-configs/"
 ---
 
 # Build configs
@@ -150,163 +151,140 @@ definition:
 
 ## Metadata structure
 
-
 ### Supergraph {#supergraph-supergraph}
 
 Defines the configuration used to build the Supergraph.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `Supergraph` | true |  |
-| `version` | `v2` | true |  |
-| `definition` | [SupergraphDefinitionV2](#supergraph-supergraphdefinitionv2) | true |  |
-
-
+| Key          | Value                                                        | Required | Description |
+| ------------ | ------------------------------------------------------------ | -------- | ----------- |
+| `kind`       | `Supergraph`                                                 | true     |             |
+| `version`    | `v2`                                                         | true     |             |
+| `definition` | [SupergraphDefinitionV2](#supergraph-supergraphdefinitionv2) | true     |             |
 
 #### SupergraphDefinitionV2 {#supergraph-supergraphdefinitionv2}
 
 Supergraph Definition V2.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `subgraphs` | [string] | true | Paths to subgraph configuration. |
+| Key         | Value    | Required | Description                      |
+| ----------- | -------- | -------- | -------------------------------- |
+| `subgraphs` | [string] | true     | Paths to subgraph configuration. |
 
 ### Subgraph {#subgraph-subgraph}
 
 Defines the configuration used to build the Subgraph.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `Subgraph` | true |  |
-| `version` | `v2` | true |  |
-| `definition` | [SubgraphDefinitionV2](#subgraph-subgraphdefinitionv2) | true |  |
-
-
+| Key          | Value                                                  | Required | Description |
+| ------------ | ------------------------------------------------------ | -------- | ----------- |
+| `kind`       | `Subgraph`                                             | true     |             |
+| `version`    | `v2`                                                   | true     |             |
+| `definition` | [SubgraphDefinitionV2](#subgraph-subgraphdefinitionv2) | true     |             |
 
 #### SubgraphDefinitionV2 {#subgraph-subgraphdefinitionv2}
 
 Subgraph Definition V2.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | string | true | Subgraph Name. |
-| `generator` | [SubgraphGeneratorConfig](#subgraph-subgraphgeneratorconfig) | true | Subgraph generator Configuration. |
-| `envFile` | string | false | Path to the Subgraph .env file. |
-| `includePaths` | [string] | true | Paths to be included to construct Subgraph metadata. |
-| `envMapping` | [EnvMapping](#subgraph-envmapping) | false | Environment Variable mapping config. |
-| `connectors` | [[SubgraphConnector](#subgraph-subgraphconnector)] | false | Connectors used in subgraph. |
-
-
+| Key            | Value                                                        | Required | Description                                          |
+| -------------- | ------------------------------------------------------------ | -------- | ---------------------------------------------------- |
+| `name`         | string                                                       | true     | Subgraph Name.                                       |
+| `generator`    | [SubgraphGeneratorConfig](#subgraph-subgraphgeneratorconfig) | true     | Subgraph generator Configuration.                    |
+| `envFile`      | string                                                       | false    | Path to the Subgraph .env file.                      |
+| `includePaths` | [string]                                                     | true     | Paths to be included to construct Subgraph metadata. |
+| `envMapping`   | [EnvMapping](#subgraph-envmapping)                           | false    | Environment Variable mapping config.                 |
+| `connectors`   | [[SubgraphConnector](#subgraph-subgraphconnector)]           | false    | Connectors used in subgraph.                         |
 
 #### SubgraphConnector {#subgraph-subgraphconnector}
 
 Subgraph Connector config.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `path` | string | true | Path to connector config file. |
-| `connectorLinkName` | string | false | Name of connector link associated with the connector. |
-
-
+| Key                 | Value  | Required | Description                                           |
+| ------------------- | ------ | -------- | ----------------------------------------------------- |
+| `path`              | string | true     | Path to connector config file.                        |
+| `connectorLinkName` | string | false    | Name of connector link associated with the connector. |
 
 #### EnvMapping {#subgraph-envmapping}
 
 Environment Variables mapping config.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [EnvSource](#subgraph-envsource) | false | Target Environment variable. |
-
-
+| Key           | Value                            | Required | Description                  |
+| ------------- | -------------------------------- | -------- | ---------------------------- |
+| `<customKey>` | [EnvSource](#subgraph-envsource) | false    | Target Environment variable. |
 
 #### EnvSource {#subgraph-envsource}
 
 Environment Variable Source.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fromEnv` | string | true | Source Environment variable. |
-
-
+| Key       | Value  | Required | Description                  |
+| --------- | ------ | -------- | ---------------------------- |
+| `fromEnv` | string | true     | Source Environment variable. |
 
 #### SubgraphGeneratorConfig {#subgraph-subgraphgeneratorconfig}
 
 Subgraph generator Configuration.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `rootPath` | string | true | Path to the directory which holds all the Subgraph metadata. |
-| `graphqlRootFieldPrefix` | string | false | Prefix to use while generating GraphQL root fields. |
-| `graphqlTypeNamePrefix` | string | false | Prefix to use while generating GraphQL type names. |
-| `namingConvention` | `none` / `graphql` / `snake_case` | false | Naming convention to use while generating GraphQL fields and types. |
+| Key                      | Value                             | Required | Description                                                         |
+| ------------------------ | --------------------------------- | -------- | ------------------------------------------------------------------- |
+| `rootPath`               | string                            | true     | Path to the directory which holds all the Subgraph metadata.        |
+| `graphqlRootFieldPrefix` | string                            | false    | Prefix to use while generating GraphQL root fields.                 |
+| `graphqlTypeNamePrefix`  | string                            | false    | Prefix to use while generating GraphQL type names.                  |
+| `namingConvention`       | `none` / `graphql` / `snake_case` | false    | Naming convention to use while generating GraphQL fields and types. |
 
 ### Connector {#connector-connector}
 
 Defines the configuration used to build the connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `Connector` | true |  |
-| `version` | `v2` | true |  |
-| `definition` | [ConnectorDefinitionV2](#connector-connectordefinitionv2) | true |  |
-
-
+| Key          | Value                                                     | Required | Description |
+| ------------ | --------------------------------------------------------- | -------- | ----------- |
+| `kind`       | `Connector`                                               | true     |             |
+| `version`    | `v2`                                                      | true     |             |
+| `definition` | [ConnectorDefinitionV2](#connector-connectordefinitionv2) | true     |             |
 
 #### ConnectorDefinitionV2 {#connector-connectordefinitionv2}
 
 Connector deployment definition V2.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | string | true | Connector name. |
-| `subgraph` | string | false | DDN project subgraph name. |
-| `source` | string | true | Connector Hub ID. |
-| `context` | string | true | Path to the context directory. |
-| `envFile` | string | false | Path to the shared .env file. |
-| `envMapping` | [EnvMapping](#connector-envmapping) | false | Environment Variable mapping config. |
-| `regionConfiguration` | [[RegionConfigurationV2](#connector-regionconfigurationv2)] | false | Connector deployment Region configuration |
-| `resources` | [Resources](#connector-resources) | false | Connector deployment Resources. |
-
-
+| Key                   | Value                                                       | Required | Description                               |
+| --------------------- | ----------------------------------------------------------- | -------- | ----------------------------------------- |
+| `name`                | string                                                      | true     | Connector name.                           |
+| `subgraph`            | string                                                      | false    | DDN project subgraph name.                |
+| `source`              | string                                                      | true     | Connector Hub ID.                         |
+| `context`             | string                                                      | true     | Path to the context directory.            |
+| `envFile`             | string                                                      | false    | Path to the shared .env file.             |
+| `envMapping`          | [EnvMapping](#connector-envmapping)                         | false    | Environment Variable mapping config.      |
+| `regionConfiguration` | [[RegionConfigurationV2](#connector-regionconfigurationv2)] | false    | Connector deployment Region configuration |
+| `resources`           | [Resources](#connector-resources)                           | false    | Connector deployment Resources.           |
 
 #### RegionConfigurationV2 {#connector-regionconfigurationv2}
 
 Connector deployment Region Configuration V2.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `region` | string | true | Region to deploy the connector to. |
-| `mode` | `ReadOnly` / `ReadWrite` | true | Connector deployment mode. |
-| `envMapping` | [EnvMapping](#connector-envmapping) | false | Environment Variable mapping config. |
-| `resources` | [Resources](#connector-resources) | false | Connector deployment Resources. |
-
-
+| Key          | Value                               | Required | Description                          |
+| ------------ | ----------------------------------- | -------- | ------------------------------------ |
+| `region`     | string                              | true     | Region to deploy the connector to.   |
+| `mode`       | `ReadOnly` / `ReadWrite`            | true     | Connector deployment mode.           |
+| `envMapping` | [EnvMapping](#connector-envmapping) | false    | Environment Variable mapping config. |
+| `resources`  | [Resources](#connector-resources)   | false    | Connector deployment Resources.      |
 
 #### Resources {#connector-resources}
 
 Connector deployment Resources.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `memory` | string | false | Connector deployment memory resource in bytes. Accepted units: k, M, G. Example: 128M, 1G |
-| `cpu` | string | false | Connector deployment cpu resource in cores. Example: 1, 1.5 |
-
-
+| Key      | Value  | Required | Description                                                                               |
+| -------- | ------ | -------- | ----------------------------------------------------------------------------------------- |
+| `memory` | string | false    | Connector deployment memory resource in bytes. Accepted units: k, M, G. Example: 128M, 1G |
+| `cpu`    | string | false    | Connector deployment cpu resource in cores. Example: 1, 1.5                               |
 
 #### EnvMapping {#connector-envmapping}
 
 Environment Variables mapping config.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [EnvSource](#connector-envsource) | false | Target Environment variable. |
-
-
+| Key           | Value                             | Required | Description                  |
+| ------------- | --------------------------------- | -------- | ---------------------------- |
+| `<customKey>` | [EnvSource](#connector-envsource) | false    | Target Environment variable. |
 
 #### EnvSource {#connector-envsource}
 
 Environment Variable Source.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fromEnv` | string | true | Source Environment variable. |
+| Key       | Value  | Required | Description                  |
+| --------- | ------ | -------- | ---------------------------- |
+| `fromEnv` | string | true     | Source Environment variable. |

--- a/docs/reference/metadata-reference/commands.mdx
+++ b/docs/reference/metadata-reference/commands.mdx
@@ -17,6 +17,7 @@ keywords:
   - command configuration
 seoFrontMatterUpdated: true
 toc_max_heading_level: 4
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/commands/"
 ---
 
 # Commands
@@ -95,18 +96,18 @@ query {
 
 ## Metadata structure
 
-
 ### Command {#command-command}
 
-The definition of a command. A command is a user-defined operation which can take arguments and returns an output. The semantics of a command are opaque to the Open DD specification.
+The definition of a command. A command is a user-defined operation which can take arguments and returns an output. The
+semantics of a command are opaque to the Open DD specification.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `Command` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [CommandV1](#command-commandv1) | true | Definition of an OpenDD Command, which is a custom operation that can take arguments and returns an output. The semantics of a command are opaque to OpenDD. |
+| Key          | Value                           | Required | Description                                                                                                                                                  |
+| ------------ | ------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `kind`       | `Command`                       | true     |                                                                                                                                                              |
+| `version`    | `v1`                            | true     |                                                                                                                                                              |
+| `definition` | [CommandV1](#command-commandv1) | true     | Definition of an OpenDD Command, which is a custom operation that can take arguments and returns an output. The semantics of a command are opaque to OpenDD. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: Command
@@ -126,77 +127,69 @@ definition:
   description: Get the latest article
 ```
 
-
 #### CommandV1 {#command-commandv1}
 
-Definition of an OpenDD Command, which is a custom operation that can take arguments and returns an output. The semantics of a command are opaque to OpenDD.
+Definition of an OpenDD Command, which is a custom operation that can take arguments and returns an output. The
+semantics of a command are opaque to OpenDD.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [CommandName](#command-commandname) | true | The name of the command. |
-| `outputType` | [TypeReference](#command-typereference) | true | The return type of the command. |
-| `arguments` | [[ArgumentDefinition](#command-argumentdefinition)] | false | The list of arguments accepted by this command. Defaults to no arguments. |
-| `source` | [CommandSource](#command-commandsource) / null | false | The source configuration for this command. |
-| `graphql` | [CommandGraphQlDefinition](#command-commandgraphqldefinition) / null | false | Configuration for how this command should appear in the GraphQL schema. |
-| `description` | string / null | false | The description of the command. Gets added to the description of the command's root field in the GraphQL schema. |
-
-
+| Key           | Value                                                                | Required | Description                                                                                                      |
+| ------------- | -------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `name`        | [CommandName](#command-commandname)                                  | true     | The name of the command.                                                                                         |
+| `outputType`  | [TypeReference](#command-typereference)                              | true     | The return type of the command.                                                                                  |
+| `arguments`   | [[ArgumentDefinition](#command-argumentdefinition)]                  | false    | The list of arguments accepted by this command. Defaults to no arguments.                                        |
+| `source`      | [CommandSource](#command-commandsource) / null                       | false    | The source configuration for this command.                                                                       |
+| `graphql`     | [CommandGraphQlDefinition](#command-commandgraphqldefinition) / null | false    | Configuration for how this command should appear in the GraphQL schema.                                          |
+| `description` | string / null                                                        | false    | The description of the command. Gets added to the description of the command's root field in the GraphQL schema. |
 
 #### CommandGraphQlDefinition {#command-commandgraphqldefinition}
 
 The definition of how a command should appear in the GraphQL API.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `rootFieldName` | [GraphQlFieldName](#command-graphqlfieldname) | true | The name of the graphql root field to use for this command. |
-| `rootFieldKind` | [GraphQlRootFieldKind](#command-graphqlrootfieldkind) | true | Whether to put this command in the Query or Mutation root of the GraphQL API. |
-| `deprecated` | [Deprecated](#command-deprecated) / null | false | Whether this command root field is deprecated. If set, this will be added to the graphql schema as a deprecated field. |
+| Key             | Value                                                 | Required | Description                                                                                                            |
+| --------------- | ----------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `rootFieldName` | [GraphQlFieldName](#command-graphqlfieldname)         | true     | The name of the graphql root field to use for this command.                                                            |
+| `rootFieldKind` | [GraphQlRootFieldKind](#command-graphqlrootfieldkind) | true     | Whether to put this command in the Query or Mutation root of the GraphQL API.                                          |
+| `deprecated`    | [Deprecated](#command-deprecated) / null              | false    | Whether this command root field is deprecated. If set, this will be added to the graphql schema as a deprecated field. |
 
- **Example:**
+**Example:**
 
 ```yaml
 rootFieldName: getLatestArticle
 rootFieldKind: Query
 ```
 
-
 #### Deprecated {#command-deprecated}
 
-OpenDd configuration to indicate whether an object type field, relationship, model root field or command root field is deprecated.
+OpenDd configuration to indicate whether an object type field, relationship, model root field or command root field is
+deprecated.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `reason` | string / null | false | The reason for deprecation. |
-
-
+| Key      | Value         | Required | Description                 |
+| -------- | ------------- | -------- | --------------------------- |
+| `reason` | string / null | false    | The reason for deprecation. |
 
 #### GraphQlRootFieldKind {#command-graphqlrootfieldkind}
 
 Whether to put this command in the Query or Mutation root of the GraphQL API.
 
-
 **Value:** `Query` / `Mutation`
-
 
 #### GraphQlFieldName {#command-graphqlfieldname}
 
 The name of a GraphQL object field.
 
-
 **Value:** string
-
 
 #### CommandSource {#command-commandsource}
 
 Description of how a command maps to a particular data connector
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `dataConnectorName` | [DataConnectorName](#command-dataconnectorname) | true | The name of the data connector backing this command. |
-| `dataConnectorCommand` | [DataConnectorCommand](#command-dataconnectorcommand) | true | The function/procedure in the data connector that backs this command. |
-| `argumentMapping` | [ArgumentMapping](#command-argumentmapping) | false | Mapping from command argument names to data connector function or procedure argument names. |
+| Key                    | Value                                                 | Required | Description                                                                                 |
+| ---------------------- | ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `dataConnectorName`    | [DataConnectorName](#command-dataconnectorname)       | true     | The name of the data connector backing this command.                                        |
+| `dataConnectorCommand` | [DataConnectorCommand](#command-dataconnectorcommand) | true     | The function/procedure in the data connector that backs this command.                       |
+| `argumentMapping`      | [ArgumentMapping](#command-argumentmapping)           | false    | Mapping from command argument names to data connector function or procedure argument names. |
 
- **Example:**
+**Example:**
 
 ```yaml
 dataConnectorName: data_connector
@@ -205,96 +198,77 @@ dataConnectorCommand:
 argumentMapping: {}
 ```
 
-
 #### ArgumentMapping {#command-argumentmapping}
 
-Mapping of a comand or model argument name to the corresponding argument name used in the data connector. The key of this object is the argument name used in the command or model and the value is the argument name used in the data connector.
+Mapping of a comand or model argument name to the corresponding argument name used in the data connector. The key of
+this object is the argument name used in the command or model and the value is the argument name used in the data
+connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [DataConnectorArgumentName](#command-dataconnectorargumentname) | false |  |
-
-
+| Key           | Value                                                           | Required | Description |
+| ------------- | --------------------------------------------------------------- | -------- | ----------- |
+| `<customKey>` | [DataConnectorArgumentName](#command-dataconnectorargumentname) | false    |             |
 
 #### DataConnectorArgumentName {#command-dataconnectorargumentname}
 
 The name of an argument as defined by a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorCommand {#command-dataconnectorcommand}
 
 The function/procedure in the data connector that backs this command.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `function` | [FunctionName](#command-functionname) | false | The name of a function backing the command. |
-| `procedure` | [ProcedureName](#command-procedurename) | false | The name of a procedure backing the command. |
-
-
+| Key         | Value                                   | Required | Description                                  |
+| ----------- | --------------------------------------- | -------- | -------------------------------------------- |
+| `function`  | [FunctionName](#command-functionname)   | false    | The name of a function backing the command.  |
+| `procedure` | [ProcedureName](#command-procedurename) | false    | The name of a procedure backing the command. |
 
 #### ProcedureName {#command-procedurename}
 
 The name of a procedure backing the command.
 
-
 **Value:** string
-
 
 #### FunctionName {#command-functionname}
 
 The name of a function backing the command.
 
-
 **Value:** string
-
 
 #### DataConnectorName {#command-dataconnectorname}
 
 The name of a data connector.
 
-
 **Value:** string
-
 
 #### ArgumentDefinition {#command-argumentdefinition}
 
 The definition of an argument for a field, command, or model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [ArgumentName](#command-argumentname) | true | The name of an argument. |
-| `type` | [TypeReference](#command-typereference) | true |  |
-| `description` | string / null | false |  |
-
-
+| Key           | Value                                   | Required | Description              |
+| ------------- | --------------------------------------- | -------- | ------------------------ |
+| `name`        | [ArgumentName](#command-argumentname)   | true     | The name of an argument. |
+| `type`        | [TypeReference](#command-typereference) | true     |                          |
+| `description` | string / null                           | false    |                          |
 
 #### ArgumentName {#command-argumentname}
 
 The name of an argument.
 
-
 **Value:** string
-
 
 #### TypeReference {#command-typereference}
 
-A reference to an Open DD type including nullable values and arrays.
-Suffix '!' to indicate a non-nullable reference, and wrap in '[]' to indicate an array.
-Eg: '[String!]!' is a non-nullable array of non-nullable strings.
-
+A reference to an Open DD type including nullable values and arrays. Suffix '!' to indicate a non-nullable reference,
+and wrap in '[]' to indicate an array. Eg: '[String!]!' is a non-nullable array of non-nullable strings.
 
 **Value:** string
-
 
 #### CommandName {#command-commandname}
 
 The name of a command.
 
-
 **Value:** string
+

--- a/docs/reference/metadata-reference/compatibility-config.mdx
+++ b/docs/reference/metadata-reference/compatibility-config.mdx
@@ -6,6 +6,7 @@ description:
 keywords:
   - compatibility config
 toc_max_heading_level: 4
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/compatibility-config/"
 ---
 
 # Compatibility Config
@@ -36,26 +37,29 @@ CompatibilityConfig `date`s prior to these dates will have these features disabl
 ##### Send missing arguments to NDC as nulls
 
 Previously missing arguments to NDC were not sent at all. Now they are sent as nulls. Note that this may require changes
-to your data connectors to handle null values. `ndc-postgres` was updated in version `v2.1.0`. 
+to your data connectors to handle null values. `ndc-postgres` was updated in version `v2.1.0`.
 
-#### 2025-04-24 
+#### 2025-04-24
 
 ##### Disallow comparable relationships with no target boolean expression type
 
-To refer to a `Relationship` in a `BooleanExpressionType`, we must add them to the `comparableRelationships` field. Previously, if the target model did not have a boolean
-expression type defined, the comparable relationship would be quietly dropped. This meant that the user would be told the relationship did not exist if they tried to use it, which was confusing. Now the engine will raise a build error indicating the root cause. 
+To refer to a `Relationship` in a `BooleanExpressionType`, we must add them to the `comparableRelationships` field.
+Previously, if the target model did not have a boolean expression type defined, the comparable relationship would be
+quietly dropped. This meant that the user would be told the relationship did not exist if they tried to use it, which
+was confusing. Now the engine will raise a build error indicating the root cause.
 
 #### 2025-04-03
 
 ##### Validate non-null GraphQL variables
 
-Enables runtime validations for non-nullable GraphQL variables. 
+Enables runtime validations for non-nullable GraphQL variables.
 
 #### 2025-03-26
 
 ##### Validate scalar boolean expression operators
 
 A build error is now raised if any of the following validations for operators in scalar boolean expressions fail.
+
 - Non-list argument types are not allowed for the `_in` operator
 - Argument type must match the scalar type for `_eq`, `_lt`, `_lte`, `_gt` and `_gte` operators
 - Mapped operators must exist in the data connector
@@ -493,26 +497,22 @@ project metadata.
 
 ## Metadata structure
 
-
 ### v2_CompatibilityConfig {#v2_compatibilityconfig-v2_compatibilityconfig}
 
 The compatibility configuration of the Hasura metadata.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `CompatibilityConfig` | true |  |
-| `date` | [CompatibilityDate](#v2_compatibilityconfig-compatibilitydate) | true | Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata. |
-
-
+| Key    | Value                                                          | Required | Description                                                                                      |
+| ------ | -------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `kind` | `CompatibilityConfig`                                          | true     |                                                                                                  |
+| `date` | [CompatibilityDate](#v2_compatibilityconfig-compatibilitydate) | true     | Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata. |
 
 #### CompatibilityDate {#v2_compatibilityconfig-compatibilitydate}
 
 Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
+| Value                                                                                                                                                                                                                                                                                                                                                                 | Description               |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
 | `2024-06-30` / `2024-09-03` / `2024-09-18` / `2024-09-26` / `2024-10-07` / `2024-10-16` / `2024-10-31` / `2024-11-13` / `2024-11-15` / `2024-11-18` / `2024-11-26` / `2024-12-05` / `2024-12-10` / `2024-12-18` / `2025-01-07` / `2025-01-25` / `2025-02-04` / `2025-02-08` / `2025-02-20` / `2025-02-27` / `2025-03-11` / `2025-03-12` / `2025-03-21` / `2025-03-26` | Known compatibility dates |
-| string | Any date |
+| string                                                                                                                                                                                                                                                                                                                                                                | Any date                  |

--- a/docs/reference/metadata-reference/data-connector-links.mdx
+++ b/docs/reference/metadata-reference/data-connector-links.mdx
@@ -17,6 +17,7 @@ keywords:
   - sql databases
 toc_max_heading_level: 4
 seoFrontMatterUpdated: true
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/data-connector-links/"
 ---
 
 # Data Connector Links
@@ -106,18 +107,17 @@ definition:
 
 ## Metadata structure
 
-
 ### DataConnectorLink {#dataconnectorlink-dataconnectorlink}
 
 Definition of a data connector, used to bring in sources of data and connect them to OpenDD models and commands.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `DataConnectorLink` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [DataConnectorLinkV1](#dataconnectorlink-dataconnectorlinkv1) | true | Definition of a data connector - version 1. |
+| Key          | Value                                                         | Required | Description                                 |
+| ------------ | ------------------------------------------------------------- | -------- | ------------------------------------------- |
+| `kind`       | `DataConnectorLink`                                           | true     |                                             |
+| `version`    | `v1`                                                          | true     |                                             |
+| `definition` | [DataConnectorLinkV1](#dataconnectorlink-dataconnectorlinkv1) | true     | Definition of a data connector - version 1. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: DataConnectorLink
@@ -145,232 +145,193 @@ definition:
         mutation: {}
 ```
 
-
 #### DataConnectorLinkV1 {#dataconnectorlink-dataconnectorlinkv1}
 
 Definition of a data connector - version 1.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [DataConnectorName](#dataconnectorlink-dataconnectorname) | true | The name of the data connector. |
-| `url` | [DataConnectorUrlV1](#dataconnectorlink-dataconnectorurlv1) | true | The url(s) to access the data connector. |
-| `headers` | [HttpHeaders](#dataconnectorlink-httpheaders) | false | Key value map of HTTP headers to be sent with each request to the data connector. This is meant for protocol level use between engine and the data connector. |
-| `schema` | [VersionedSchemaAndCapabilities](#dataconnectorlink-versionedschemaandcapabilities) | true | The schema of the data connector. This schema is used as the source of truth when serving requests and the live schema of the data connector is not looked up. |
-| `argumentPresets` | [[DataConnectorArgumentPreset](#dataconnectorlink-dataconnectorargumentpreset)] | false | Argument presets that applies to all functions and procedures of this data connector. Defaults to no argument presets. |
-| `responseHeaders` | [ResponseHeaders](#dataconnectorlink-responseheaders) / null | false | HTTP response headers configuration that is forwarded from a data connector to the client. |
-
-
+| Key               | Value                                                                               | Required | Description                                                                                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`            | [DataConnectorName](#dataconnectorlink-dataconnectorname)                           | true     | The name of the data connector.                                                                                                                                |
+| `url`             | [DataConnectorUrlV1](#dataconnectorlink-dataconnectorurlv1)                         | true     | The url(s) to access the data connector.                                                                                                                       |
+| `headers`         | [HttpHeaders](#dataconnectorlink-httpheaders)                                       | false    | Key value map of HTTP headers to be sent with each request to the data connector. This is meant for protocol level use between engine and the data connector.  |
+| `schema`          | [VersionedSchemaAndCapabilities](#dataconnectorlink-versionedschemaandcapabilities) | true     | The schema of the data connector. This schema is used as the source of truth when serving requests and the live schema of the data connector is not looked up. |
+| `argumentPresets` | [[DataConnectorArgumentPreset](#dataconnectorlink-dataconnectorargumentpreset)]     | false    | Argument presets that applies to all functions and procedures of this data connector. Defaults to no argument presets.                                         |
+| `responseHeaders` | [ResponseHeaders](#dataconnectorlink-responseheaders) / null                        | false    | HTTP response headers configuration that is forwarded from a data connector to the client.                                                                     |
 
 #### ResponseHeaders {#dataconnectorlink-responseheaders}
 
 Configuration of what HTTP response headers should be forwarded from a data connector to the client in HTTP response.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `headersField` | [DataConnectorColumnName](#dataconnectorlink-dataconnectorcolumnname) | true | Name of the field in the NDC function/procedure's result which contains the response headers |
-| `resultField` | [DataConnectorColumnName](#dataconnectorlink-dataconnectorcolumnname) | true | Name of the field in the NDC function/procedure's result which contains the result |
-| `forwardHeaders` | [string] | true | List of actual HTTP response headers from the data connector to be set as response headers |
-
-
+| Key              | Value                                                                 | Required | Description                                                                                  |
+| ---------------- | --------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `headersField`   | [DataConnectorColumnName](#dataconnectorlink-dataconnectorcolumnname) | true     | Name of the field in the NDC function/procedure's result which contains the response headers |
+| `resultField`    | [DataConnectorColumnName](#dataconnectorlink-dataconnectorcolumnname) | true     | Name of the field in the NDC function/procedure's result which contains the result           |
+| `forwardHeaders` | [string]                                                              | true     | List of actual HTTP response headers from the data connector to be set as response headers   |
 
 #### DataConnectorColumnName {#dataconnectorlink-dataconnectorcolumnname}
 
 The name of a column in a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorArgumentPreset {#dataconnectorlink-dataconnectorargumentpreset}
 
 An argument preset that can be applied to all functions/procedures of a connector
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argument` | [DataConnectorArgumentName](#dataconnectorlink-dataconnectorargumentname) | true | The name of an argument as defined by a data connector. |
-| `value` | [DataConnectorArgumentPresetValue](#dataconnectorlink-dataconnectorargumentpresetvalue) | true | The value of a data connector argument preset. |
-
-
+| Key        | Value                                                                                   | Required | Description                                             |
+| ---------- | --------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------- |
+| `argument` | [DataConnectorArgumentName](#dataconnectorlink-dataconnectorargumentname)               | true     | The name of an argument as defined by a data connector. |
+| `value`    | [DataConnectorArgumentPresetValue](#dataconnectorlink-dataconnectorargumentpresetvalue) | true     | The value of a data connector argument preset.          |
 
 #### DataConnectorArgumentPresetValue {#dataconnectorlink-dataconnectorargumentpresetvalue}
 
 The value of a data connector argument preset.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `httpHeaders` | [HttpHeadersPreset](#dataconnectorlink-httpheaderspreset) | true | HTTP headers that can be preset from request |
-
-
+| Key           | Value                                                     | Required | Description                                  |
+| ------------- | --------------------------------------------------------- | -------- | -------------------------------------------- |
+| `httpHeaders` | [HttpHeadersPreset](#dataconnectorlink-httpheaderspreset) | true     | HTTP headers that can be preset from request |
 
 #### HttpHeadersPreset {#dataconnectorlink-httpheaderspreset}
 
 Configuration of what HTTP request headers should be forwarded to a data connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `forward` | [string] | true | List of HTTP headers that should be forwarded from HTTP requests |
-| `additional` | [AdditionalHttpHeaders](#dataconnectorlink-additionalhttpheaders) | true | Additional headers that should be forwarded, from other contexts |
-
-
+| Key          | Value                                                             | Required | Description                                                      |
+| ------------ | ----------------------------------------------------------------- | -------- | ---------------------------------------------------------------- |
+| `forward`    | [string]                                                          | true     | List of HTTP headers that should be forwarded from HTTP requests |
+| `additional` | [AdditionalHttpHeaders](#dataconnectorlink-additionalhttpheaders) | true     | Additional headers that should be forwarded, from other contexts |
 
 #### AdditionalHttpHeaders {#dataconnectorlink-additionalhttpheaders}
 
 Key value map of HTTP headers to be forwarded in the headers argument of a data connector request.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [ValueExpression](#dataconnectorlink-valueexpression) | false |  |
-
-
+| Key           | Value                                                 | Required | Description |
+| ------------- | ----------------------------------------------------- | -------- | ----------- |
+| `<customKey>` | [ValueExpression](#dataconnectorlink-valueexpression) | false    |             |
 
 #### ValueExpression {#dataconnectorlink-valueexpression}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | [OpenDdSessionVariable](#dataconnectorlink-openddsessionvariable) | false |  |
-| `valueFromEnv` | string | false |  |
-
-
+| Key               | Value                                                             | Required | Description |
+| ----------------- | ----------------------------------------------------------------- | -------- | ----------- |
+| `literal`         |                                                                   | false    |             |
+| `sessionVariable` | [OpenDdSessionVariable](#dataconnectorlink-openddsessionvariable) | false    |             |
+| `valueFromEnv`    | string                                                            | false    |             |
 
 #### OpenDdSessionVariable {#dataconnectorlink-openddsessionvariable}
 
 Used to represent the name of a session variable, like "x-hasura-role".
 
-
 **Value:** string
-
 
 #### DataConnectorArgumentName {#dataconnectorlink-dataconnectorargumentname}
 
 The name of an argument as defined by a data connector.
 
-
 **Value:** string
-
 
 #### VersionedSchemaAndCapabilities {#dataconnectorlink-versionedschemaandcapabilities}
 
 Versioned schema and capabilities for a data connector.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
+| Value                                                                   | Description                                                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------ |
 | [SchemaAndCapabilitiesV01](#dataconnectorlink-schemaandcapabilitiesv01) | Version 0.1 of schema and capabilities for a data connector. |
 | [SchemaAndCapabilitiesV02](#dataconnectorlink-schemaandcapabilitiesv02) | Version 0.2 of schema and capabilities for a data connector. |
-
-
 
 #### SchemaAndCapabilitiesV02 {#dataconnectorlink-schemaandcapabilitiesv02}
 
 Version 0.2 of schema and capabilities for a data connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `version` | `v0.2` | true |  |
-| `schema` | [Schema Response](https://hasura.github.io/ndc-spec/specification/schema/index.html) | true |  |
-| `capabilities` | [Capabilities Response](https://hasura.github.io/ndc-spec/specification/capabilities.html) | true |  |
-
-
+| Key            | Value                                                                                      | Required | Description |
+| -------------- | ------------------------------------------------------------------------------------------ | -------- | ----------- |
+| `version`      | `v0.2`                                                                                     | true     |             |
+| `schema`       | [Schema Response](https://hasura.github.io/ndc-spec/specification/schema/index.html)       | true     |             |
+| `capabilities` | [Capabilities Response](https://hasura.github.io/ndc-spec/specification/capabilities.html) | true     |             |
 
 #### SchemaAndCapabilitiesV01 {#dataconnectorlink-schemaandcapabilitiesv01}
 
 Version 0.1 of schema and capabilities for a data connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `version` | `v0.1` | true |  |
-| `schema` | [Schema Response](https://hasura.github.io/ndc-spec/specification/schema/index.html) | true |  |
-| `capabilities` | [Capabilities Response](https://hasura.github.io/ndc-spec/specification/capabilities.html) | true |  |
-
-
+| Key            | Value                                                                                      | Required | Description |
+| -------------- | ------------------------------------------------------------------------------------------ | -------- | ----------- |
+| `version`      | `v0.1`                                                                                     | true     |             |
+| `schema`       | [Schema Response](https://hasura.github.io/ndc-spec/specification/schema/index.html)       | true     |             |
+| `capabilities` | [Capabilities Response](https://hasura.github.io/ndc-spec/specification/capabilities.html) | true     |             |
 
 #### HttpHeaders {#dataconnectorlink-httpheaders}
 
-Key value map of HTTP headers to be sent with an HTTP request. The key is the header name and the value is a potential reference to an environment variable.
+Key value map of HTTP headers to be sent with an HTTP request. The key is the header name and the value is a potential
+reference to an environment variable.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [EnvironmentValue](#dataconnectorlink-environmentvalue) | false |  |
-
-
+| Key           | Value                                                   | Required | Description |
+| ------------- | ------------------------------------------------------- | -------- | ----------- |
+| `<customKey>` | [EnvironmentValue](#dataconnectorlink-environmentvalue) | false    |             |
 
 #### DataConnectorUrlV1 {#dataconnectorlink-dataconnectorurlv1}
 
 A URL to access a data connector. This can be a single URL or a pair of read and write URLs.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `singleUrl` | [EnvironmentValue](#dataconnectorlink-environmentvalue) | false |  |
-| `readWriteUrls` | [ReadWriteUrls](#dataconnectorlink-readwriteurls) | false | A pair of URLs to access a data connector, one for reading and one for writing. |
-
-
+| Key             | Value                                                   | Required | Description                                                                     |
+| --------------- | ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------- |
+| `singleUrl`     | [EnvironmentValue](#dataconnectorlink-environmentvalue) | false    |                                                                                 |
+| `readWriteUrls` | [ReadWriteUrls](#dataconnectorlink-readwriteurls)       | false    | A pair of URLs to access a data connector, one for reading and one for writing. |
 
 #### ReadWriteUrls {#dataconnectorlink-readwriteurls}
 
 A pair of URLs to access a data connector, one for reading and one for writing.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `read` | [EnvironmentValue](#dataconnectorlink-environmentvalue) | true |  |
-| `write` | [EnvironmentValue](#dataconnectorlink-environmentvalue) | true |  |
-
-
+| Key     | Value                                                   | Required | Description |
+| ------- | ------------------------------------------------------- | -------- | ----------- |
+| `read`  | [EnvironmentValue](#dataconnectorlink-environmentvalue) | true     |             |
+| `write` | [EnvironmentValue](#dataconnectorlink-environmentvalue) | true     |             |
 
 #### EnvironmentValue {#dataconnectorlink-environmentvalue}
 
 Either a literal string or a reference to a Hasura secret
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `value` | string | false |  |
-| `valueFromEnv` | string | false |  |
-
-
+| Key            | Value  | Required | Description |
+| -------------- | ------ | -------- | ----------- |
+| `value`        | string | false    |             |
+| `valueFromEnv` | string | false    |             |
 
 #### DataConnectorName {#dataconnectorlink-dataconnectorname}
 
 The name of a data connector.
 
-
 **Value:** string
+
 ### DataConnectorScalarRepresentation {#dataconnectorscalarrepresentation-dataconnectorscalarrepresentation}
 
 The representation of a data connector scalar in terms of Open DD types
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `DataConnectorScalarRepresentation` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [DataConnectorScalarRepresentationV1](#dataconnectorscalarrepresentation-dataconnectorscalarrepresentationv1) | true | The representation of a data connector scalar in terms of Open DD types. Deprecated in favour of `BooleanExpressionType`. |
-
-
+| Key          | Value                                                                                                         | Required | Description                                                                                                               |
+| ------------ | ------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `kind`       | `DataConnectorScalarRepresentation`                                                                           | true     |                                                                                                                           |
+| `version`    | `v1`                                                                                                          | true     |                                                                                                                           |
+| `definition` | [DataConnectorScalarRepresentationV1](#dataconnectorscalarrepresentation-dataconnectorscalarrepresentationv1) | true     | The representation of a data connector scalar in terms of Open DD types. Deprecated in favour of `BooleanExpressionType`. |
 
 #### DataConnectorScalarRepresentationV1 {#dataconnectorscalarrepresentation-dataconnectorscalarrepresentationv1}
 
-The representation of a data connector scalar in terms of Open DD types. Deprecated in favour of `BooleanExpressionType`.
+The representation of a data connector scalar in terms of Open DD types. Deprecated in favour of
+`BooleanExpressionType`.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `dataConnectorName` | [DataConnectorName](#dataconnectorscalarrepresentation-dataconnectorname) | true | The name of the data connector that this scalar type comes from. |
-| `dataConnectorScalarType` | [DataConnectorScalarType](#dataconnectorscalarrepresentation-dataconnectorscalartype) | true | The name of the scalar type coming from the data connector. |
-| `representation` | [TypeName](#dataconnectorscalarrepresentation-typename) | true | The name of the Open DD type that this data connector scalar type should be represented as. |
-| `graphql` | [DataConnectorScalarGraphQLConfiguration](#dataconnectorscalarrepresentation-dataconnectorscalargraphqlconfiguration) / null | false | Configuration for how this scalar's operators should appear in the GraphQL schema. |
+| Key                       | Value                                                                                                                        | Required | Description                                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `dataConnectorName`       | [DataConnectorName](#dataconnectorscalarrepresentation-dataconnectorname)                                                    | true     | The name of the data connector that this scalar type comes from.                            |
+| `dataConnectorScalarType` | [DataConnectorScalarType](#dataconnectorscalarrepresentation-dataconnectorscalartype)                                        | true     | The name of the scalar type coming from the data connector.                                 |
+| `representation`          | [TypeName](#dataconnectorscalarrepresentation-typename)                                                                      | true     | The name of the Open DD type that this data connector scalar type should be represented as. |
+| `graphql`                 | [DataConnectorScalarGraphQLConfiguration](#dataconnectorscalarrepresentation-dataconnectorscalargraphqlconfiguration) / null | false    | Configuration for how this scalar's operators should appear in the GraphQL schema.          |
 
- **Example:**
+**Example:**
 
 ```yaml
 dataConnectorName: data_connector
@@ -380,66 +341,52 @@ graphql:
   comparisonExpressionTypeName: String_Comparison_Exp
 ```
 
-
 #### DataConnectorScalarGraphQLConfiguration {#dataconnectorscalarrepresentation-dataconnectorscalargraphqlconfiguration}
 
 GraphQL configuration of a data connector scalar
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `comparisonExpressionTypeName` | [GraphQlTypeName](#dataconnectorscalarrepresentation-graphqltypename) / null | false |  |
-
-
+| Key                            | Value                                                                        | Required | Description |
+| ------------------------------ | ---------------------------------------------------------------------------- | -------- | ----------- |
+| `comparisonExpressionTypeName` | [GraphQlTypeName](#dataconnectorscalarrepresentation-graphqltypename) / null | false    |             |
 
 #### GraphQlTypeName {#dataconnectorscalarrepresentation-graphqltypename}
 
 The name of a GraphQL type.
 
-
 **Value:** string
-
 
 #### TypeName {#dataconnectorscalarrepresentation-typename}
 
 The name of the Open DD type that this data connector scalar type should be represented as.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| [InbuiltType](#dataconnectorscalarrepresentation-inbuilttype) | An inbuilt primitive OpenDD type. |
-| [CustomTypeName](#dataconnectorscalarrepresentation-customtypename) |  |
-
-
+| Value                                                               | Description                       |
+| ------------------------------------------------------------------- | --------------------------------- |
+| [InbuiltType](#dataconnectorscalarrepresentation-inbuilttype)       | An inbuilt primitive OpenDD type. |
+| [CustomTypeName](#dataconnectorscalarrepresentation-customtypename) |                                   |
 
 #### CustomTypeName {#dataconnectorscalarrepresentation-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
-
 
 #### InbuiltType {#dataconnectorscalarrepresentation-inbuilttype}
 
 An inbuilt primitive OpenDD type.
 
-
 **Value:** `ID` / `Int` / `Float` / `Boolean` / `String`
-
 
 #### DataConnectorScalarType {#dataconnectorscalarrepresentation-dataconnectorscalartype}
 
 The name of a scalar type in a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorName {#dataconnectorscalarrepresentation-dataconnectorname}
 
 The name of a data connector.
 
-
 **Value:** string
+

--- a/docs/reference/metadata-reference/engine-plugins.mdx
+++ b/docs/reference/metadata-reference/engine-plugins.mdx
@@ -10,6 +10,7 @@ keywords:
   - Lifecycle hooks
   - lifecycle plugin hooks
 toc_max_heading_level: 4
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/engine-plugins/"
 ---
 
 # Engine Plugins
@@ -66,18 +67,17 @@ definition:
 
 ## Metadata structure
 
-
 ### LifecyclePluginHook {#lifecyclepluginhook-lifecyclepluginhook}
 
 Definition of a lifecycle plugin hook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `LifecyclePluginHook` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [LifecyclePluginHookV1](#lifecyclepluginhook-lifecyclepluginhookv1) | true | Definition of a lifecycle plugin hook - version 1. |
+| Key          | Value                                                               | Required | Description                                        |
+| ------------ | ------------------------------------------------------------------- | -------- | -------------------------------------------------- |
+| `kind`       | `LifecyclePluginHook`                                               | true     |                                                    |
+| `version`    | `v1`                                                                | true     |                                                    |
+| `definition` | [LifecyclePluginHookV1](#lifecyclepluginhook-lifecyclepluginhookv1) | true     | Definition of a lifecycle plugin hook - version 1. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: LifecyclePluginHook
@@ -99,219 +99,181 @@ definition:
         variables: {}
 ```
 
-
 #### LifecyclePluginHookV1 {#lifecyclepluginhook-lifecyclepluginhookv1}
 
 Definition of a lifecycle plugin hook - version 1.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| [LifecyclePreParsePluginHook](#lifecyclepluginhook-lifecyclepreparsepluginhook) | Definition of a lifecycle plugin hook for the pre-parse stage. |
+| Value                                                                                 | Description                                                       |
+| ------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [LifecyclePreParsePluginHook](#lifecyclepluginhook-lifecyclepreparsepluginhook)       | Definition of a lifecycle plugin hook for the pre-parse stage.    |
 | [LifecyclePreResponsePluginHook](#lifecyclepluginhook-lifecyclepreresponsepluginhook) | Definition of a lifecycle plugin hook for the pre-response stage. |
-| [LifecyclePreRoutePluginHook](#lifecyclepluginhook-lifecyclepreroutepluginhook) | Definition of a lifecycle plugin hook for the pre-route stage. |
-
-
+| [LifecyclePreRoutePluginHook](#lifecyclepluginhook-lifecyclepreroutepluginhook)       | Definition of a lifecycle plugin hook for the pre-route stage.    |
 
 #### LifecyclePreRoutePluginHook {#lifecyclepluginhook-lifecyclepreroutepluginhook}
 
 Definition of a lifecycle plugin hook for the pre-route stage.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `pre` | `route` | true |  |
-| `name` | string | true | The name of the lifecycle plugin hook. |
-| `url` | [EnvironmentValue](#lifecyclepluginhook-environmentvalue) | true | The URL to access the lifecycle plugin hook. |
-| `config` | [LifecyclePreRoutePluginHookConfig](#lifecyclepluginhook-lifecyclepreroutepluginhookconfig) | true | Configuration for the lifecycle plugin hook. |
-
-
+| Key      | Value                                                                                       | Required | Description                                  |
+| -------- | ------------------------------------------------------------------------------------------- | -------- | -------------------------------------------- |
+| `pre`    | `route`                                                                                     | true     |                                              |
+| `name`   | string                                                                                      | true     | The name of the lifecycle plugin hook.       |
+| `url`    | [EnvironmentValue](#lifecyclepluginhook-environmentvalue)                                   | true     | The URL to access the lifecycle plugin hook. |
+| `config` | [LifecyclePreRoutePluginHookConfig](#lifecyclepluginhook-lifecyclepreroutepluginhookconfig) | true     | Configuration for the lifecycle plugin hook. |
 
 #### LifecyclePreRoutePluginHookConfig {#lifecyclepluginhook-lifecyclepreroutepluginhookconfig}
 
 Configuration for a lifecycle plugin hook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `matchPath` | string | true | Regex to match the request path |
-| `matchMethods` | [[RequestMethod](#lifecyclepluginhook-requestmethod)] | true | Possible HTTP methods for the request |
-| `request` | [LifecyclePreRoutePluginHookConfigRequest](#lifecyclepluginhook-lifecyclepreroutepluginhookconfigrequest) | true | Configuration for the request to the lifecycle plugin hook. |
-| `response` | [LifecyclePreRoutePluginHookConfigResponse](#lifecyclepluginhook-lifecyclepreroutepluginhookconfigresponse) / null | false | Configuration for the response to the lifecycle plugin hook. |
-
-
+| Key            | Value                                                                                                              | Required | Description                                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------------------------------ |
+| `matchPath`    | string                                                                                                             | true     | Regex to match the request path                              |
+| `matchMethods` | [[RequestMethod](#lifecyclepluginhook-requestmethod)]                                                              | true     | Possible HTTP methods for the request                        |
+| `request`      | [LifecyclePreRoutePluginHookConfigRequest](#lifecyclepluginhook-lifecyclepreroutepluginhookconfigrequest)          | true     | Configuration for the request to the lifecycle plugin hook.  |
+| `response`     | [LifecyclePreRoutePluginHookConfigResponse](#lifecyclepluginhook-lifecyclepreroutepluginhookconfigresponse) / null | false    | Configuration for the response to the lifecycle plugin hook. |
 
 #### LifecyclePreRoutePluginHookConfigResponse {#lifecyclepluginhook-lifecyclepreroutepluginhookconfigresponse}
 
 Configuration for a lifecycle plugin hook response.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `headers` | [LifecyclePluginHookHeadersConfig](#lifecyclepluginhook-lifecyclepluginhookheadersconfig) / null | false | Configuration for the headers in the response from the engine. |
-
-
+| Key       | Value                                                                                            | Required | Description                                                    |
+| --------- | ------------------------------------------------------------------------------------------------ | -------- | -------------------------------------------------------------- |
+| `headers` | [LifecyclePluginHookHeadersConfig](#lifecyclepluginhook-lifecyclepluginhookheadersconfig) / null | false    | Configuration for the headers in the response from the engine. |
 
 #### LifecyclePreRoutePluginHookConfigRequest {#lifecyclepluginhook-lifecyclepreroutepluginhookconfigrequest}
 
 Configuration for a lifecycle plugin hook request.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `headers` | [LifecyclePluginHookHeadersConfig](#lifecyclepluginhook-lifecyclepluginhookheadersconfig) / null | false | Configuration for the headers in the pre-route plugin hook HTTP requests. |
-| `method` | [LifecyclePreRoutePluginHookConfigRequestMethods](#lifecyclepluginhook-lifecyclepreroutepluginhookconfigrequestmethods) | true | Configuration for the HTTP method for the pre-route plugin hook HTTP requests. |
-| `rawRequest` | [PreRouteRequestConfig](#lifecyclepluginhook-prerouterequestconfig) | true | Configuration for the raw request body for the pre-route plugin hook HTTP requests. |
-
-
+| Key          | Value                                                                                                                   | Required | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------- |
+| `headers`    | [LifecyclePluginHookHeadersConfig](#lifecyclepluginhook-lifecyclepluginhookheadersconfig) / null                        | false    | Configuration for the headers in the pre-route plugin hook HTTP requests.           |
+| `method`     | [LifecyclePreRoutePluginHookConfigRequestMethods](#lifecyclepluginhook-lifecyclepreroutepluginhookconfigrequestmethods) | true     | Configuration for the HTTP method for the pre-route plugin hook HTTP requests.      |
+| `rawRequest` | [PreRouteRequestConfig](#lifecyclepluginhook-prerouterequestconfig)                                                     | true     | Configuration for the raw request body for the pre-route plugin hook HTTP requests. |
 
 #### PreRouteRequestConfig {#lifecyclepluginhook-prerouterequestconfig}
 
 Configuration for the raw request body for the pre-route plugin hook HTTP requests.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `path` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false | Configuration for adding/excluding the request path of the incoming request |
-| `method` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false | Configuration for adding/excluding the request method of the incoming request |
-| `query` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false | Configuration for adding/excluding the query params of the incoming request |
-| `body` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false | Configuration for adding/excluding the body of the incoming request |
-
-
+| Key      | Value                                                | Required | Description                                                                   |
+| -------- | ---------------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
+| `path`   | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false    | Configuration for adding/excluding the request path of the incoming request   |
+| `method` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false    | Configuration for adding/excluding the request method of the incoming request |
+| `query`  | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false    | Configuration for adding/excluding the query params of the incoming request   |
+| `body`   | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false    | Configuration for adding/excluding the body of the incoming request           |
 
 #### LifecyclePreRoutePluginHookConfigRequestMethods {#lifecyclepluginhook-lifecyclepreroutepluginhookconfigrequestmethods}
 
 Configuration for the method for the pre-route plugin hook HTTP requests.
 
-
 **Value:** `GET` / `POST`
-
 
 #### RequestMethod {#lifecyclepluginhook-requestmethod}
 
 Possible HTTP Request Methods for the incoming requests handled by the pre-route plugin hook.
 
-
 **Value:** `GET` / `POST` / `PUT` / `DELETE` / `PATCH`
-
 
 #### LifecyclePreResponsePluginHook {#lifecyclepluginhook-lifecyclepreresponsepluginhook}
 
 Definition of a lifecycle plugin hook for the pre-response stage.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `pre` | `response` | true |  |
-| `name` | string | true | The name of the lifecycle plugin hook. |
-| `url` | [EnvironmentValue](#lifecyclepluginhook-environmentvalue) | true | The URL to access the lifecycle plugin hook. |
-| `config` | [LifecyclePreResponsePluginHookConfig](#lifecyclepluginhook-lifecyclepreresponsepluginhookconfig) | true | Configuration for the lifecycle plugin hook. |
-
-
+| Key      | Value                                                                                             | Required | Description                                  |
+| -------- | ------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------- |
+| `pre`    | `response`                                                                                        | true     |                                              |
+| `name`   | string                                                                                            | true     | The name of the lifecycle plugin hook.       |
+| `url`    | [EnvironmentValue](#lifecyclepluginhook-environmentvalue)                                         | true     | The URL to access the lifecycle plugin hook. |
+| `config` | [LifecyclePreResponsePluginHookConfig](#lifecyclepluginhook-lifecyclepreresponsepluginhookconfig) | true     | Configuration for the lifecycle plugin hook. |
 
 #### LifecyclePreResponsePluginHookConfig {#lifecyclepluginhook-lifecyclepreresponsepluginhookconfig}
 
 Configuration for a lifecycle plugin hook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `request` | [LifecyclePreResponsePluginHookConfigRequest](#lifecyclepluginhook-lifecyclepreresponsepluginhookconfigrequest) | true | Configuration for the request to the lifecycle plugin hook. |
-
-
+| Key       | Value                                                                                                           | Required | Description                                                 |
+| --------- | --------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- |
+| `request` | [LifecyclePreResponsePluginHookConfigRequest](#lifecyclepluginhook-lifecyclepreresponsepluginhookconfigrequest) | true     | Configuration for the request to the lifecycle plugin hook. |
 
 #### LifecyclePreResponsePluginHookConfigRequest {#lifecyclepluginhook-lifecyclepreresponsepluginhookconfigrequest}
 
 Configuration for a lifecycle plugin hook request.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `headers` | [LifecyclePluginHookHeadersConfig](#lifecyclepluginhook-lifecyclepluginhookheadersconfig) / null | false | Configuration for the headers. |
-| `session` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false | Configuration for the session (includes roles and session variables). |
-| `rawRequest` | [RawRequestConfig](#lifecyclepluginhook-rawrequestconfig) | true | Configuration for the raw request. |
-| `rawResponse` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false | Configuration for the response. |
-
-
+| Key           | Value                                                                                            | Required | Description                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------ | -------- | --------------------------------------------------------------------- |
+| `headers`     | [LifecyclePluginHookHeadersConfig](#lifecyclepluginhook-lifecyclepluginhookheadersconfig) / null | false    | Configuration for the headers.                                        |
+| `session`     | [LeafConfig](#lifecyclepluginhook-leafconfig) / null                                             | false    | Configuration for the session (includes roles and session variables). |
+| `rawRequest`  | [RawRequestConfig](#lifecyclepluginhook-rawrequestconfig)                                        | true     | Configuration for the raw request.                                    |
+| `rawResponse` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null                                             | false    | Configuration for the response.                                       |
 
 #### LifecyclePreParsePluginHook {#lifecyclepluginhook-lifecyclepreparsepluginhook}
 
 Definition of a lifecycle plugin hook for the pre-parse stage.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `pre` | `parse` | true |  |
-| `name` | string | true | The name of the lifecycle plugin hook. |
-| `url` | [EnvironmentValue](#lifecyclepluginhook-environmentvalue) | true | The URL to access the lifecycle plugin hook. |
-| `config` | [LifecyclePreParsePluginHookConfig](#lifecyclepluginhook-lifecyclepreparsepluginhookconfig) | true | Configuration for the lifecycle plugin hook. |
-
-
+| Key      | Value                                                                                       | Required | Description                                  |
+| -------- | ------------------------------------------------------------------------------------------- | -------- | -------------------------------------------- |
+| `pre`    | `parse`                                                                                     | true     |                                              |
+| `name`   | string                                                                                      | true     | The name of the lifecycle plugin hook.       |
+| `url`    | [EnvironmentValue](#lifecyclepluginhook-environmentvalue)                                   | true     | The URL to access the lifecycle plugin hook. |
+| `config` | [LifecyclePreParsePluginHookConfig](#lifecyclepluginhook-lifecyclepreparsepluginhookconfig) | true     | Configuration for the lifecycle plugin hook. |
 
 #### LifecyclePreParsePluginHookConfig {#lifecyclepluginhook-lifecyclepreparsepluginhookconfig}
 
 Configuration for a lifecycle plugin hook.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `request` | [LifecyclePreParsePluginHookConfigRequest](#lifecyclepluginhook-lifecyclepreparsepluginhookconfigrequest) | true | Configuration for the request to the lifecycle plugin hook. |
-
-
+| Key       | Value                                                                                                     | Required | Description                                                 |
+| --------- | --------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- |
+| `request` | [LifecyclePreParsePluginHookConfigRequest](#lifecyclepluginhook-lifecyclepreparsepluginhookconfigrequest) | true     | Configuration for the request to the lifecycle plugin hook. |
 
 #### LifecyclePreParsePluginHookConfigRequest {#lifecyclepluginhook-lifecyclepreparsepluginhookconfigrequest}
 
 Configuration for a lifecycle plugin hook request.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `headers` | [LifecyclePluginHookHeadersConfig](#lifecyclepluginhook-lifecyclepluginhookheadersconfig) / null | false | Configuration for the headers. |
-| `session` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false | Configuration for the session (includes roles and session variables). |
-| `rawRequest` | [RawRequestConfig](#lifecyclepluginhook-rawrequestconfig) | true | Configuration for the raw request. |
-
-
+| Key          | Value                                                                                            | Required | Description                                                           |
+| ------------ | ------------------------------------------------------------------------------------------------ | -------- | --------------------------------------------------------------------- |
+| `headers`    | [LifecyclePluginHookHeadersConfig](#lifecyclepluginhook-lifecyclepluginhookheadersconfig) / null | false    | Configuration for the headers.                                        |
+| `session`    | [LeafConfig](#lifecyclepluginhook-leafconfig) / null                                             | false    | Configuration for the session (includes roles and session variables). |
+| `rawRequest` | [RawRequestConfig](#lifecyclepluginhook-rawrequestconfig)                                        | true     | Configuration for the raw request.                                    |
 
 #### RawRequestConfig {#lifecyclepluginhook-rawrequestconfig}
 
 Configuration for the raw request.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `query` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false | Configuration for the query. |
-| `variables` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false | Configuration for the variables. |
-
-
+| Key         | Value                                                | Required | Description                      |
+| ----------- | ---------------------------------------------------- | -------- | -------------------------------- |
+| `query`     | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false    | Configuration for the query.     |
+| `variables` | [LeafConfig](#lifecyclepluginhook-leafconfig) / null | false    | Configuration for the variables. |
 
 #### LeafConfig {#lifecyclepluginhook-leafconfig}
 
 Leaf Configuration.
 
 | Key | Value | Required | Description |
-|-----|-----|-----|-----|
-
-
+| --- | ----- | -------- | ----------- |
 
 #### LifecyclePluginHookHeadersConfig {#lifecyclepluginhook-lifecyclepluginhookheadersconfig}
 
 Configuration for a lifecycle plugin hook headers.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `additional` | [HttpHeaders](#lifecyclepluginhook-httpheaders) / null | false | Additional headers to be sent with the request. |
-| `forward` | [string] | false | Headers to be forwarded from the incoming request. |
-
-
+| Key          | Value                                                  | Required | Description                                        |
+| ------------ | ------------------------------------------------------ | -------- | -------------------------------------------------- |
+| `additional` | [HttpHeaders](#lifecyclepluginhook-httpheaders) / null | false    | Additional headers to be sent with the request.    |
+| `forward`    | [string]                                               | false    | Headers to be forwarded from the incoming request. |
 
 #### HttpHeaders {#lifecyclepluginhook-httpheaders}
 
-Key value map of HTTP headers to be sent with an HTTP request. The key is the header name and the value is a potential reference to an environment variable.
+Key value map of HTTP headers to be sent with an HTTP request. The key is the header name and the value is a potential
+reference to an environment variable.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [EnvironmentValue](#lifecyclepluginhook-environmentvalue) | false |  |
-
-
+| Key           | Value                                                     | Required | Description |
+| ------------- | --------------------------------------------------------- | -------- | ----------- |
+| `<customKey>` | [EnvironmentValue](#lifecyclepluginhook-environmentvalue) | false    |             |
 
 #### EnvironmentValue {#lifecyclepluginhook-environmentvalue}
 
 Either a literal string or a reference to a Hasura secret
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `value` | string | false |  |
-| `valueFromEnv` | string | false |  |
+| Key            | Value  | Required | Description |
+| -------------- | ------ | -------- | ----------- |
+| `value`        | string | false    |             |
+| `valueFromEnv` | string | false    |             |

--- a/docs/reference/metadata-reference/graphql-config.mdx
+++ b/docs/reference/metadata-reference/graphql-config.mdx
@@ -10,6 +10,7 @@ keywords:
   - graphql api configuration
   - graphql configuration
 seoFrontMatterUpdated: true
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/graphql-config/"
 ---
 
 # Configuration for GraphQL API
@@ -95,207 +96,173 @@ definition:
 
 ## Metadata structure
 
-
 ### GraphqlConfig {#graphqlconfig-graphqlconfig}
 
 GraphqlConfig object tells us two things:
 
-1. How the Graphql schema should look like for the features (`where`, `order_by` etc) Hasura provides 2. What features should be enabled/disabled across the subgraphs
+1. How the Graphql schema should look like for the features (`where`, `order_by` etc) Hasura provides 2. What features
+   should be enabled/disabled across the subgraphs
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `GraphqlConfig` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [GraphqlConfigV1](#graphqlconfig-graphqlconfigv1) | true | GraphqlConfig object tells us two things:  1. How the Graphql schema should look like for the features (`where`, `order_by` etc) Hasura provides 2. What features should be enabled/disabled across the subgraphs |
-
-
+| Key          | Value                                             | Required | Description                                                                                                                                                                                                      |
+| ------------ | ------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kind`       | `GraphqlConfig`                                   | true     |                                                                                                                                                                                                                  |
+| `version`    | `v1`                                              | true     |                                                                                                                                                                                                                  |
+| `definition` | [GraphqlConfigV1](#graphqlconfig-graphqlconfigv1) | true     | GraphqlConfig object tells us two things: 1. How the Graphql schema should look like for the features (`where`, `order_by` etc) Hasura provides 2. What features should be enabled/disabled across the subgraphs |
 
 #### GraphqlConfigV1 {#graphqlconfig-graphqlconfigv1}
 
 GraphqlConfig object tells us two things:
 
-1. How the Graphql schema should look like for the features (`where`, `order_by` etc) Hasura provides 2. What features should be enabled/disabled across the subgraphs
+1. How the Graphql schema should look like for the features (`where`, `order_by` etc) Hasura provides 2. What features
+   should be enabled/disabled across the subgraphs
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `query` | [QueryGraphqlConfig](#graphqlconfig-querygraphqlconfig) | true | Configuration for the GraphQL schema of Hasura features for queries. `None` means disable the feature. |
-| `mutation` | [MutationGraphqlConfig](#graphqlconfig-mutationgraphqlconfig) | true | Configuration for the GraphQL schema of Hasura features for mutations. |
-| `subscription` | [SubscriptionGraphqlConfig](#graphqlconfig-subscriptiongraphqlconfig) / null | false |  |
-| `apolloFederation` | [GraphqlApolloFederationConfig](#graphqlconfig-graphqlapollofederationconfig) / null | false |  |
-
-
+| Key                | Value                                                                                | Required | Description                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------ |
+| `query`            | [QueryGraphqlConfig](#graphqlconfig-querygraphqlconfig)                              | true     | Configuration for the GraphQL schema of Hasura features for queries. `None` means disable the feature. |
+| `mutation`         | [MutationGraphqlConfig](#graphqlconfig-mutationgraphqlconfig)                        | true     | Configuration for the GraphQL schema of Hasura features for mutations.                                 |
+| `subscription`     | [SubscriptionGraphqlConfig](#graphqlconfig-subscriptiongraphqlconfig) / null         | false    |                                                                                                        |
+| `apolloFederation` | [GraphqlApolloFederationConfig](#graphqlconfig-graphqlapollofederationconfig) / null | false    |                                                                                                        |
 
 #### GraphqlApolloFederationConfig {#graphqlconfig-graphqlapollofederationconfig}
 
 Configuration for the GraphQL schema of Hasura features for Apollo Federation.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `enableRootFields` | boolean | true | Adds the `_entities` and `_services` root fields required for Apollo Federation. |
-
-
+| Key                | Value   | Required | Description                                                                      |
+| ------------------ | ------- | -------- | -------------------------------------------------------------------------------- |
+| `enableRootFields` | boolean | true     | Adds the `_entities` and `_services` root fields required for Apollo Federation. |
 
 #### SubscriptionGraphqlConfig {#graphqlconfig-subscriptiongraphqlconfig}
 
 Configuration for the GraphQL schema of Hasura features for subscriptions.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `rootOperationTypeName` | [GraphQlTypeName](#graphqlconfig-graphqltypename) | true | The name of the root operation type name for subscriptions. Usually `subscription`. |
-
-
+| Key                     | Value                                             | Required | Description                                                                         |
+| ----------------------- | ------------------------------------------------- | -------- | ----------------------------------------------------------------------------------- |
+| `rootOperationTypeName` | [GraphQlTypeName](#graphqlconfig-graphqltypename) | true     | The name of the root operation type name for subscriptions. Usually `subscription`. |
 
 #### MutationGraphqlConfig {#graphqlconfig-mutationgraphqlconfig}
 
 Configuration for the GraphQL schema of Hasura features for mutations.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `rootOperationTypeName` | [GraphQlTypeName](#graphqlconfig-graphqltypename) | true | The name of the root operation type name for mutations. Usually `mutation`. |
-
-
+| Key                     | Value                                             | Required | Description                                                                 |
+| ----------------------- | ------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `rootOperationTypeName` | [GraphQlTypeName](#graphqlconfig-graphqltypename) | true     | The name of the root operation type name for mutations. Usually `mutation`. |
 
 #### QueryGraphqlConfig {#graphqlconfig-querygraphqlconfig}
 
 Configuration for the GraphQL schema of Hasura features for queries. `None` means disable the feature.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `rootOperationTypeName` | [GraphQlTypeName](#graphqlconfig-graphqltypename) | true | The name of the root operation type name for queries. Usually `query`. |
-| `argumentsInput` | [ArgumentsInputGraphqlConfig](#graphqlconfig-argumentsinputgraphqlconfig) / null | false | Configuration for the arguments input. |
-| `limitInput` | [LimitInputGraphqlConfig](#graphqlconfig-limitinputgraphqlconfig) / null | false | Configuration for the limit operation. |
-| `offsetInput` | [OffsetInputGraphqlConfig](#graphqlconfig-offsetinputgraphqlconfig) / null | false | Configuration for the offset operation. |
-| `filterInput` | [FilterInputGraphqlConfig](#graphqlconfig-filterinputgraphqlconfig) / null | false | Configuration for the filter operation. |
-| `orderByInput` | [OrderByInputGraphqlConfig](#graphqlconfig-orderbyinputgraphqlconfig) / null | false | Configuration for the sort operation. |
-| `aggregate` | [AggregateGraphqlConfig](#graphqlconfig-aggregategraphqlconfig) / null | false | Configuration for aggregates |
-
-
+| Key                     | Value                                                                            | Required | Description                                                            |
+| ----------------------- | -------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| `rootOperationTypeName` | [GraphQlTypeName](#graphqlconfig-graphqltypename)                                | true     | The name of the root operation type name for queries. Usually `query`. |
+| `argumentsInput`        | [ArgumentsInputGraphqlConfig](#graphqlconfig-argumentsinputgraphqlconfig) / null | false    | Configuration for the arguments input.                                 |
+| `limitInput`            | [LimitInputGraphqlConfig](#graphqlconfig-limitinputgraphqlconfig) / null         | false    | Configuration for the limit operation.                                 |
+| `offsetInput`           | [OffsetInputGraphqlConfig](#graphqlconfig-offsetinputgraphqlconfig) / null       | false    | Configuration for the offset operation.                                |
+| `filterInput`           | [FilterInputGraphqlConfig](#graphqlconfig-filterinputgraphqlconfig) / null       | false    | Configuration for the filter operation.                                |
+| `orderByInput`          | [OrderByInputGraphqlConfig](#graphqlconfig-orderbyinputgraphqlconfig) / null     | false    | Configuration for the sort operation.                                  |
+| `aggregate`             | [AggregateGraphqlConfig](#graphqlconfig-aggregategraphqlconfig) / null           | false    | Configuration for aggregates                                           |
 
 #### AggregateGraphqlConfig {#graphqlconfig-aggregategraphqlconfig}
 
 Configuration for the GraphQL schema for aggregates.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `filterInputFieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the filter input parameter of aggregate fields and field name in predicates |
-| `countFieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the _count field used for the count aggregate function |
-| `countDistinctFieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the _count_distinct field used for the count distinct aggregate function |
-
-
+| Key                      | Value                                               | Required | Description                                                                             |
+| ------------------------ | --------------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `filterInputFieldName`   | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the filter input parameter of aggregate fields and field name in predicates |
+| `countFieldName`         | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the \_count field used for the count aggregate function                     |
+| `countDistinctFieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the \_count_distinct field used for the count distinct aggregate function   |
 
 #### OrderByInputGraphqlConfig {#graphqlconfig-orderbyinputgraphqlconfig}
 
 Configuration for the sort operation.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the filter operation field. Usually `order_by`. |
-| `enumDirectionValues` | [OrderByDirectionValues](#graphqlconfig-orderbydirectionvalues) | true | The names of the direction parameters. |
-| `enumTypeNames` | [[OrderByEnumTypeName](#graphqlconfig-orderbyenumtypename)] | true |  |
-
-
+| Key                   | Value                                                           | Required | Description                                                 |
+| --------------------- | --------------------------------------------------------------- | -------- | ----------------------------------------------------------- |
+| `fieldName`           | [GraphQlFieldName](#graphqlconfig-graphqlfieldname)             | true     | The name of the filter operation field. Usually `order_by`. |
+| `enumDirectionValues` | [OrderByDirectionValues](#graphqlconfig-orderbydirectionvalues) | true     | The names of the direction parameters.                      |
+| `enumTypeNames`       | [[OrderByEnumTypeName](#graphqlconfig-orderbyenumtypename)]     | true     |                                                             |
 
 #### OrderByEnumTypeName {#graphqlconfig-orderbyenumtypename}
 
 Type name for a sort directions enum, with the given set of possible directions.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `directions` | [[OrderByDirection](#graphqlconfig-orderbydirection)] | true |  |
-| `typeName` | [GraphQlTypeName](#graphqlconfig-graphqltypename) | true |  |
-
-
+| Key          | Value                                                 | Required | Description |
+| ------------ | ----------------------------------------------------- | -------- | ----------- |
+| `directions` | [[OrderByDirection](#graphqlconfig-orderbydirection)] | true     |             |
+| `typeName`   | [GraphQlTypeName](#graphqlconfig-graphqltypename)     | true     |             |
 
 #### OrderByDirection {#graphqlconfig-orderbydirection}
 
 Sort direction.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| `Asc` | Ascending. |
+| Value  | Description |
+| ------ | ----------- |
+| `Asc`  | Ascending.  |
 | `Desc` | Descending. |
-
-
 
 #### OrderByDirectionValues {#graphqlconfig-orderbydirectionvalues}
 
 The names of the direction parameters.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `asc` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the ascending parameter. Usually `Asc`. |
-| `desc` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the descending parameter. Usually `Desc`. |
-
-
+| Key    | Value                                               | Required | Description                                           |
+| ------ | --------------------------------------------------- | -------- | ----------------------------------------------------- |
+| `asc`  | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the ascending parameter. Usually `Asc`.   |
+| `desc` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the descending parameter. Usually `Desc`. |
 
 #### FilterInputGraphqlConfig {#graphqlconfig-filterinputgraphqlconfig}
 
 Configuration for the filter operation.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the filter operation field. Usually `where`. |
-| `operatorNames` | [FilterInputOperatorNames](#graphqlconfig-filterinputoperatornames) | true | The names of built-in filter operators. |
-
-
+| Key             | Value                                                               | Required | Description                                              |
+| --------------- | ------------------------------------------------------------------- | -------- | -------------------------------------------------------- |
+| `fieldName`     | [GraphQlFieldName](#graphqlconfig-graphqlfieldname)                 | true     | The name of the filter operation field. Usually `where`. |
+| `operatorNames` | [FilterInputOperatorNames](#graphqlconfig-filterinputoperatornames) | true     | The names of built-in filter operators.                  |
 
 #### FilterInputOperatorNames {#graphqlconfig-filterinputoperatornames}
 
 The names of built-in filter operators.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `and` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the `and` operator. Usually `_and`. |
-| `or` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the `or` operator. Usually `_or`. |
-| `not` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the `not` operator. Usually `_not`. |
-| `isNull` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the `is null` operator. Usually `_is_null`. |
-
-
+| Key      | Value                                               | Required | Description                                             |
+| -------- | --------------------------------------------------- | -------- | ------------------------------------------------------- |
+| `and`    | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the `and` operator. Usually `_and`.         |
+| `or`     | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the `or` operator. Usually `_or`.           |
+| `not`    | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the `not` operator. Usually `_not`.         |
+| `isNull` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the `is null` operator. Usually `_is_null`. |
 
 #### OffsetInputGraphqlConfig {#graphqlconfig-offsetinputgraphqlconfig}
 
 Configuration for the offset operation.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the offset operation field. Usually `offset`. |
-
-
+| Key         | Value                                               | Required | Description                                               |
+| ----------- | --------------------------------------------------- | -------- | --------------------------------------------------------- |
+| `fieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the offset operation field. Usually `offset`. |
 
 #### LimitInputGraphqlConfig {#graphqlconfig-limitinputgraphqlconfig}
 
 Configuration for the limit operation.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of the limit operation field. Usually `limit`. |
-
-
+| Key         | Value                                               | Required | Description                                             |
+| ----------- | --------------------------------------------------- | -------- | ------------------------------------------------------- |
+| `fieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of the limit operation field. Usually `limit`. |
 
 #### ArgumentsInputGraphqlConfig {#graphqlconfig-argumentsinputgraphqlconfig}
 
 Configuration for the arguments input.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true | The name of arguments passing field. Usually `args`. |
-
-
+| Key         | Value                                               | Required | Description                                          |
+| ----------- | --------------------------------------------------- | -------- | ---------------------------------------------------- |
+| `fieldName` | [GraphQlFieldName](#graphqlconfig-graphqlfieldname) | true     | The name of arguments passing field. Usually `args`. |
 
 #### GraphQlFieldName {#graphqlconfig-graphqlfieldname}
 
 The name of a GraphQL object field.
 
-
 **Value:** string
-
 
 #### GraphQlTypeName {#graphqlconfig-graphqltypename}
 
 The name of a GraphQL type.
 
-
 **Value:** string
+

--- a/docs/reference/metadata-reference/index.mdx
+++ b/docs/reference/metadata-reference/index.mdx
@@ -17,6 +17,7 @@ keywords:
   - graphql api specifications
 hide_table_of_contents: true
 seoFrontMatterUpdated: true
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/"
 ---
 
 # Supergraph Modeling

--- a/docs/reference/metadata-reference/introduction.mdx
+++ b/docs/reference/metadata-reference/introduction.mdx
@@ -16,6 +16,7 @@ keywords:
   - data modeling
   - api permissions
 seoFrontMatterUpdated: true
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/introduction/"
 ---
 
 # Working with Metadata

--- a/docs/reference/metadata-reference/models.mdx
+++ b/docs/reference/metadata-reference/models.mdx
@@ -18,6 +18,7 @@ keywords:
   - data connectors
   - unique identifiers
 seoFrontMatterUpdated: true
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/models/"
 ---
 
 # Models

--- a/docs/reference/metadata-reference/orderby-expressions.mdx
+++ b/docs/reference/metadata-reference/orderby-expressions.mdx
@@ -14,6 +14,7 @@ keywords:
   - orderby expressions
 toc_max_heading_level: 4
 seoFrontMatterUpdated: false
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/orderby-expressions/"
 ---
 
 # OrderBy Expressions
@@ -91,18 +92,17 @@ Note here that we can specify different orderBy operators for `AlbumId` and `Art
 
 ## Metadata structure
 
-
 ### OrderByExpression {#orderbyexpression-orderbyexpression}
 
 Definition of an order by expression on an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `OrderByExpression` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [OrderByExpressionV1](#orderbyexpression-orderbyexpressionv1) | true | Definition of a type representing an order by expression on an OpenDD type. |
+| Key          | Value                                                         | Required | Description                                                                 |
+| ------------ | ------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `kind`       | `OrderByExpression`                                           | true     |                                                                             |
+| `version`    | `v1`                                                          | true     |                                                                             |
+| `definition` | [OrderByExpressionV1](#orderbyexpression-orderbyexpressionv1) | true     | Definition of a type representing an order by expression on an OpenDD type. |
 
- **Examples:**
+**Examples:**
 
 ```yaml
 kind: OrderByExpression
@@ -127,8 +127,6 @@ definition:
   description: Order by expression for Albums
 ```
 
-
-
 ```yaml
 kind: OrderByExpression
 version: v1
@@ -144,166 +142,132 @@ definition:
   description: Order by expression for Int
 ```
 
-
 #### OrderByExpressionV1 {#orderbyexpression-orderbyexpressionv1}
 
 Definition of a type representing an order by expression on an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [OrderByExpressionName](#orderbyexpression-orderbyexpressionname) | true | The name used to refer to this expression. This name is unique only in the context of the `orderedType` |
-| `operand` | [OrderByExpressionOperand](#orderbyexpression-orderbyexpressionoperand) | true | The type that this expression applies to. |
-| `graphql` | [OrderByExpressionGraphQlConfiguration](#orderbyexpression-orderbyexpressiongraphqlconfiguration) / null | false | Configuration for how this order by expression should appear in the GraphQL schema. |
-| `description` | string / null | false | The description of the order by expression. |
-
-
+| Key           | Value                                                                                                    | Required | Description                                                                                             |
+| ------------- | -------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `name`        | [OrderByExpressionName](#orderbyexpression-orderbyexpressionname)                                        | true     | The name used to refer to this expression. This name is unique only in the context of the `orderedType` |
+| `operand`     | [OrderByExpressionOperand](#orderbyexpression-orderbyexpressionoperand)                                  | true     | The type that this expression applies to.                                                               |
+| `graphql`     | [OrderByExpressionGraphQlConfiguration](#orderbyexpression-orderbyexpressiongraphqlconfiguration) / null | false    | Configuration for how this order by expression should appear in the GraphQL schema.                     |
+| `description` | string / null                                                                                            | false    | The description of the order by expression.                                                             |
 
 #### OrderByExpressionGraphQlConfiguration {#orderbyexpression-orderbyexpressiongraphqlconfiguration}
 
 GraphQL configuration settings for a type representing an order by expression on an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `expressionTypeName` | [GraphQlTypeName](#orderbyexpression-graphqltypename) | true | The name of a GraphQL type. |
-
-
+| Key                  | Value                                                 | Required | Description                 |
+| -------------------- | ----------------------------------------------------- | -------- | --------------------------- |
+| `expressionTypeName` | [GraphQlTypeName](#orderbyexpression-graphqltypename) | true     | The name of a GraphQL type. |
 
 #### GraphQlTypeName {#orderbyexpression-graphqltypename}
 
 The name of a GraphQL type.
 
-
 **Value:** string
-
 
 #### OrderByExpressionOperand {#orderbyexpression-orderbyexpressionoperand}
 
 Configuration for object or scalar order by expression
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `object` | [OrderByExpressionObjectOperand](#orderbyexpression-orderbyexpressionobjectoperand) | false | Definition of an type representing an order by expression on an OpenDD object type. |
-| `scalar` | [OrderByExpressionScalarOperand](#orderbyexpression-orderbyexpressionscalaroperand) | false | Definition of a type representing an order by expression on an OpenDD scalar type. |
-
-
+| Key      | Value                                                                               | Required | Description                                                                         |
+| -------- | ----------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------- |
+| `object` | [OrderByExpressionObjectOperand](#orderbyexpression-orderbyexpressionobjectoperand) | false    | Definition of an type representing an order by expression on an OpenDD object type. |
+| `scalar` | [OrderByExpressionScalarOperand](#orderbyexpression-orderbyexpressionscalaroperand) | false    | Definition of a type representing an order by expression on an OpenDD scalar type.  |
 
 #### OrderByExpressionScalarOperand {#orderbyexpression-orderbyexpressionscalaroperand}
 
 Definition of a type representing an order by expression on an OpenDD scalar type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `orderedType` | [TypeName](#orderbyexpression-typename) | true | The type that this expression applies to. |
-| `enableOrderByDirections` | [EnableAllOrSpecific](#orderbyexpression-enableallorspecific) | true | Order by directions supported by this scalar type. |
-
-
+| Key                       | Value                                                         | Required | Description                                        |
+| ------------------------- | ------------------------------------------------------------- | -------- | -------------------------------------------------- |
+| `orderedType`             | [TypeName](#orderbyexpression-typename)                       | true     | The type that this expression applies to.          |
+| `enableOrderByDirections` | [EnableAllOrSpecific](#orderbyexpression-enableallorspecific) | true     | Order by directions supported by this scalar type. |
 
 #### EnableAllOrSpecific {#orderbyexpression-enableallorspecific}
 
 Enable all or specific values.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `enableAll` | boolean | false |  |
-| `enableSpecific` | [[OrderByDirection](#orderbyexpression-orderbydirection)] | false |  |
-
-
+| Key              | Value                                                     | Required | Description |
+| ---------------- | --------------------------------------------------------- | -------- | ----------- |
+| `enableAll`      | boolean                                                   | false    |             |
+| `enableSpecific` | [[OrderByDirection](#orderbyexpression-orderbydirection)] | false    |             |
 
 #### OrderByDirection {#orderbyexpression-orderbydirection}
 
-
 **Value:** `Asc` / `Desc`
-
 
 #### TypeName {#orderbyexpression-typename}
 
 The type that this expression applies to.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| [InbuiltType](#orderbyexpression-inbuilttype) | An inbuilt primitive OpenDD type. |
-| [CustomTypeName](#orderbyexpression-customtypename) |  |
-
-
+| Value                                               | Description                       |
+| --------------------------------------------------- | --------------------------------- |
+| [InbuiltType](#orderbyexpression-inbuilttype)       | An inbuilt primitive OpenDD type. |
+| [CustomTypeName](#orderbyexpression-customtypename) |                                   |
 
 #### InbuiltType {#orderbyexpression-inbuilttype}
 
 An inbuilt primitive OpenDD type.
 
-
 **Value:** `ID` / `Int` / `Float` / `Boolean` / `String`
-
 
 #### OrderByExpressionObjectOperand {#orderbyexpression-orderbyexpressionobjectoperand}
 
 Definition of an type representing an order by expression on an OpenDD object type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `orderedType` | [CustomTypeName](#orderbyexpression-customtypename) | true | The type that this expression applies to. |
-| `orderableFields` | [[OrderByExpressionOrderableField](#orderbyexpression-orderbyexpressionorderablefield)] | true | Orderable fields of the `orderedType` |
-| `orderableRelationships` | [[OrderByExpressionOrderableRelationship](#orderbyexpression-orderbyexpressionorderablerelationship)] | true | Orderable relationships |
-
-
+| Key                      | Value                                                                                                 | Required | Description                               |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------- |
+| `orderedType`            | [CustomTypeName](#orderbyexpression-customtypename)                                                   | true     | The type that this expression applies to. |
+| `orderableFields`        | [[OrderByExpressionOrderableField](#orderbyexpression-orderbyexpressionorderablefield)]               | true     | Orderable fields of the `orderedType`     |
+| `orderableRelationships` | [[OrderByExpressionOrderableRelationship](#orderbyexpression-orderbyexpressionorderablerelationship)] | true     | Orderable relationships                   |
 
 #### OrderByExpressionOrderableRelationship {#orderbyexpression-orderbyexpressionorderablerelationship}
 
 Definition of a relationship in a type representing an order by expression on an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `relationshipName` | [RelationshipName](#orderbyexpression-relationshipname) | true | The name of the relationship. |
-| `orderByExpression` | [OrderByExpressionName](#orderbyexpression-orderbyexpressionname) / null | false | The OrderByExpression to use for this relationship. This is optional for model relationships. If not specified we use the model's OrderByExpression configuration. For local command relationships this is required. |
-
-
+| Key                 | Value                                                                    | Required | Description                                                                                                                                                                                                          |
+| ------------------- | ------------------------------------------------------------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `relationshipName`  | [RelationshipName](#orderbyexpression-relationshipname)                  | true     | The name of the relationship.                                                                                                                                                                                        |
+| `orderByExpression` | [OrderByExpressionName](#orderbyexpression-orderbyexpressionname) / null | false    | The OrderByExpression to use for this relationship. This is optional for model relationships. If not specified we use the model's OrderByExpression configuration. For local command relationships this is required. |
 
 #### RelationshipName {#orderbyexpression-relationshipname}
 
 The name of the GraphQL relationship field.
 
-
 **Value:** string
-
 
 #### OrderByExpressionOrderableField {#orderbyexpression-orderbyexpressionorderablefield}
 
 Definition of a field in a type representing an order by expression on an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [FieldName](#orderbyexpression-fieldname) | true |  |
-| `orderByExpression` | [OrderByExpressionName](#orderbyexpression-orderbyexpressionname) | true | OrderByExpression to use for this field. |
-
-
+| Key                 | Value                                                             | Required | Description                              |
+| ------------------- | ----------------------------------------------------------------- | -------- | ---------------------------------------- |
+| `fieldName`         | [FieldName](#orderbyexpression-fieldname)                         | true     |                                          |
+| `orderByExpression` | [OrderByExpressionName](#orderbyexpression-orderbyexpressionname) | true     | OrderByExpression to use for this field. |
 
 #### FieldName {#orderbyexpression-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### CustomTypeName {#orderbyexpression-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
-
 
 #### OrderByExpressionName {#orderbyexpression-orderbyexpressionname}
 
 The name of an order by expression.
 
-
 **Value:** string
+

--- a/docs/reference/metadata-reference/permissions.mdx
+++ b/docs/reference/metadata-reference/permissions.mdx
@@ -17,6 +17,7 @@ keywords:
   - api control rules
   - access management
 seoFrontMatterUpdated: true
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/permissions/"
 ---
 
 import Thumbnail from "@site/src/components/Thumbnail";
@@ -209,18 +210,17 @@ definition:
 
 ## Metadata structure
 
-
 ### TypePermissions {#typepermissions-typepermissions}
 
 Definition of permissions for an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `TypePermissions` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [TypePermissionsV1](#typepermissions-typepermissionsv1) | true | Definition of permissions for an OpenDD type. |
+| Key          | Value                                                   | Required | Description                                   |
+| ------------ | ------------------------------------------------------- | -------- | --------------------------------------------- |
+| `kind`       | `TypePermissions`                                       | true     |                                               |
+| `version`    | `v1`                                                    | true     |                                               |
+| `definition` | [TypePermissionsV1](#typepermissions-typepermissionsv1) | true     | Definition of permissions for an OpenDD type. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: TypePermissions
@@ -241,29 +241,26 @@ definition:
           - author_id
 ```
 
-
 #### TypePermissionsV1 {#typepermissions-typepermissionsv1}
 
 Definition of permissions for an OpenDD type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `typeName` | [CustomTypeName](#typepermissions-customtypename) | true | The name of the type for which permissions are being defined. Must be an object type. |
-| `permissions` | [[TypePermission](#typepermissions-typepermission)] | true | A list of type permissions, one for each role. |
-
-
+| Key           | Value                                               | Required | Description                                                                           |
+| ------------- | --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------- |
+| `typeName`    | [CustomTypeName](#typepermissions-customtypename)   | true     | The name of the type for which permissions are being defined. Must be an object type. |
+| `permissions` | [[TypePermission](#typepermissions-typepermission)] | true     | A list of type permissions, one for each role.                                        |
 
 #### TypePermission {#typepermissions-typepermission}
 
 Defines permissions for a particular role for a type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `role` | [Role](#typepermissions-role) | true | The role for which permissions are being defined. |
-| `output` | [TypeOutputPermission](#typepermissions-typeoutputpermission) / null | false | Permissions for this role when this type is used in an output context. If null, this type is inaccessible for this role in an output context. |
-| `input` | [TypeInputPermission](#typepermissions-typeinputpermission) / null | false | Permissions for this role when this type is used in an input context. If null, this type is accessible for this role in an input context. |
+| Key      | Value                                                                | Required | Description                                                                                                                                   |
+| -------- | -------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `role`   | [Role](#typepermissions-role)                                        | true     | The role for which permissions are being defined.                                                                                             |
+| `output` | [TypeOutputPermission](#typepermissions-typeoutputpermission) / null | false    | Permissions for this role when this type is used in an output context. If null, this type is inaccessible for this role in an output context. |
+| `input`  | [TypeInputPermission](#typepermissions-typeinputpermission) / null   | false    | Permissions for this role when this type is used in an input context. If null, this type is accessible for this role in an input context.     |
 
- **Example:**
+**Example:**
 
 ```yaml
 role: user
@@ -278,94 +275,78 @@ input:
         sessionVariable: x-hasura-user-id
 ```
 
-
 #### TypeInputPermission {#typepermissions-typeinputpermission}
 
 Permissions for a type for a particular role when used in an input context.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldPresets` | [[FieldPreset](#typepermissions-fieldpreset)] | false | Preset values for fields of the type |
-
-
+| Key            | Value                                         | Required | Description                          |
+| -------------- | --------------------------------------------- | -------- | ------------------------------------ |
+| `fieldPresets` | [[FieldPreset](#typepermissions-fieldpreset)] | false    | Preset values for fields of the type |
 
 #### FieldPreset {#typepermissions-fieldpreset}
 
 Preset value for a field
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#typepermissions-fieldname) | true | Field name for preset |
-| `value` | [ValueExpression](#typepermissions-valueexpression) | true | Value for preset |
-
-
+| Key     | Value                                               | Required | Description           |
+| ------- | --------------------------------------------------- | -------- | --------------------- |
+| `field` | [FieldName](#typepermissions-fieldname)             | true     | Field name for preset |
+| `value` | [ValueExpression](#typepermissions-valueexpression) | true     | Value for preset      |
 
 #### ValueExpression {#typepermissions-valueexpression}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | [OpenDdSessionVariable](#typepermissions-openddsessionvariable) | false |  |
-| `valueFromEnv` | string | false |  |
-
-
+| Key               | Value                                                           | Required | Description |
+| ----------------- | --------------------------------------------------------------- | -------- | ----------- |
+| `literal`         |                                                                 | false    |             |
+| `sessionVariable` | [OpenDdSessionVariable](#typepermissions-openddsessionvariable) | false    |             |
+| `valueFromEnv`    | string                                                          | false    |             |
 
 #### OpenDdSessionVariable {#typepermissions-openddsessionvariable}
 
 Used to represent the name of a session variable, like "x-hasura-role".
 
-
 **Value:** string
-
 
 #### TypeOutputPermission {#typepermissions-typeoutputpermission}
 
 Permissions for a type for a particular role when used in an output context.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `allowedFields` | [[FieldName](#typepermissions-fieldname)] | true | Fields of the type that are accessible for a role |
-
-
+| Key             | Value                                     | Required | Description                                       |
+| --------------- | ----------------------------------------- | -------- | ------------------------------------------------- |
+| `allowedFields` | [[FieldName](#typepermissions-fieldname)] | true     | Fields of the type that are accessible for a role |
 
 #### FieldName {#typepermissions-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### Role {#typepermissions-role}
 
 The role for which permissions are being defined.
 
-
 **Value:** string
-
 
 #### CustomTypeName {#typepermissions-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
+
 ### ModelPermissions {#modelpermissions-modelpermissions}
 
 Definition of permissions for an OpenDD model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `ModelPermissions` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [ModelPermissionsV1](#modelpermissions-modelpermissionsv1) | true | Definition of permissions for an OpenDD model. |
+| Key          | Value                                                      | Required | Description                                    |
+| ------------ | ---------------------------------------------------------- | -------- | ---------------------------------------------- |
+| `kind`       | `ModelPermissions`                                         | true     |                                                |
+| `version`    | `v1`                                                       | true     |                                                |
+| `definition` | [ModelPermissionsV1](#modelpermissions-modelpermissionsv1) | true     | Definition of permissions for an OpenDD model. |
 
- **Examples:**
+**Examples:**
 
 ```yaml
 kind: ModelPermissions
@@ -385,8 +366,6 @@ definition:
             value:
               sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 kind: ModelPermissions
@@ -410,28 +389,25 @@ definition:
                   sessionVariable: x-hasura-user-id
 ```
 
-
 #### ModelPermissionsV1 {#modelpermissions-modelpermissionsv1}
 
 Definition of permissions for an OpenDD model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `modelName` | [ModelName](#modelpermissions-modelname) | true | The name of the model for which permissions are being defined. |
-| `permissions` | [[ModelPermission](#modelpermissions-modelpermission)] | true | A list of model permissions, one for each role. |
-
-
+| Key           | Value                                                  | Required | Description                                                    |
+| ------------- | ------------------------------------------------------ | -------- | -------------------------------------------------------------- |
+| `modelName`   | [ModelName](#modelpermissions-modelname)               | true     | The name of the model for which permissions are being defined. |
+| `permissions` | [[ModelPermission](#modelpermissions-modelpermission)] | true     | A list of model permissions, one for each role.                |
 
 #### ModelPermission {#modelpermissions-modelpermission}
 
 Defines the permissions for an OpenDD model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `role` | [Role](#modelpermissions-role) | true | The role for which permissions are being defined. |
-| `select` | [SelectPermission](#modelpermissions-selectpermission) / null | false | The permissions for selecting from this model for this role. If this is null, the role is not allowed to query the model. |
+| Key      | Value                                                         | Required | Description                                                                                                               |
+| -------- | ------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `role`   | [Role](#modelpermissions-role)                                | true     | The role for which permissions are being defined.                                                                         |
+| `select` | [SelectPermission](#modelpermissions-selectpermission) / null | false    | The permissions for selecting from this model for this role. If this is null, the role is not allowed to query the model. |
 
- **Example:**
+**Example:**
 
 ```yaml
 role: user
@@ -448,71 +424,60 @@ select:
         literal: true
 ```
 
-
 #### SelectPermission {#modelpermissions-selectpermission}
 
 Defines the permissions for selecting a model for a role.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `filter` | null / [ModelPredicate](#modelpermissions-modelpredicate) | true | Filter expression when selecting rows for this model. Null filter implies all rows are selectable. |
-| `argumentPresets` | [[ArgumentPreset](#modelpermissions-argumentpreset)] | false | Preset values for arguments for this role |
-| `allowSubscriptions` | boolean | false | Whether the role is allowed to subscribe to the root fields of this model. |
-
-
+| Key                  | Value                                                     | Required | Description                                                                                        |
+| -------------------- | --------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `filter`             | null / [ModelPredicate](#modelpermissions-modelpredicate) | true     | Filter expression when selecting rows for this model. Null filter implies all rows are selectable. |
+| `argumentPresets`    | [[ArgumentPreset](#modelpermissions-argumentpreset)]      | false    | Preset values for arguments for this role                                                          |
+| `allowSubscriptions` | boolean                                                   | false    | Whether the role is allowed to subscribe to the root fields of this model.                         |
 
 #### ArgumentPreset {#modelpermissions-argumentpreset}
 
 Preset value for an argument
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argument` | [ArgumentName](#modelpermissions-argumentname) | true | Argument name for preset |
-| `value` | [ValueExpressionOrPredicate](#modelpermissions-valueexpressionorpredicate) | true | Value for preset |
-
-
+| Key        | Value                                                                      | Required | Description              |
+| ---------- | -------------------------------------------------------------------------- | -------- | ------------------------ |
+| `argument` | [ArgumentName](#modelpermissions-argumentname)                             | true     | Argument name for preset |
+| `value`    | [ValueExpressionOrPredicate](#modelpermissions-valueexpressionorpredicate) | true     | Value for preset         |
 
 #### ValueExpressionOrPredicate {#modelpermissions-valueexpressionorpredicate}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | [OpenDdSessionVariable](#modelpermissions-openddsessionvariable) | false | Used to represent the name of a session variable, like "x-hasura-role". |
-| `booleanExpression` | [ModelPredicate](#modelpermissions-modelpredicate) | false |  |
-| `valueFromEnv` | string | false |  |
-
-
+| Key                 | Value                                                            | Required | Description                                                             |
+| ------------------- | ---------------------------------------------------------------- | -------- | ----------------------------------------------------------------------- |
+| `literal`           |                                                                  | false    |                                                                         |
+| `sessionVariable`   | [OpenDdSessionVariable](#modelpermissions-openddsessionvariable) | false    | Used to represent the name of a session variable, like "x-hasura-role". |
+| `booleanExpression` | [ModelPredicate](#modelpermissions-modelpredicate)               | false    |                                                                         |
+| `valueFromEnv`      | string                                                           | false    |                                                                         |
 
 #### ArgumentName {#modelpermissions-argumentname}
 
 The name of an argument.
 
-
 **Value:** string
-
 
 #### ModelPredicate {#modelpermissions-modelpredicate}
 
 A predicate that can be used to restrict the objects returned when querying a model.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldComparison` | [FieldComparisonPredicate](#modelpermissions-fieldcomparisonpredicate) | false | Field comparison predicate filters objects based on a field value. |
-| `fieldIsNull` | [FieldIsNullPredicate](#modelpermissions-fieldisnullpredicate) | false | Predicate to check if the given field is null. |
-| `relationship` | [RelationshipPredicate](#modelpermissions-relationshippredicate) | false | Relationship predicate filters objects of a source model based on a predicate on the related model. |
-| `and` | [[ModelPredicate](#modelpermissions-modelpredicate)] | false |  |
-| `or` | [[ModelPredicate](#modelpermissions-modelpredicate)] | false |  |
-| `not` | [ModelPredicate](#modelpermissions-modelpredicate) | false |  |
+| Key               | Value                                                                  | Required | Description                                                                                         |
+| ----------------- | ---------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `fieldComparison` | [FieldComparisonPredicate](#modelpermissions-fieldcomparisonpredicate) | false    | Field comparison predicate filters objects based on a field value.                                  |
+| `fieldIsNull`     | [FieldIsNullPredicate](#modelpermissions-fieldisnullpredicate)         | false    | Predicate to check if the given field is null.                                                      |
+| `relationship`    | [RelationshipPredicate](#modelpermissions-relationshippredicate)       | false    | Relationship predicate filters objects of a source model based on a predicate on the related model. |
+| `and`             | [[ModelPredicate](#modelpermissions-modelpredicate)]                   | false    |                                                                                                     |
+| `or`              | [[ModelPredicate](#modelpermissions-modelpredicate)]                   | false    |                                                                                                     |
+| `not`             | [ModelPredicate](#modelpermissions-modelpredicate)                     | false    |                                                                                                     |
 
- **Examples:**
+**Examples:**
 
 ```yaml
 fieldComparison:
@@ -521,8 +486,6 @@ fieldComparison:
   value:
     sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 relationship:
@@ -534,8 +497,6 @@ relationship:
       value:
         sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 and:
@@ -551,8 +512,6 @@ and:
         literal: Hello World
 ```
 
-
-
 ```yaml
 not:
   fieldComparison:
@@ -562,112 +521,92 @@ not:
       sessionVariable: x-hasura-user-id
 ```
 
-
 #### RelationshipPredicate {#modelpermissions-relationshippredicate}
 
 Relationship predicate filters objects of a source model based on a predicate on the related model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [RelationshipName](#modelpermissions-relationshipname) | true | The name of the relationship of the object type of the model to follow. |
-| `predicate` | [ModelPredicate](#modelpermissions-modelpredicate) / null | false | The predicate to apply on the related objects. If this is null, then the predicate evaluates to true as long as there is at least one related object present. |
-
-
+| Key         | Value                                                     | Required | Description                                                                                                                                                   |
+| ----------- | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`      | [RelationshipName](#modelpermissions-relationshipname)    | true     | The name of the relationship of the object type of the model to follow.                                                                                       |
+| `predicate` | [ModelPredicate](#modelpermissions-modelpredicate) / null | false    | The predicate to apply on the related objects. If this is null, then the predicate evaluates to true as long as there is at least one related object present. |
 
 #### RelationshipName {#modelpermissions-relationshipname}
 
 The name of the GraphQL relationship field.
 
-
 **Value:** string
-
 
 #### FieldIsNullPredicate {#modelpermissions-fieldisnullpredicate}
 
 Predicate to check if the given field is null.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#modelpermissions-fieldname) | true | The name of the field that should be checked for a null value. |
-
-
+| Key     | Value                                    | Required | Description                                                    |
+| ------- | ---------------------------------------- | -------- | -------------------------------------------------------------- |
+| `field` | [FieldName](#modelpermissions-fieldname) | true     | The name of the field that should be checked for a null value. |
 
 #### FieldComparisonPredicate {#modelpermissions-fieldcomparisonpredicate}
 
 Field comparison predicate filters objects based on a field value.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#modelpermissions-fieldname) | true | The field name of the object type of the model to compare. |
-| `operator` | [OperatorName](#modelpermissions-operatorname) | true | The name of the operator to use for comparison. |
-| `value` | [ValueExpression](#modelpermissions-valueexpression) | true | The value expression to compare against. |
-
-
+| Key        | Value                                                | Required | Description                                                |
+| ---------- | ---------------------------------------------------- | -------- | ---------------------------------------------------------- |
+| `field`    | [FieldName](#modelpermissions-fieldname)             | true     | The field name of the object type of the model to compare. |
+| `operator` | [OperatorName](#modelpermissions-operatorname)       | true     | The name of the operator to use for comparison.            |
+| `value`    | [ValueExpression](#modelpermissions-valueexpression) | true     | The value expression to compare against.                   |
 
 #### ValueExpression {#modelpermissions-valueexpression}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | [OpenDdSessionVariable](#modelpermissions-openddsessionvariable) | false |  |
-| `valueFromEnv` | string | false |  |
-
-
+| Key               | Value                                                            | Required | Description |
+| ----------------- | ---------------------------------------------------------------- | -------- | ----------- |
+| `literal`         |                                                                  | false    |             |
+| `sessionVariable` | [OpenDdSessionVariable](#modelpermissions-openddsessionvariable) | false    |             |
+| `valueFromEnv`    | string                                                           | false    |             |
 
 #### OpenDdSessionVariable {#modelpermissions-openddsessionvariable}
 
 Used to represent the name of a session variable, like "x-hasura-role".
 
-
 **Value:** string
-
 
 #### OperatorName {#modelpermissions-operatorname}
 
 The name of an operator
 
-
 **Value:** string
-
 
 #### FieldName {#modelpermissions-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### Role {#modelpermissions-role}
 
 The role for which permissions are being defined.
 
-
 **Value:** string
-
 
 #### ModelName {#modelpermissions-modelname}
 
 The name of data model.
 
-
 **Value:** string
+
 ### CommandPermissions {#commandpermissions-commandpermissions}
 
 Definition of permissions for an OpenDD command.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `CommandPermissions` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [CommandPermissionsV1](#commandpermissions-commandpermissionsv1) | true | Definition of permissions for an OpenDD command. |
+| Key          | Value                                                            | Required | Description                                      |
+| ------------ | ---------------------------------------------------------------- | -------- | ------------------------------------------------ |
+| `kind`       | `CommandPermissions`                                             | true     |                                                  |
+| `version`    | `v1`                                                             | true     |                                                  |
+| `definition` | [CommandPermissionsV1](#commandpermissions-commandpermissionsv1) | true     | Definition of permissions for an OpenDD command. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: CommandPermissions
@@ -681,29 +620,26 @@ definition:
       allowExecution: true
 ```
 
-
 #### CommandPermissionsV1 {#commandpermissions-commandpermissionsv1}
 
 Definition of permissions for an OpenDD command.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `commandName` | [CommandName](#commandpermissions-commandname) | true | The name of the command for which permissions are being defined. |
-| `permissions` | [[CommandPermission](#commandpermissions-commandpermission)] | true | A list of command permissions, one for each role. |
-
-
+| Key           | Value                                                        | Required | Description                                                      |
+| ------------- | ------------------------------------------------------------ | -------- | ---------------------------------------------------------------- |
+| `commandName` | [CommandName](#commandpermissions-commandname)               | true     | The name of the command for which permissions are being defined. |
+| `permissions` | [[CommandPermission](#commandpermissions-commandpermission)] | true     | A list of command permissions, one for each role.                |
 
 #### CommandPermission {#commandpermissions-commandpermission}
 
 Defines the permissions for a role for a command.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `role` | [Role](#commandpermissions-role) | true | The role for which permissions are being defined. |
-| `allowExecution` | boolean | true | Whether the command is executable by the role. |
-| `argumentPresets` | [[ArgumentPreset](#commandpermissions-argumentpreset)] | false | Preset values for arguments for this role |
+| Key               | Value                                                  | Required | Description                                       |
+| ----------------- | ------------------------------------------------------ | -------- | ------------------------------------------------- |
+| `role`            | [Role](#commandpermissions-role)                       | true     | The role for which permissions are being defined. |
+| `allowExecution`  | boolean                                                | true     | Whether the command is executable by the role.    |
+| `argumentPresets` | [[ArgumentPreset](#commandpermissions-argumentpreset)] | false    | Preset values for arguments for this role         |
 
- **Example:**
+**Example:**
 
 ```yaml
 role: user
@@ -714,51 +650,44 @@ argumentPresets:
       session_variable: x-hasura-user_id
 ```
 
-
 #### ArgumentPreset {#commandpermissions-argumentpreset}
 
 Preset value for an argument
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argument` | [ArgumentName](#commandpermissions-argumentname) | true | Argument name for preset |
-| `value` | [ValueExpressionOrPredicate](#commandpermissions-valueexpressionorpredicate) | true | Value for preset |
-
-
+| Key        | Value                                                                        | Required | Description              |
+| ---------- | ---------------------------------------------------------------------------- | -------- | ------------------------ |
+| `argument` | [ArgumentName](#commandpermissions-argumentname)                             | true     | Argument name for preset |
+| `value`    | [ValueExpressionOrPredicate](#commandpermissions-valueexpressionorpredicate) | true     | Value for preset         |
 
 #### ValueExpressionOrPredicate {#commandpermissions-valueexpressionorpredicate}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | [OpenDdSessionVariable](#commandpermissions-openddsessionvariable) | false | Used to represent the name of a session variable, like "x-hasura-role". |
-| `booleanExpression` | [ModelPredicate](#commandpermissions-modelpredicate) | false |  |
-| `valueFromEnv` | string | false |  |
-
-
+| Key                 | Value                                                              | Required | Description                                                             |
+| ------------------- | ------------------------------------------------------------------ | -------- | ----------------------------------------------------------------------- |
+| `literal`           |                                                                    | false    |                                                                         |
+| `sessionVariable`   | [OpenDdSessionVariable](#commandpermissions-openddsessionvariable) | false    | Used to represent the name of a session variable, like "x-hasura-role". |
+| `booleanExpression` | [ModelPredicate](#commandpermissions-modelpredicate)               | false    |                                                                         |
+| `valueFromEnv`      | string                                                             | false    |                                                                         |
 
 #### ModelPredicate {#commandpermissions-modelpredicate}
 
 A predicate that can be used to restrict the objects returned when querying a model.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldComparison` | [FieldComparisonPredicate](#commandpermissions-fieldcomparisonpredicate) | false | Field comparison predicate filters objects based on a field value. |
-| `fieldIsNull` | [FieldIsNullPredicate](#commandpermissions-fieldisnullpredicate) | false | Predicate to check if the given field is null. |
-| `relationship` | [RelationshipPredicate](#commandpermissions-relationshippredicate) | false | Relationship predicate filters objects of a source model based on a predicate on the related model. |
-| `and` | [[ModelPredicate](#commandpermissions-modelpredicate)] | false |  |
-| `or` | [[ModelPredicate](#commandpermissions-modelpredicate)] | false |  |
-| `not` | [ModelPredicate](#commandpermissions-modelpredicate) | false |  |
+| Key               | Value                                                                    | Required | Description                                                                                         |
+| ----------------- | ------------------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------- |
+| `fieldComparison` | [FieldComparisonPredicate](#commandpermissions-fieldcomparisonpredicate) | false    | Field comparison predicate filters objects based on a field value.                                  |
+| `fieldIsNull`     | [FieldIsNullPredicate](#commandpermissions-fieldisnullpredicate)         | false    | Predicate to check if the given field is null.                                                      |
+| `relationship`    | [RelationshipPredicate](#commandpermissions-relationshippredicate)       | false    | Relationship predicate filters objects of a source model based on a predicate on the related model. |
+| `and`             | [[ModelPredicate](#commandpermissions-modelpredicate)]                   | false    |                                                                                                     |
+| `or`              | [[ModelPredicate](#commandpermissions-modelpredicate)]                   | false    |                                                                                                     |
+| `not`             | [ModelPredicate](#commandpermissions-modelpredicate)                     | false    |                                                                                                     |
 
- **Examples:**
+**Examples:**
 
 ```yaml
 fieldComparison:
@@ -767,8 +696,6 @@ fieldComparison:
   value:
     sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 relationship:
@@ -780,8 +707,6 @@ relationship:
       value:
         sessionVariable: x-hasura-user-id
 ```
-
-
 
 ```yaml
 and:
@@ -797,8 +722,6 @@ and:
         literal: Hello World
 ```
 
-
-
 ```yaml
 not:
   fieldComparison:
@@ -808,106 +731,84 @@ not:
       sessionVariable: x-hasura-user-id
 ```
 
-
 #### RelationshipPredicate {#commandpermissions-relationshippredicate}
 
 Relationship predicate filters objects of a source model based on a predicate on the related model.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [RelationshipName](#commandpermissions-relationshipname) | true | The name of the relationship of the object type of the model to follow. |
-| `predicate` | [ModelPredicate](#commandpermissions-modelpredicate) / null | false | The predicate to apply on the related objects. If this is null, then the predicate evaluates to true as long as there is at least one related object present. |
-
-
+| Key         | Value                                                       | Required | Description                                                                                                                                                   |
+| ----------- | ----------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`      | [RelationshipName](#commandpermissions-relationshipname)    | true     | The name of the relationship of the object type of the model to follow.                                                                                       |
+| `predicate` | [ModelPredicate](#commandpermissions-modelpredicate) / null | false    | The predicate to apply on the related objects. If this is null, then the predicate evaluates to true as long as there is at least one related object present. |
 
 #### RelationshipName {#commandpermissions-relationshipname}
 
 The name of the GraphQL relationship field.
 
-
 **Value:** string
-
 
 #### FieldIsNullPredicate {#commandpermissions-fieldisnullpredicate}
 
 Predicate to check if the given field is null.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#commandpermissions-fieldname) | true | The name of the field that should be checked for a null value. |
-
-
+| Key     | Value                                      | Required | Description                                                    |
+| ------- | ------------------------------------------ | -------- | -------------------------------------------------------------- |
+| `field` | [FieldName](#commandpermissions-fieldname) | true     | The name of the field that should be checked for a null value. |
 
 #### FieldComparisonPredicate {#commandpermissions-fieldcomparisonpredicate}
 
 Field comparison predicate filters objects based on a field value.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `field` | [FieldName](#commandpermissions-fieldname) | true | The field name of the object type of the model to compare. |
-| `operator` | [OperatorName](#commandpermissions-operatorname) | true | The name of the operator to use for comparison. |
-| `value` | [ValueExpression](#commandpermissions-valueexpression) | true | The value expression to compare against. |
-
-
+| Key        | Value                                                  | Required | Description                                                |
+| ---------- | ------------------------------------------------------ | -------- | ---------------------------------------------------------- |
+| `field`    | [FieldName](#commandpermissions-fieldname)             | true     | The field name of the object type of the model to compare. |
+| `operator` | [OperatorName](#commandpermissions-operatorname)       | true     | The name of the operator to use for comparison.            |
+| `value`    | [ValueExpression](#commandpermissions-valueexpression) | true     | The value expression to compare against.                   |
 
 #### ValueExpression {#commandpermissions-valueexpression}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | [OpenDdSessionVariable](#commandpermissions-openddsessionvariable) | false |  |
-| `valueFromEnv` | string | false |  |
-
-
+| Key               | Value                                                              | Required | Description |
+| ----------------- | ------------------------------------------------------------------ | -------- | ----------- |
+| `literal`         |                                                                    | false    |             |
+| `sessionVariable` | [OpenDdSessionVariable](#commandpermissions-openddsessionvariable) | false    |             |
+| `valueFromEnv`    | string                                                             | false    |             |
 
 #### OperatorName {#commandpermissions-operatorname}
 
 The name of an operator
 
-
 **Value:** string
-
 
 #### FieldName {#commandpermissions-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### OpenDdSessionVariable {#commandpermissions-openddsessionvariable}
 
 Used to represent the name of a session variable, like "x-hasura-role".
 
-
 **Value:** string
-
 
 #### ArgumentName {#commandpermissions-argumentname}
 
 The name of an argument.
 
-
 **Value:** string
-
 
 #### Role {#commandpermissions-role}
 
 The role for which permissions are being defined.
 
-
 **Value:** string
-
 
 #### CommandName {#commandpermissions-commandname}
 
 The name of a command.
 
-
 **Value:** string
+

--- a/docs/reference/metadata-reference/relationships.mdx
+++ b/docs/reference/metadata-reference/relationships.mdx
@@ -17,6 +17,7 @@ keywords:
   - hasura api configuration
 toc_max_heading_level: 4
 seoFrontMatterUpdated: true
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/relationships/"
 ---
 
 import GraphiQLIDE from "@site/src/components/GraphiQLIDE";
@@ -312,18 +313,17 @@ The CLI also works to automatically track your relationships for you whenever yo
 
 ## Metadata structure
 
-
 ### Relationship {#relationship-relationship}
 
 Definition of a relationship on an OpenDD type which allows it to be extended with related models or commands.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `Relationship` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [RelationshipV1](#relationship-relationshipv1) | true | Definition of a relationship on an OpenDD type which allows it to be extended with related models or commands. |
+| Key          | Value                                          | Required | Description                                                                                                    |
+| ------------ | ---------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `kind`       | `Relationship`                                 | true     |                                                                                                                |
+| `version`    | `v1`                                           | true     |                                                                                                                |
+| `definition` | [RelationshipV1](#relationship-relationshipv1) | true     | Definition of a relationship on an OpenDD type which allows it to be extended with related models or commands. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: Relationship
@@ -346,53 +346,47 @@ definition:
   description: Articles written by an author
 ```
 
-
 #### RelationshipV1 {#relationship-relationshipv1}
 
 Definition of a relationship on an OpenDD type which allows it to be extended with related models or commands.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [RelationshipName](#relationship-relationshipname) | true | The name of the relationship. |
-| `sourceType` | [CustomTypeName](#relationship-customtypename) | true | The source type of the relationship. |
-| `target` | [RelationshipTarget](#relationship-relationshiptarget) | true | The target of the relationship. |
-| `mapping` | [[RelationshipMapping](#relationship-relationshipmapping)] | true | The mapping configuration of source to target for the relationship. |
-| `description` | string / null | false | The description of the relationship. Gets added to the description of the relationship in the graphql schema. |
-| `deprecated` | [Deprecated](#relationship-deprecated) / null | false | Whether this relationship is deprecated. If set, the deprecation status is added to the relationship field's graphql schema. |
-| `graphql` | [RelationshipGraphQlDefinition](#relationship-relationshipgraphqldefinition) / null | false | Configuration for how this relationship should appear in the GraphQL schema. |
-
-
+| Key           | Value                                                                               | Required | Description                                                                                                                  |
+| ------------- | ----------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | [RelationshipName](#relationship-relationshipname)                                  | true     | The name of the relationship.                                                                                                |
+| `sourceType`  | [CustomTypeName](#relationship-customtypename)                                      | true     | The source type of the relationship.                                                                                         |
+| `target`      | [RelationshipTarget](#relationship-relationshiptarget)                              | true     | The target of the relationship.                                                                                              |
+| `mapping`     | [[RelationshipMapping](#relationship-relationshipmapping)]                          | true     | The mapping configuration of source to target for the relationship.                                                          |
+| `description` | string / null                                                                       | false    | The description of the relationship. Gets added to the description of the relationship in the graphql schema.                |
+| `deprecated`  | [Deprecated](#relationship-deprecated) / null                                       | false    | Whether this relationship is deprecated. If set, the deprecation status is added to the relationship field's graphql schema. |
+| `graphql`     | [RelationshipGraphQlDefinition](#relationship-relationshipgraphqldefinition) / null | false    | Configuration for how this relationship should appear in the GraphQL schema.                                                 |
 
 #### RelationshipGraphQlDefinition {#relationship-relationshipgraphqldefinition}
 
 The definition of how a relationship appears in the GraphQL API
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `aggregateFieldName` | [FieldName](#relationship-fieldname) / null | false | The field name to use for the field that represents an aggregate over the relationship |
-
-
+| Key                  | Value                                       | Required | Description                                                                            |
+| -------------------- | ------------------------------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `aggregateFieldName` | [FieldName](#relationship-fieldname) / null | false    | The field name to use for the field that represents an aggregate over the relationship |
 
 #### Deprecated {#relationship-deprecated}
 
-OpenDd configuration to indicate whether an object type field, relationship, model root field or command root field is deprecated.
+OpenDd configuration to indicate whether an object type field, relationship, model root field or command root field is
+deprecated.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `reason` | string / null | false | The reason for deprecation. |
-
-
+| Key      | Value         | Required | Description                 |
+| -------- | ------------- | -------- | --------------------------- |
+| `reason` | string / null | false    | The reason for deprecation. |
 
 #### RelationshipMapping {#relationship-relationshipmapping}
 
 Definition of a how a particular field in the source maps to a target field or argument.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `source` | [RelationshipMappingSource](#relationship-relationshipmappingsource) | true | The source configuration for this relationship mapping. |
-| `target` | [RelationshipMappingTarget](#relationship-relationshipmappingtarget) | true | The target configuration for this relationship mapping. |
+| Key      | Value                                                                | Required | Description                                             |
+| -------- | -------------------------------------------------------------------- | -------- | ------------------------------------------------------- |
+| `source` | [RelationshipMappingSource](#relationship-relationshipmappingsource) | true     | The source configuration for this relationship mapping. |
+| `target` | [RelationshipMappingTarget](#relationship-relationshipmappingtarget) | true     | The target configuration for this relationship mapping. |
 
- **Example:**
+**Example:**
 
 ```yaml
 source:
@@ -403,107 +397,86 @@ target:
     - fieldName: author_id
 ```
 
-
 #### RelationshipMappingTarget {#relationship-relationshipmappingtarget}
 
 The target configuration for a relationship mapping.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argument` | [ArgumentMappingTarget](#relationship-argumentmappingtarget) | false | An argument target for a relationship mapping. |
-| `modelField` | [[RelationshipSourceFieldAccess](#relationship-relationshipsourcefieldaccess)] | false |  |
-
-
+| Key          | Value                                                                          | Required | Description                                    |
+| ------------ | ------------------------------------------------------------------------------ | -------- | ---------------------------------------------- |
+| `argument`   | [ArgumentMappingTarget](#relationship-argumentmappingtarget)                   | false    | An argument target for a relationship mapping. |
+| `modelField` | [[RelationshipSourceFieldAccess](#relationship-relationshipsourcefieldaccess)] | false    |                                                |
 
 #### ArgumentMappingTarget {#relationship-argumentmappingtarget}
 
 An argument target for a relationship mapping.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argumentName` | [ArgumentName](#relationship-argumentname) | true |  |
-
-
+| Key            | Value                                      | Required | Description |
+| -------------- | ------------------------------------------ | -------- | ----------- |
+| `argumentName` | [ArgumentName](#relationship-argumentname) | true     |             |
 
 #### ArgumentName {#relationship-argumentname}
 
 The name of an argument.
 
-
 **Value:** string
-
 
 #### RelationshipMappingSource {#relationship-relationshipmappingsource}
 
 The source configuration for a relationship mapping.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `value` | [ValueExpression](#relationship-valueexpression) | false | An expression which evaluates to a value that can be used in permissions and various presets. |
-| `fieldPath` | [[RelationshipSourceFieldAccess](#relationship-relationshipsourcefieldaccess)] | false |  |
-
-
+| Key         | Value                                                                          | Required | Description                                                                                   |
+| ----------- | ------------------------------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------- |
+| `value`     | [ValueExpression](#relationship-valueexpression)                               | false    | An expression which evaluates to a value that can be used in permissions and various presets. |
+| `fieldPath` | [[RelationshipSourceFieldAccess](#relationship-relationshipsourcefieldaccess)] | false    |                                                                                               |
 
 #### RelationshipSourceFieldAccess {#relationship-relationshipsourcefieldaccess}
 
 A field access in a relationship mapping.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fieldName` | [FieldName](#relationship-fieldname) | true |  |
-
-
+| Key         | Value                                | Required | Description |
+| ----------- | ------------------------------------ | -------- | ----------- |
+| `fieldName` | [FieldName](#relationship-fieldname) | true     |             |
 
 #### FieldName {#relationship-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### ValueExpression {#relationship-valueexpression}
 
 An expression which evaluates to a value that can be used in permissions and various presets.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `literal` |  | false |  |
-| `sessionVariable` | [OpenDdSessionVariable](#relationship-openddsessionvariable) | false |  |
-| `valueFromEnv` | string | false |  |
-
-
+| Key               | Value                                                        | Required | Description |
+| ----------------- | ------------------------------------------------------------ | -------- | ----------- |
+| `literal`         |                                                              | false    |             |
+| `sessionVariable` | [OpenDdSessionVariable](#relationship-openddsessionvariable) | false    |             |
+| `valueFromEnv`    | string                                                       | false    |             |
 
 #### OpenDdSessionVariable {#relationship-openddsessionvariable}
 
 Used to represent the name of a session variable, like "x-hasura-role".
 
-
 **Value:** string
-
 
 #### RelationshipTarget {#relationship-relationshiptarget}
 
 The target for a relationship.
 
-
 **Must have exactly one of the following fields:**
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `model` | [ModelRelationshipTarget](#relationship-modelrelationshiptarget) | false | The target model for a relationship. |
-| `command` | [CommandRelationshipTarget](#relationship-commandrelationshiptarget) | false | The target command for a relationship. |
+| Key       | Value                                                                | Required | Description                            |
+| --------- | -------------------------------------------------------------------- | -------- | -------------------------------------- |
+| `model`   | [ModelRelationshipTarget](#relationship-modelrelationshiptarget)     | false    | The target model for a relationship.   |
+| `command` | [CommandRelationshipTarget](#relationship-commandrelationshiptarget) | false    | The target command for a relationship. |
 
- **Example:**
+**Example:**
 
 ```yaml
 model:
@@ -512,91 +485,73 @@ model:
   relationshipType: Array
 ```
 
-
 #### CommandRelationshipTarget {#relationship-commandrelationshiptarget}
 
 The target command for a relationship.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [CommandName](#relationship-commandname) | true | The name of the command. |
-| `subgraph` | string / null | false | The subgraph of the target command. Defaults to the current subgraph. |
-
-
+| Key        | Value                                    | Required | Description                                                           |
+| ---------- | ---------------------------------------- | -------- | --------------------------------------------------------------------- |
+| `name`     | [CommandName](#relationship-commandname) | true     | The name of the command.                                              |
+| `subgraph` | string / null                            | false    | The subgraph of the target command. Defaults to the current subgraph. |
 
 #### CommandName {#relationship-commandname}
 
 The name of a command.
 
-
 **Value:** string
-
 
 #### ModelRelationshipTarget {#relationship-modelrelationshiptarget}
 
 The target model for a relationship.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [ModelName](#relationship-modelname) | true | The name of the data model. |
-| `subgraph` | string / null | false | The subgraph of the target model. Defaults to the current subgraph. |
-| `relationshipType` | [RelationshipType](#relationship-relationshiptype) | true | Type of the relationship - object or array. |
-| `aggregate` | [ModelRelationshipTargetAggregate](#relationship-modelrelationshiptargetaggregate) / null | false | How to aggregate over the relationship. Only valid for array relationships |
-
-
+| Key                | Value                                                                                     | Required | Description                                                                |
+| ------------------ | ----------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------- |
+| `name`             | [ModelName](#relationship-modelname)                                                      | true     | The name of the data model.                                                |
+| `subgraph`         | string / null                                                                             | false    | The subgraph of the target model. Defaults to the current subgraph.        |
+| `relationshipType` | [RelationshipType](#relationship-relationshiptype)                                        | true     | Type of the relationship - object or array.                                |
+| `aggregate`        | [ModelRelationshipTargetAggregate](#relationship-modelrelationshiptargetaggregate) / null | false    | How to aggregate over the relationship. Only valid for array relationships |
 
 #### ModelRelationshipTargetAggregate {#relationship-modelrelationshiptargetaggregate}
 
 Which aggregate expression to use to aggregate the array relationship.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `aggregateExpression` | [AggregateExpressionName](#relationship-aggregateexpressionname) | true | The name of the aggregate expression that defines how to aggregate across the relationship. |
-| `description` | string / null | false | The description of the relationship aggregate. Gets added to the description of the aggregate field in the GraphQL schema |
-
-
+| Key                   | Value                                                            | Required | Description                                                                                                               |
+| --------------------- | ---------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `aggregateExpression` | [AggregateExpressionName](#relationship-aggregateexpressionname) | true     | The name of the aggregate expression that defines how to aggregate across the relationship.                               |
+| `description`         | string / null                                                    | false    | The description of the relationship aggregate. Gets added to the description of the aggregate field in the GraphQL schema |
 
 #### AggregateExpressionName {#relationship-aggregateexpressionname}
 
 The name of an aggregate expression.
 
-
 **Value:** string
-
 
 #### RelationshipType {#relationship-relationshiptype}
 
 Type of the relationship.
 
-
 **One of the following values:**
 
-| Value | Description |
-|-----|-----|
-| `Object` | Select one related object from the target. |
-| `Array` | Select multiple related objects from the target. |
-
-
+| Value    | Description                                      |
+| -------- | ------------------------------------------------ |
+| `Object` | Select one related object from the target.       |
+| `Array`  | Select multiple related objects from the target. |
 
 #### ModelName {#relationship-modelname}
 
 The name of data model.
 
-
 **Value:** string
-
 
 #### CustomTypeName {#relationship-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
-
 
 #### RelationshipName {#relationship-relationshipname}
 
 The name of the GraphQL relationship field.
 
-
 **Value:** string
+

--- a/docs/reference/metadata-reference/types.mdx
+++ b/docs/reference/metadata-reference/types.mdx
@@ -17,6 +17,7 @@ keywords:
   - custom types
 toc_max_heading_level: 4
 seoFrontMatterUpdated: true
+canonicalUrl: "https://promptql.io/docs/reference/metadata-reference/types/"
 ---
 
 # Types
@@ -155,18 +156,17 @@ definition:
 
 ## Metadata structure
 
-
 ### ScalarType {#scalartype-scalartype}
 
 Definition of a user-defined scalar type that that has opaque semantics.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `ScalarType` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [ScalarTypeV1](#scalartype-scalartypev1) | true | Definition of a user-defined scalar type that that has opaque semantics. |
+| Key          | Value                                    | Required | Description                                                              |
+| ------------ | ---------------------------------------- | -------- | ------------------------------------------------------------------------ |
+| `kind`       | `ScalarType`                             | true     |                                                                          |
+| `version`    | `v1`                                     | true     |                                                                          |
+| `definition` | [ScalarTypeV1](#scalartype-scalartypev1) | true     | Definition of a user-defined scalar type that that has opaque semantics. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: ScalarType
@@ -177,54 +177,47 @@ graphql:
 description: A custom string type
 ```
 
-
 #### ScalarTypeV1 {#scalartype-scalartypev1}
 
 Definition of a user-defined scalar type that that has opaque semantics.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [CustomTypeName](#scalartype-customtypename) | true | The name to give this scalar type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph. |
-| `graphql` | [ScalarTypeGraphQLConfiguration](#scalartype-scalartypegraphqlconfiguration) / null | false | Configuration for how this scalar type should appear in the GraphQL schema. |
-| `description` | string / null | false | The description of this scalar. Gets added to the description of the scalar's definition in the graphql schema. |
-
-
+| Key           | Value                                                                               | Required | Description                                                                                                                                 |
+| ------------- | ----------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | [CustomTypeName](#scalartype-customtypename)                                        | true     | The name to give this scalar type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph. |
+| `graphql`     | [ScalarTypeGraphQLConfiguration](#scalartype-scalartypegraphqlconfiguration) / null | false    | Configuration for how this scalar type should appear in the GraphQL schema.                                                                 |
+| `description` | string / null                                                                       | false    | The description of this scalar. Gets added to the description of the scalar's definition in the graphql schema.                             |
 
 #### ScalarTypeGraphQLConfiguration {#scalartype-scalartypegraphqlconfiguration}
 
 GraphQL configuration of an Open DD scalar type
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `typeName` | [GraphQlTypeName](#scalartype-graphqltypename) | true | The name of the GraphQl type to use for this scalar. |
-
-
+| Key        | Value                                          | Required | Description                                          |
+| ---------- | ---------------------------------------------- | -------- | ---------------------------------------------------- |
+| `typeName` | [GraphQlTypeName](#scalartype-graphqltypename) | true     | The name of the GraphQl type to use for this scalar. |
 
 #### GraphQlTypeName {#scalartype-graphqltypename}
 
 The name of a GraphQL type.
 
-
 **Value:** string
-
 
 #### CustomTypeName {#scalartype-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
+
 ### ObjectType {#objecttype-objecttype}
 
 Definition of a user-defined Open DD object type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `ObjectType` | true |  |
-| `version` | `v1` | true |  |
-| `definition` | [ObjectTypeV1](#objecttype-objecttypev1) | true | Definition of a user-defined Open DD object type. |
+| Key          | Value                                    | Required | Description                                       |
+| ------------ | ---------------------------------------- | -------- | ------------------------------------------------- |
+| `kind`       | `ObjectType`                             | true     |                                                   |
+| `version`    | `v1`                                     | true     |                                                   |
+| `definition` | [ObjectTypeV1](#objecttype-objecttypev1) | true     | Definition of a user-defined Open DD object type. |
 
- **Example:**
+**Example:**
 
 ```yaml
 kind: ObjectType
@@ -270,212 +263,174 @@ definition:
               ai_model: model
 ```
 
-
 #### ObjectTypeV1 {#objecttype-objecttypev1}
 
 Definition of a user-defined Open DD object type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [CustomTypeName](#objecttype-customtypename) | true | The name to give this object type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph. |
-| `fields` | [[ObjectFieldDefinition](#objecttype-objectfielddefinition)] | true | The list of fields defined for this object type. |
-| `globalIdFields` | [[FieldName](#objecttype-fieldname)] / null | false | The subset of fields that uniquely identify this object in the domain. Setting this property will automatically implement the GraphQL Relay Node interface for this object type and add an `id` global ID field. If setting this property, there must not be a field named `id` already present. |
-| `graphql` | [ObjectTypeGraphQLConfiguration](#objecttype-objecttypegraphqlconfiguration) / null | false | Configuration for how this object type should appear in the GraphQL schema. |
-| `description` | string / null | false | The description of the object. Gets added to the description of the object's definition in the graphql schema. |
-| `dataConnectorTypeMapping` | [[DataConnectorTypeMapping](#objecttype-dataconnectortypemapping)] | false | Mapping of this object type to corresponding object types in various data connectors. |
-
-
+| Key                        | Value                                                                               | Required | Description                                                                                                                                                                                                                                                                                      |
+| -------------------------- | ----------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                     | [CustomTypeName](#objecttype-customtypename)                                        | true     | The name to give this object type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph.                                                                                                                                                      |
+| `fields`                   | [[ObjectFieldDefinition](#objecttype-objectfielddefinition)]                        | true     | The list of fields defined for this object type.                                                                                                                                                                                                                                                 |
+| `globalIdFields`           | [[FieldName](#objecttype-fieldname)] / null                                         | false    | The subset of fields that uniquely identify this object in the domain. Setting this property will automatically implement the GraphQL Relay Node interface for this object type and add an `id` global ID field. If setting this property, there must not be a field named `id` already present. |
+| `graphql`                  | [ObjectTypeGraphQLConfiguration](#objecttype-objecttypegraphqlconfiguration) / null | false    | Configuration for how this object type should appear in the GraphQL schema.                                                                                                                                                                                                                      |
+| `description`              | string / null                                                                       | false    | The description of the object. Gets added to the description of the object's definition in the graphql schema.                                                                                                                                                                                   |
+| `dataConnectorTypeMapping` | [[DataConnectorTypeMapping](#objecttype-dataconnectortypemapping)]                  | false    | Mapping of this object type to corresponding object types in various data connectors.                                                                                                                                                                                                            |
 
 #### DataConnectorTypeMapping {#objecttype-dataconnectortypemapping}
 
-This defines the mapping of the fields of an object type to the corresponding columns of an object type in a data connector.
+This defines the mapping of the fields of an object type to the corresponding columns of an object type in a data
+connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `dataConnectorName` | [DataConnectorName](#objecttype-dataconnectorname) | true |  |
-| `dataConnectorObjectType` | [DataConnectorObjectType](#objecttype-dataconnectorobjecttype) | true |  |
-| `fieldMapping` | [FieldMappings](#objecttype-fieldmappings) | false |  |
-
-
+| Key                       | Value                                                          | Required | Description |
+| ------------------------- | -------------------------------------------------------------- | -------- | ----------- |
+| `dataConnectorName`       | [DataConnectorName](#objecttype-dataconnectorname)             | true     |             |
+| `dataConnectorObjectType` | [DataConnectorObjectType](#objecttype-dataconnectorobjecttype) | true     |             |
+| `fieldMapping`            | [FieldMappings](#objecttype-fieldmappings)                     | false    |             |
 
 #### FieldMappings {#objecttype-fieldmappings}
 
 Mapping of object fields to their source columns in the data connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [FieldMapping](#objecttype-fieldmapping) | false |  |
-
-
+| Key           | Value                                    | Required | Description |
+| ------------- | ---------------------------------------- | -------- | ----------- |
+| `<customKey>` | [FieldMapping](#objecttype-fieldmapping) | false    |             |
 
 #### FieldMapping {#objecttype-fieldmapping}
 
 Source field directly maps to some column in the data connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `column` | [ColumnFieldMapping](#objecttype-columnfieldmapping) | true | The target column in a data connector object that a source field maps to. |
-
-
+| Key      | Value                                                | Required | Description                                                               |
+| -------- | ---------------------------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `column` | [ColumnFieldMapping](#objecttype-columnfieldmapping) | true     | The target column in a data connector object that a source field maps to. |
 
 #### ColumnFieldMapping {#objecttype-columnfieldmapping}
 
 The target column in a data connector object that a source field maps to.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [DataConnectorColumnName](#objecttype-dataconnectorcolumnname) | true | The name of the target column |
-| `argumentMapping` | [ArgumentMapping](#objecttype-argumentmapping) / null | false | Arguments to the column field |
-
-
+| Key               | Value                                                          | Required | Description                   |
+| ----------------- | -------------------------------------------------------------- | -------- | ----------------------------- |
+| `name`            | [DataConnectorColumnName](#objecttype-dataconnectorcolumnname) | true     | The name of the target column |
+| `argumentMapping` | [ArgumentMapping](#objecttype-argumentmapping) / null          | false    | Arguments to the column field |
 
 #### ArgumentMapping {#objecttype-argumentmapping}
 
-Mapping of a comand or model argument name to the corresponding argument name used in the data connector. The key of this object is the argument name used in the command or model and the value is the argument name used in the data connector.
+Mapping of a comand or model argument name to the corresponding argument name used in the data connector. The key of
+this object is the argument name used in the command or model and the value is the argument name used in the data
+connector.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `<customKey>` | [DataConnectorArgumentName](#objecttype-dataconnectorargumentname) | false |  |
-
-
+| Key           | Value                                                              | Required | Description |
+| ------------- | ------------------------------------------------------------------ | -------- | ----------- |
+| `<customKey>` | [DataConnectorArgumentName](#objecttype-dataconnectorargumentname) | false    |             |
 
 #### DataConnectorArgumentName {#objecttype-dataconnectorargumentname}
 
 The name of an argument as defined by a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorColumnName {#objecttype-dataconnectorcolumnname}
 
 The name of a column in a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorObjectType {#objecttype-dataconnectorobjecttype}
 
 The name of an object type in a data connector.
 
-
 **Value:** string
-
 
 #### DataConnectorName {#objecttype-dataconnectorname}
 
 The name of a data connector.
 
-
 **Value:** string
-
 
 #### ObjectTypeGraphQLConfiguration {#objecttype-objecttypegraphqlconfiguration}
 
 GraphQL configuration of an Open DD object type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `typeName` | [GraphQlTypeName](#objecttype-graphqltypename) / null | false | The name to use for the GraphQL type representation of this object type when used in an output context. |
-| `inputTypeName` | [GraphQlTypeName](#objecttype-graphqltypename) / null | false | The name to use for the GraphQL type representation of this object type when used in an input context. |
-| `apolloFederation` | [ObjectApolloFederationConfig](#objecttype-objectapollofederationconfig) / null | false | Configuration for exposing apollo federation related types and directives. |
-
-
+| Key                | Value                                                                           | Required | Description                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `typeName`         | [GraphQlTypeName](#objecttype-graphqltypename) / null                           | false    | The name to use for the GraphQL type representation of this object type when used in an output context. |
+| `inputTypeName`    | [GraphQlTypeName](#objecttype-graphqltypename) / null                           | false    | The name to use for the GraphQL type representation of this object type when used in an input context.  |
+| `apolloFederation` | [ObjectApolloFederationConfig](#objecttype-objectapollofederationconfig) / null | false    | Configuration for exposing apollo federation related types and directives.                              |
 
 #### ObjectApolloFederationConfig {#objecttype-objectapollofederationconfig}
 
 Configuration for apollo federation related types and directives.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `keys` | [[ApolloFederationObjectKey](#objecttype-apollofederationobjectkey)] | true |  |
-
-
+| Key    | Value                                                                | Required | Description |
+| ------ | -------------------------------------------------------------------- | -------- | ----------- |
+| `keys` | [[ApolloFederationObjectKey](#objecttype-apollofederationobjectkey)] | true     |             |
 
 #### ApolloFederationObjectKey {#objecttype-apollofederationobjectkey}
 
 The definition of a key for an apollo federation object.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `fields` | [[FieldName](#objecttype-fieldname)] | true |  |
-
-
+| Key      | Value                                | Required | Description |
+| -------- | ------------------------------------ | -------- | ----------- |
+| `fields` | [[FieldName](#objecttype-fieldname)] | true     |             |
 
 #### GraphQlTypeName {#objecttype-graphqltypename}
 
 The name of a GraphQL type.
 
-
 **Value:** string
-
 
 #### ObjectFieldDefinition {#objecttype-objectfielddefinition}
 
 The definition of a field in a user-defined object type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [FieldName](#objecttype-fieldname) | true | The name of the field. This name is used both when referring to the field elsewhere in the metadata and when creating the corresponding GraphQl type. |
-| `type` | [TypeReference](#objecttype-typereference) | true | The type of this field. This uses the GraphQL syntax to represent field types and must refer to one of the inbuilt OpenDd types or another user-defined type. |
-| `description` | string / null | false | The description of this field. Gets added to the description of the field's definition in the graphql schema. |
-| `deprecated` | [Deprecated](#objecttype-deprecated) / null | false | Whether this field is deprecated. If set, the deprecation status is added to the field's graphql schema. |
-| `arguments` | [[FieldArgumentDefinition](#objecttype-fieldargumentdefinition)] | false | The arguments for the field |
-
-
+| Key           | Value                                                            | Required | Description                                                                                                                                                   |
+| ------------- | ---------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | [FieldName](#objecttype-fieldname)                               | true     | The name of the field. This name is used both when referring to the field elsewhere in the metadata and when creating the corresponding GraphQl type.         |
+| `type`        | [TypeReference](#objecttype-typereference)                       | true     | The type of this field. This uses the GraphQL syntax to represent field types and must refer to one of the inbuilt OpenDd types or another user-defined type. |
+| `description` | string / null                                                    | false    | The description of this field. Gets added to the description of the field's definition in the graphql schema.                                                 |
+| `deprecated`  | [Deprecated](#objecttype-deprecated) / null                      | false    | Whether this field is deprecated. If set, the deprecation status is added to the field's graphql schema.                                                      |
+| `arguments`   | [[FieldArgumentDefinition](#objecttype-fieldargumentdefinition)] | false    | The arguments for the field                                                                                                                                   |
 
 #### FieldArgumentDefinition {#objecttype-fieldargumentdefinition}
 
 The definition of an argument for a field in a user-defined object type.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `name` | [ArgumentName](#objecttype-argumentname) | true |  |
-| `argumentType` | [TypeReference](#objecttype-typereference) | true |  |
-| `description` | string / null | false |  |
-
-
+| Key            | Value                                      | Required | Description |
+| -------------- | ------------------------------------------ | -------- | ----------- |
+| `name`         | [ArgumentName](#objecttype-argumentname)   | true     |             |
+| `argumentType` | [TypeReference](#objecttype-typereference) | true     |             |
+| `description`  | string / null                              | false    |             |
 
 #### ArgumentName {#objecttype-argumentname}
 
 The name of an argument.
 
-
 **Value:** string
-
 
 #### Deprecated {#objecttype-deprecated}
 
-OpenDd configuration to indicate whether an object type field, relationship, model root field or command root field is deprecated.
+OpenDd configuration to indicate whether an object type field, relationship, model root field or command root field is
+deprecated.
 
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `reason` | string / null | false | The reason for deprecation. |
-
-
+| Key      | Value         | Required | Description                 |
+| -------- | ------------- | -------- | --------------------------- |
+| `reason` | string / null | false    | The reason for deprecation. |
 
 #### TypeReference {#objecttype-typereference}
 
-A reference to an Open DD type including nullable values and arrays.
-Suffix '!' to indicate a non-nullable reference, and wrap in '[]' to indicate an array.
-Eg: '[String!]!' is a non-nullable array of non-nullable strings.
-
+A reference to an Open DD type including nullable values and arrays. Suffix '!' to indicate a non-nullable reference,
+and wrap in '[]' to indicate an array. Eg: '[String!]!' is a non-nullable array of non-nullable strings.
 
 **Value:** string
-
 
 #### FieldName {#objecttype-fieldname}
 
 The name of a field in a user-defined object type.
 
-
 **Value:** string
-
 
 #### CustomTypeName {#objecttype-customtypename}
 
 The name of a user-defined type.
 
-
 **Value:** string
+

--- a/docs/reference/overview.mdx
+++ b/docs/reference/overview.mdx
@@ -12,6 +12,7 @@ keywords:
   - metadata
   - cli commands
 seoFrontMatterUpdated: false
+canonicalUrl: "https://promptql.io/docs/reference/overview/"
 ---
 
 # Reference

--- a/src/components/CanonicalUrl/index.tsx
+++ b/src/components/CanonicalUrl/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useDoc } from '@docusaurus/theme-common/internal';
+import Head from '@docusaurus/Head';
+
+export default function CanonicalUrl() {
+  const { metadata } = useDoc();
+  const canonicalUrl = metadata.frontMatter?.canonicalUrl as string | undefined;
+
+  if (!canonicalUrl) return null;
+
+  return (
+    <Head>
+      <link rel="canonical" href={canonicalUrl} />
+    </Head>
+  );
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -13,6 +13,7 @@ import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import Unlisted from '@theme/Unlisted';
 import CustomFooter from '@site/src/components/CustomFooter';
 import HasuraBanner from '@site/src/components/HasuraBanner';
+import CanonicalUrl from '@site/src/components/CanonicalUrl';
 import type { Props } from '@theme/DocItem/Layout';
 
 import styles from './styles.module.css';
@@ -44,24 +45,27 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
     metadata: { unlisted },
   } = useDoc();
   return (
-    <div className="row">
-      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
-        {unlisted && <Unlisted />}
-        <DocVersionBanner />
-        <div className={styles.docItemContainer}>
-          <article>
-            <DocBreadcrumbs />
-            <DocVersionBadge />
-            {docTOC.mobile}
-            <DocItemContent>{children}</DocItemContent>
-            <DocItemFooter />
-          </article>
-          <DocItemPaginator />
-          <HasuraBanner />
-          <CustomFooter />
+    <>
+      <CanonicalUrl />
+      <div className="row">
+        <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+          {unlisted && <Unlisted />}
+          <DocVersionBanner />
+          <div className={styles.docItemContainer}>
+            <article>
+              <DocBreadcrumbs />
+              <DocVersionBadge />
+              {docTOC.mobile}
+              <DocItemContent>{children}</DocItemContent>
+              <DocItemFooter />
+            </article>
+            <DocItemPaginator />
+            <HasuraBanner />
+            <CustomFooter />
+          </div>
         </div>
+        {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
       </div>
-      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Description 📝

Adds a `CanonicalUrl` component that allows us to explicitly define a `canonicalUrl` in frontmatter for any page we wish.

This allows an author to add `canonicalUrl: https://promptql.io/docs/<page_path>` for any content that is duplicated, and we want to promote SEO for the PromptQL version.

For pages that _don't_ contain `canonicalUrl` frontmatter, Docusaurus will continue to generate the canonical URL automatically.

Content changes will be incorporated in a follow-up PR that branches off this feature branch.