### PR TITLE
private-ddn: update aws byoc permission

### DIFF
--- a/docs/private-ddn/creating-a-data-plane/byoc.mdx
+++ b/docs/private-ddn/creating-a-data-plane/byoc.mdx
@@ -115,6 +115,7 @@ Resources:
               - iam:GetServiceLinkedRoleDeletionStatus
               - sqs:GetQueueAttributes
               - rds:DescribeDBInstances
+              - rds:DescribeOrderableDBInstanceOptions
             Resource: '*'
           - Effect: Allow
             Action:


### PR DESCRIPTION
This pull request updates the permissions list in the `Resources:` section of the `docs/private-ddn/creating-a-data-plane/byoc.mdx` file. The change replaces the `rds:DescribeDBInstances` permission with `rds:DescribeOrderableDBInstanceOptions`.