### PR TITLE
add docs for pre-response plugin modes

### DIFF
--- a/docs/plugins/introduction.mdx
+++ b/docs/plugins/introduction.mdx
@@ -328,8 +328,8 @@ Please note that the session information will be carried forward and cannot be m
 ## Pre-Response Plugin
 
 The `pre-response` plugin is triggered at the final step in the execution pipeline after the query is executed. Use this
-step to add webhooks after the query is executed. Please note that the `pre-response` plugin cannot control or change
-the execution pipeline.
+step to add webhooks after the query is executed. Pre-response plugins can operate in two modes: asynchronous (default)
+or synchronous.
 
 For pre-response plugin configuration
 [click here](reference/metadata-reference/engine-plugins.mdx#lifecyclepluginhook-lifecyclepreresponsepluginhook).
@@ -367,27 +367,199 @@ The request sent to the plugin can be customized based on the plugin's
 
 :::
 
-### Pre-Response Plugin Response
+### Pre-Response Plugin Modes
 
-The `pre-response` plugin cannot control the execution pipeline. The response from the plugin is ignored by DDN.
+Pre-response plugins can operate in two modes:
+
+#### Asynchronous Mode (Default)
+
+In asynchronous mode, the engine sends requests to the plugin but does not wait for a response. The engine immediately
+sends the response to the client after executing the query. This is the default behavior if no mode is specified.
+
+The response from asynchronous pre-response plugins is ignored by DDN.
+
+```yaml title="Example configuration for an asynchronous pre-response plugin:"
+kind: LifecyclePluginHook
+version: v1
+definition:
+  name: async-pre-response-plugin
+  url:
+    valueFromEnv: PRE_RESPONSE_URL
+  pre: response
+  config:
+    request:
+      headers:
+        additional:
+          hasura-m-auth:
+            value: "your-strong-m-auth-key"
+      session: {}
+      rawRequest:
+        query: {}
+        variables: {}
+    mode:
+      type: asynchronous
+```
+
+#### Synchronous Mode
+
+In synchronous mode, the engine waits for the plugin to respond before sending the response to the client. This allows
+the plugin to modify the response or perform actions that must complete before the client receives the response.
+
+```yaml title="Example configuration for a synchronous pre-response plugin:"
+kind: LifecyclePluginHook
+version: v1
+definition:
+  name: sync-pre-response-plugin
+  url:
+    valueFromEnv: PRE_RESPONSE_URL
+  pre: response
+  config:
+    request:
+      headers:
+        additional:
+          hasura-m-auth:
+            value: "your-strong-m-auth-key"
+      session: {}
+      rawRequest:
+        query: {}
+        variables: {}
+    mode:
+      type: synchronous
+      onPluginFailure: continue
+```
+
+The `config.mode.type: synchronous` parameter enables synchronous operation, and `config.mode.onPluginFailure: continue`
+determines how the engine should handle failures in the plugin. The `onPluginFailure` can be set to either `continue` or
+`fail`.
+
+Synchronous pre-response plugins can return the following responses:
+
+| Response Type       | HTTP Status Code | Response Body     | Description                                                                |
+| ------------------- | ---------------- | ----------------- | -------------------------------------------------------------------------- |
+| `Continue`          | `204`            | None              | The original response will be sent to the client without modification.     |
+| `Modified Response` | `200`            | Modified response | The modified response will be sent to the client instead of the original.  |
+| `User Error`        | `400`            | Error object      | The plugin encountered a user error, which will be returned to the client. |
+| `Internal Error`    | `500`            | Error object      | Treated as an internal server error and returned to the client.            |
+
+:::note Performance Considerations Synchronous pre-response plugins add latency to the request processing as the engine
+must wait for the plugin to respond before sending the response to the client. Asynchronous plugins do not add latency
+as they run in parallel with the response being sent to the client. :::
 
 ### Use Cases
 
-The `pre-response` plugin can be used to add a number of functionalities to DDN. Some use cases also make use of the
-pre-parse plugin. They are:
+The `pre-response` plugin can be used to add a number of functionalities to DDN:
+
+#### Asynchronous Use Cases
 
 - **Slack Notifications**: Trigger Slack notifications after a query/mutation is executed.
-- **Cache Set**: Implement a cache set layer to store the response in the cache.
-- **Cache Invalidation**: Implement a cache invalidation layer to invalidate the cache based on the incoming request and
-  session information.
 - **Audit Logs**: Add audit logs to track the queries and mutations executed by the users.
+- **Analytics**: Collect analytics data about API usage patterns.
+- **Cache Set**: Implement a cache set layer to store the response in the cache for future requests.
+- **Cache Invalidation**: Implement a cache invalidation layer to invalidate the cache based on the incoming request.
+
+#### Synchronous Use Cases
+
+- **Response Transformation**: Modify or enrich the response data before it reaches the client.
+- **Data Masking**: Remove sensitive information from responses based on user permissions.
+- **Response Validation**: Validate responses against business rules before sending to clients.
+- **Adding Extensions**: Add custom extensions to the GraphQL response, such as timestamps, custom metadata, or computed
+  summary information.
 
 ### Multiple Pre-Response Plugins
 
 Multiple `pre-response` plugins can be configured in DDN metadata.
 
-The engine sends requests to all configured `pre-response` plugins in parallel. It does not wait for responses from the
-plugins and immediately sends the response generated by the engine to the client.
+#### Multiple Asynchronous Plugins
+
+For asynchronous plugins, the engine sends requests to all configured plugins in parallel. It does not wait for
+responses from the plugins and immediately sends the response generated by the engine to the client.
+
+#### Multiple Synchronous Plugins
+
+For synchronous plugins, the engine processes them in the order they are defined in the metadata. Each plugin receives
+the response as potentially modified by the previous plugin, creating a chain of response transformations.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Engine as "DDN Engine"
+    participant Hook1 as "Sync Pre-response Hook 1"
+    participant Hook2 as "Sync Pre-response Hook 2"
+
+    Client->>Engine: GraphQL Request
+    Engine->>Engine: Execute Query
+    Engine->>Hook1: Original Response
+
+    alt Hook1 returns Continue (204)
+        Hook1->>Engine: Continue (no changes)
+        Engine->>Hook2: Original Response
+    else Hook1 returns Modified Response (200)
+        Hook1->>Engine: Modified Response A
+        Engine->>Hook2: Modified Response A
+    else Hook1 returns Error (400/500)
+        Hook1->>Engine: Error Response
+        Engine->>Client: Error Response (skip remaining hooks)
+    end
+
+    alt Hook2 returns Continue (204)
+        Hook2->>Engine: Continue (no changes)
+        Engine->>Client: Current Response
+    else Hook2 returns Modified Response (200)
+        Hook2->>Engine: Modified Response B
+        Engine->>Client: Modified Response B
+    else Hook2 returns Error (400/500)
+        Hook2->>Engine: Error Response
+        Engine->>Client: Error Response
+    end
+```
+
+:::tip Plugin Ordering If you have multiple synchronous pre-response plugins that need to be executed in a specific
+order, define them in a single HML file. This ensures they are processed in the exact sequence you specify. :::
+
+#### Combining Synchronous and Asynchronous Plugins
+
+You can configure both synchronous and asynchronous pre-response plugins together. In this case:
+
+1. **Asynchronous plugins start executing immediately** in the background (fire-and-forget)
+2. **Synchronous plugins execute sequentially** in the order they are defined, creating a chain of response
+   transformations
+3. **The client receives the response** after synchronous plugins finish, while asynchronous plugins continue running in
+   the background
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Engine as "DDN Engine"
+    participant AsyncHook1 as "Async Plugin 1"
+    participant AsyncHook2 as "Async Plugin 2"
+    participant SyncHook1 as "Sync Plugin 1"
+    participant SyncHook2 as "Sync Plugin 2"
+
+    Client->>Engine: GraphQL Request
+    Engine->>Engine: Execute Query
+
+    Note over Engine,AsyncHook2: Asynchronous plugins start immediately (background)
+    par
+        Engine->>AsyncHook1: Original Response (fire-and-forget)
+    and
+        Engine->>AsyncHook2: Original Response (fire-and-forget)
+    end
+
+    Note over Engine,SyncHook2: Synchronous plugins execute sequentially
+    Engine->>SyncHook1: Original Response
+    SyncHook1->>Engine: Modified Response A
+    Engine->>SyncHook2: Modified Response A
+    SyncHook2->>Engine: Final Response
+
+    Engine->>Client: Final Response (async plugins continue in background)
+```
+
+This approach allows you to:
+
+- **Start background tasks immediately** using asynchronous plugins for logging, notifications, or analytics
+- **Transform responses** using synchronous plugins before the client receives them
+- **Optimize performance** by running non-blocking operations in parallel while only adding latency for operations that
+  must complete before the response is sent
 
 ## Pre-Route Plugin
 

--- a/docs/plugins/introduction.mdx
+++ b/docs/plugins/introduction.mdx
@@ -441,9 +441,13 @@ Synchronous pre-response plugins can return the following responses:
 | `User Error`        | `400`            | Error object      | The plugin encountered a user error, which will be returned to the client. |
 | `Internal Error`    | `500`            | Error object      | Treated as an internal server error and returned to the client.            |
 
-:::note Performance Considerations Synchronous pre-response plugins add latency to the request processing as the engine
-must wait for the plugin to respond before sending the response to the client. Asynchronous plugins do not add latency
-as they run in parallel with the response being sent to the client. :::
+:::note Performance Considerations
+
+Synchronous pre-response plugins add latency to the request processing as the engine must wait for the plugin to respond
+before sending the response to the client. Asynchronous plugins do not add latency as they run in parallel with the
+response being sent to the client.
+
+:::
 
 ### Use Cases
 
@@ -513,8 +517,12 @@ sequenceDiagram
     end
 ```
 
-:::tip Plugin Ordering If you have multiple synchronous pre-response plugins that need to be executed in a specific
-order, define them in a single HML file. This ensures they are processed in the exact sequence you specify. :::
+:::tip Plugin Ordering
+
+If you have multiple synchronous pre-response plugins that need to be executed in a specific order, define them in a
+single HML file. This ensures they are processed in the exact sequence you specify.
+
+:::
 
 #### Combining Synchronous and Asynchronous Plugins
 

--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -31,11 +31,15 @@ the behavior of your API at an early stage.
 
 Pre-response plugins are triggered at the final stage of the execution pipeline, **after the query has been executed but
 before the response is sent to the client**. These plugins allow you to execute logic based on the response such as
-calling third-party services before the client receives the response.
+calling third-party services. They can operate in asynchronous mode (default) for non-blocking operations like
+notifications, or synchronous mode for response modifications and operations that must complete before the client
+receives the response.
 
 ### Pre-Route plugins
 
-Pre-route plugins are executed at the very beginning of request handling, **before predefined endpoints are processed**. They allow you to insert custom HTTP handlers into your API, enabling features like REST-style GraphQL endpoints, internal tools, or documentation interfaces such as a GraphQL schema visualizer or Swagger UI for a JSON API.
+Pre-route plugins are executed at the very beginning of request handling, **before predefined endpoints are processed**.
+They allow you to insert custom HTTP handlers into your API, enabling features like REST-style GraphQL endpoints,
+internal tools, or documentation interfaces such as a GraphQL schema visualizer or Swagger UI for a JSON API.
 
 ## Find out more
 


### PR DESCRIPTION
## Description 📝

This PR adds docs for the pre-response plugin modes. There are two modes:

1. Asynchronous (default mode)
2. Synchronous

We have also added details about how they combine and behave.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

links will be updated soon....

Updated the "How plugins work" page:
Updated the overview page:

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->