### PR TITLE
Update quickstart.mdx

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -148,7 +148,7 @@ code={`query UsersAndOrders{
     email
     orders {
       id 
-      created_at
+      createdAt
       status
     }
   }


### PR DESCRIPTION
Correct field name in query.  Field named created_at should be createdAt

## Description 📝

In Step 9 of the 3.0 Quickstart guide, the field `created_at` is not a valid field.  The query should instead reference `createdAt`.