### PR TITLE
chore: bifurcate metadata sync

### DIFF
--- a/docs/reference/metadata-reference/permissions.mdx
+++ b/docs/reference/metadata-reference/permissions.mdx
@@ -267,45 +267,6 @@ definition:
 ```
 
 
-
-```yaml
-kind: TypePermissions
-version: v2
-definition:
-  typeName: movie
-  permissions:
-    rulesBased:
-      - allowFields:
-          condition:
-            contains:
-              left:
-                sessionVariable: x-hasura-role
-              right:
-                literal:
-                  - admin
-                  - user
-                  - user_not
-                  - user_and
-                  - user_or
-                  - limited_fields_user
-          fields:
-            - movie_id
-            - rating
-            - title
-            - release_date
-      - denyFields:
-          condition:
-            contains:
-              left:
-                sessionVariable: x-hasura-role
-              right:
-                literal:
-                  - limited_fields_user
-          fields:
-            - rating
-```
-
-
 #### TypePermissions (v2) {#typepermissions-typepermissions-(v2)}
 
 | Key | Value | Required | Description |
@@ -497,72 +458,6 @@ definition:
 ```
 
 
-
-```yaml
-kind: ModelPermissions
-version: v2
-definition:
-  modelName: actors_by_movie
-  permissions:
-    rulesBased:
-      - allow:
-          condition:
-            contains:
-              left:
-                sessionVariable: x-hasura-role
-              right:
-                literal:
-                  - admin
-                  - user_with_preset_movie_id
-      - presetArgument:
-          condition:
-            equal:
-              left:
-                sessionVariable: x-hasura-role
-              right:
-                literal: user_with_preset_movie_id
-          argumentName: movie_id
-          value:
-            literal: 1
-```
-
-
-
-```yaml
-kind: ModelPermissions
-version: v2
-definition:
-  modelName: actors
-  permissions:
-    rulesBased:
-      - allow:
-          condition:
-            contains:
-              left:
-                sessionVariable: x-hasura-role
-              right:
-                literal:
-                  - admin
-                  - object_relationship_user
-      - filter:
-          condition:
-            equal:
-              left:
-                sessionVariable: x-hasura-role
-              right:
-                literal: object_relationship_user
-          predicate:
-            relationship:
-              name: Country
-              predicate:
-                fieldComparison:
-                  field: name
-                  operator: _eq
-                  value:
-                    literal: UK
-```
-
-
 #### ModelPermissions (v2) {#modelpermissions-modelpermissions-(v2)}
 
 | Key | Value | Required | Description |
@@ -580,145 +475,17 @@ Definition of permissions for an OpenDD model.
 | Key | Value | Required | Description |
 |-----|-----|-----|-----|
 | `modelName` | [ModelName](#modelpermissions-modelname) | true | The name of the model for which permissions are being defined. |
-| `permissions` | [ModelPermissionOperand](#modelpermissions-modelpermissionoperand) | true | Permissions for this model |
+| `permissions` | [RoleBased](#modelpermissions-rolebased) | true | Permissions for this model |
 
 
 
-#### ModelPermissionOperand {#modelpermissions-modelpermissionoperand}
+#### RoleBased {#modelpermissions-rolebased}
 
-Configuration for role-based model permissions
-
-
-**Must have exactly one of the following fields:**
+Definition of role-based type permissions on an OpenDD model
 
 | Key | Value | Required | Description |
 |-----|-----|-----|-----|
-| `roleBased` | [[ModelPermission](#modelpermissions-modelpermission)] | false |  |
-| `rulesBased` | [[ModelAuthorizationRule](#modelpermissions-modelauthorizationrule)] | false |  |
-
-
-
-#### ModelAuthorizationRule {#modelpermissions-modelauthorizationrule}
-
-A rule that determines which model and argument presets are available to a user
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `allow` | [Allow](#modelpermissions-allow) | false | Allow access if the condition evaluates to `true` |
-| `deny` | [Deny](#modelpermissions-deny) | false | Deny access if the condition evaluates to `true` |
-| `presetArgument` | [PresetArgument](#modelpermissions-presetargument) | false | A preset value for an argument that applies when the condition evaluates to `true` |
-| `filter` | [Filter](#modelpermissions-filter) | false | A filter that applies when the condition evaluates to `true` |
-| `allowRelationalOperations` | [AllowRelationalOperations](#modelpermissions-allowrelationaloperations) | false | Allow these relational operations if the condition evaluates to `true` |
-| `denyRelationalOperations` | [DenyRelationalOperations](#modelpermissions-denyrelationaloperations) | false | Deny these relational operations if the condition evaluates to `true` |
-
-
-
-#### DenyRelationalOperations {#modelpermissions-denyrelationaloperations}
-
-Deny these relational operations if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) | true |  |
-| `operations` | [[RelationalOperation](#modelpermissions-relationaloperation)] | true |  |
-
-
-
-#### AllowRelationalOperations {#modelpermissions-allowrelationaloperations}
-
-Allow these relational operations if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) / null | false |  |
-| `operations` | [[RelationalOperation](#modelpermissions-relationaloperation)] | true |  |
-
-
-
-#### RelationalOperation {#modelpermissions-relationaloperation}
-
-An operation on a model
-
-
-**Value:** `insert` / `update` / `delete`
-
-
-#### Filter {#modelpermissions-filter}
-
-A filter that applies when the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) / null | false |  |
-| `predicate` | [ModelPredicate](#modelpermissions-modelpredicate) | true |  |
-
-
-
-#### PresetArgument {#modelpermissions-presetargument}
-
-A preset value for an argument that applies when the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argumentName` | [ArgumentName](#modelpermissions-argumentname) | true |  |
-| `condition` | [Condition](#modelpermissions-condition) / null | false |  |
-| `value` | [ValueExpressionOrPredicate](#modelpermissions-valueexpressionorpredicate) | true |  |
-
-
-
-#### Deny {#modelpermissions-deny}
-
-Deny access if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) | true | A boolean expression used to determine if a rules-based permission should be applied. |
-
-
-
-#### Allow {#modelpermissions-allow}
-
-Allow access if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) / null | false |  |
-
-
-
-#### Condition {#modelpermissions-condition}
-
-A boolean expression used to determine if a rules-based permission should be applied.
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `and` | [[Condition](#modelpermissions-condition)] | false |  |
-| `or` | [[Condition](#modelpermissions-condition)] | false |  |
-| `not` | [Condition](#modelpermissions-condition) | false |  |
-| `equal` | [Comparison](#modelpermissions-comparison) | false | A left and right value for comparison |
-| `contains` | [Comparison](#modelpermissions-comparison) | false |  |
-| `greaterThan` | [Comparison](#modelpermissions-comparison) | false |  |
-| `lessThan` | [Comparison](#modelpermissions-comparison) | false |  |
-| `greaterThanOrEqual` | [Comparison](#modelpermissions-comparison) | false |  |
-| `lessThanOrEqual` | [Comparison](#modelpermissions-comparison) | false |  |
-| `isNull` | [ValueExpression](#modelpermissions-valueexpression) | false |  |
-
-
-
-#### Comparison {#modelpermissions-comparison}
-
-A left and right value for comparison
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `left` | [ValueExpression](#modelpermissions-valueexpression) | true |  |
-| `right` | [ValueExpression](#modelpermissions-valueexpression) | true |  |
+| `roleBased` | [[ModelPermission](#modelpermissions-modelpermission)] | true |  |
 
 
 
@@ -1032,7 +799,7 @@ Definition of permissions for an OpenDD command.
 | [CommandPermissions (v1)](#commandpermissions-commandpermissions-(v1)) |  |
 | [CommandPermissions (v2)](#commandpermissions-commandpermissions-(v2)) |  |
 
- **Examples:**
+ **Example:**
 
 ```yaml
 kind: CommandPermissions
@@ -1044,40 +811,6 @@ definition:
       allowExecution: true
     - role: user
       allowExecution: true
-```
-
-
-
-```yaml
-kind: CommandPermissions
-version: v2
-definition:
-  commandName: get_actors_with_filter
-  permissions:
-    rulesBased:
-      - allow:
-          condition:
-            contains:
-              left:
-                sessionVariable: x-hasura-role
-              right:
-                literal:
-                  - filter_user
-      - presetArgument:
-          condition:
-            equal:
-              left:
-                sessionVariable: x-hasura-role
-              right:
-                literal: filter_user
-          argumentName: actor_bool_exp
-          value:
-            booleanExpression:
-              fieldComparison:
-                field: actor_id
-                operator: _eq
-                value:
-                  literal: 4
 ```
 
 
@@ -1098,101 +831,17 @@ Definition of permissions for an OpenDD command.
 | Key | Value | Required | Description |
 |-----|-----|-----|-----|
 | `commandName` | [CommandName](#commandpermissions-commandname) | true | The name of the command for which permissions are being defined. |
-| `permissions` | [CommandPermissionOperand](#commandpermissions-commandpermissionoperand) | true | The permissions for the command. |
+| `permissions` | [RoleBased](#commandpermissions-rolebased) | true | The permissions for the command. |
 
 
 
-#### CommandPermissionOperand {#commandpermissions-commandpermissionoperand}
+#### RoleBased {#commandpermissions-rolebased}
 
-Configuration for role-based command permissions
-
-
-**Must have exactly one of the following fields:**
+Definition of role-based permissions on an OpenDD command
 
 | Key | Value | Required | Description |
 |-----|-----|-----|-----|
-| `roleBased` | [[CommandPermission](#commandpermissions-commandpermission)] | false |  |
-| `rulesBased` | [[CommandAuthorizationRule](#commandpermissions-commandauthorizationrule)] | false |  |
-
-
-
-#### CommandAuthorizationRule {#commandpermissions-commandauthorizationrule}
-
-A rule that determines which commands and argument presets are available to a user
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `allow` | [Allow](#commandpermissions-allow) | false |  |
-| `deny` | [Deny](#commandpermissions-deny) | false |  |
-| `presetArgument` | [PresetArgument](#commandpermissions-presetargument) | false |  |
-
-
-
-#### PresetArgument {#commandpermissions-presetargument}
-
-A preset value for an argument that applies when the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argumentName` | [ArgumentName](#commandpermissions-argumentname) | true |  |
-| `condition` | [Condition](#commandpermissions-condition) / null | false |  |
-| `value` | [ValueExpressionOrPredicate](#commandpermissions-valueexpressionorpredicate) | true |  |
-
-
-
-#### Deny {#commandpermissions-deny}
-
-Deny access if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#commandpermissions-condition) | true | A boolean expression used to determine if a rules-based permission should be applied. |
-
-
-
-#### Allow {#commandpermissions-allow}
-
-Allow access if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#commandpermissions-condition) / null | false |  |
-
-
-
-#### Condition {#commandpermissions-condition}
-
-A boolean expression used to determine if a rules-based permission should be applied.
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `and` | [[Condition](#commandpermissions-condition)] | false |  |
-| `or` | [[Condition](#commandpermissions-condition)] | false |  |
-| `not` | [Condition](#commandpermissions-condition) | false |  |
-| `equal` | [Comparison](#commandpermissions-comparison) | false | A left and right value for comparison |
-| `contains` | [Comparison](#commandpermissions-comparison) | false |  |
-| `greaterThan` | [Comparison](#commandpermissions-comparison) | false |  |
-| `lessThan` | [Comparison](#commandpermissions-comparison) | false |  |
-| `greaterThanOrEqual` | [Comparison](#commandpermissions-comparison) | false |  |
-| `lessThanOrEqual` | [Comparison](#commandpermissions-comparison) | false |  |
-| `isNull` | [ValueExpression](#commandpermissions-valueexpression) | false |  |
-
-
-
-#### Comparison {#commandpermissions-comparison}
-
-A left and right value for comparison
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `left` | [ValueExpression](#commandpermissions-valueexpression) | true |  |
-| `right` | [ValueExpression](#commandpermissions-valueexpression) | true |  |
+| `roleBased` | [[CommandPermission](#commandpermissions-commandpermission)] | true |  |
 
 
 

--- a/utilities/generate-metadata-docs/filter-rules-based.js
+++ b/utilities/generate-metadata-docs/filter-rules-based.js
@@ -1,0 +1,93 @@
+/**
+ * This script removes rules-based authorization content from the HML schema.
+ * It filters out:
+ * - RulesBased variants from oneOf/anyOf arrays
+ * - rulesBased keys from examples and definitions
+ * - Examples that become empty/meaningless after filtering (e.g., permissions: {})
+ */
+
+const fs = require('fs');
+
+/**
+ * Check if an object is empty or contains only empty nested objects
+ */
+function isEmptyOrMeaningless(obj) {
+  if (obj === null || obj === undefined) return true;
+  if (typeof obj !== 'object') return false;
+  if (Array.isArray(obj)) return obj.length === 0;
+
+  const keys = Object.keys(obj);
+  if (keys.length === 0) return true;
+
+  // Check if all values are empty
+  return keys.every(key => isEmptyOrMeaningless(obj[key]));
+}
+
+/**
+ * Check if an example has become meaningless after filtering
+ * (e.g., has permissions: {} which indicates it was a rules-based-only example)
+ */
+function isExampleMeaningless(example) {
+  if (!example || typeof example !== 'object') return false;
+
+  // Check if this is a permissions-related example with empty permissions
+  if (example.definition && example.definition.permissions) {
+    if (isEmptyOrMeaningless(example.definition.permissions)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Remove rules-based content from the schema
+ */
+function removeRulesBased(obj, isInExamplesArray = false) {
+  if (Array.isArray(obj)) {
+    return obj
+      .filter(item => {
+        // Remove objects that are RulesBased variants in oneOf/anyOf
+        if (item && typeof item === 'object') {
+          if (item.title === 'RulesBased') return false;
+          if (item.required && Array.isArray(item.required) && item.required.includes('rulesBased')) return false;
+        }
+        return true;
+      })
+      .map(item => removeRulesBased(item, isInExamplesArray))
+      .filter(item => {
+        // After processing, remove meaningless examples
+        if (isInExamplesArray && isExampleMeaningless(item)) {
+          return false;
+        }
+        return true;
+      });
+  }
+
+  if (obj && typeof obj === 'object') {
+    const result = {};
+    for (const [key, value] of Object.entries(obj)) {
+      // Skip rulesBased keys in examples and definitions
+      if (key === 'rulesBased') continue;
+
+      // Track if we're entering an examples array
+      const enteringExamples = key === 'examples' && Array.isArray(value);
+      result[key] = removeRulesBased(value, enteringExamples);
+    }
+    return result;
+  }
+
+  return obj;
+}
+
+const schemaPath = './hml_schema_resolved.json';
+
+try {
+  const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+  const filtered = removeRulesBased(schema, false);
+  fs.writeFileSync(schemaPath, JSON.stringify(filtered, null, 2));
+  console.log('✅ Rules-based authorization removed from hml_schema_resolved.json');
+} catch (error) {
+  console.error('❌ Failed to filter schema:', error.message);
+  process.exit(1);
+}

--- a/utilities/generate-metadata-docs/hml_schema_resolved.json
+++ b/utilities/generate-metadata-docs/hml_schema_resolved.json
@@ -24,11 +24,16 @@
                   "title": "v2_CompatibilityConfig",
                   "description": "The compatibility configuration of the Hasura metadata.",
                   "type": "object",
-                  "required": ["date", "kind"],
+                  "required": [
+                    "date",
+                    "kind"
+                  ],
                   "properties": {
                     "kind": {
                       "type": "string",
-                      "enum": ["CompatibilityConfig"]
+                      "enum": [
+                        "CompatibilityConfig"
+                      ]
                     },
                     "date": {
                       "description": "Any backwards incompatible changes made to Hasura DDN after this date won't impact the metadata.",
@@ -94,22 +99,32 @@
                       "title": "AuthConfigV1",
                       "description": "Definition of the authentication configuration v1, used by the API server.",
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["AuthConfig"]
+                          "enum": [
+                            "AuthConfig"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/AuthConfigV1",
                           "title": "AuthConfig (V1)",
                           "description": "Definition of the authentication configuration v1, used by the API server.",
                           "type": "object",
-                          "required": ["mode"],
+                          "required": [
+                            "mode"
+                          ],
                           "properties": {
                             "allowRoleEmulationBy": {
                               "anyOf": [
@@ -130,7 +145,9 @@
                               "oneOf": [
                                 {
                                   "type": "object",
-                                  "required": ["webhook"],
+                                  "required": [
+                                    "webhook"
+                                  ],
                                   "properties": {
                                     "webhook": {
                                       "$id": "https://hasura.io/jsonschemas/metadata/AuthHookConfig",
@@ -143,7 +160,10 @@
                                         }
                                       ],
                                       "type": "object",
-                                      "required": ["method", "url"],
+                                      "required": [
+                                        "method",
+                                        "url"
+                                      ],
                                       "properties": {
                                         "url": {
                                           "description": "The URL of the authentication webhook.",
@@ -157,7 +177,10 @@
                                               "$id": "https://hasura.io/jsonschemas/metadata/AuthHookMethod",
                                               "title": "AuthHookMethod",
                                               "type": "string",
-                                              "enum": ["Get", "Post"]
+                                              "enum": [
+                                                "Get",
+                                                "Post"
+                                              ]
                                             }
                                           ]
                                         }
@@ -169,7 +192,9 @@
                                 },
                                 {
                                   "type": "object",
-                                  "required": ["jwt"],
+                                  "required": [
+                                    "jwt"
+                                  ],
                                   "properties": {
                                     "jwt": {
                                       "$id": "https://hasura.io/jsonschemas/metadata/JWTConfig",
@@ -200,11 +225,18 @@
                                         }
                                       ],
                                       "type": "object",
-                                      "required": ["claimsConfig", "key", "tokenLocation"],
+                                      "required": [
+                                        "claimsConfig",
+                                        "key",
+                                        "tokenLocation"
+                                      ],
                                       "properties": {
                                         "audience": {
                                           "description": "Optional validation to check that the `aud` field is a member of the `audience` received, otherwise will throw error.",
-                                          "type": ["array", "null"],
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
                                           "items": {
                                             "type": "string"
                                           },
@@ -212,11 +244,17 @@
                                         },
                                         "issuer": {
                                           "description": "Optional validation to check that the `iss` field is a member of the `iss` received, otherwise will throw error.",
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         },
                                         "allowedSkew": {
                                           "description": "Allowed leeway (in seconds) to the `exp` validation to account for clock skew.",
-                                          "type": ["integer", "null"],
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
                                           "format": "uint64",
                                           "minimum": 0
                                         },
@@ -230,14 +268,19 @@
                                               "oneOf": [
                                                 {
                                                   "type": "object",
-                                                  "required": ["locations"],
+                                                  "required": [
+                                                    "locations"
+                                                  ],
                                                   "properties": {
                                                     "locations": {
                                                       "$id": "https://hasura.io/jsonschemas/metadata/JWTClaimsMap",
                                                       "title": "JWTClaimsMap",
                                                       "description": "Can be used when Hasura claims are not all present in the single object, but individual claims are provided a JSON pointer within the decoded JWT and optionally a default value.",
                                                       "type": "object",
-                                                      "required": ["x-hasura-allowed-roles", "x-hasura-default-role"],
+                                                      "required": [
+                                                        "x-hasura-allowed-roles",
+                                                        "x-hasura-default-role"
+                                                      ],
                                                       "properties": {
                                                         "x-hasura-default-role": {
                                                           "description": "JSON pointer to lookup the default role within the decoded JWT.",
@@ -249,7 +292,9 @@
                                                                 {
                                                                   "description": "Literal value of the claims mapping",
                                                                   "type": "object",
-                                                                  "required": ["literal"],
+                                                                  "required": [
+                                                                    "literal"
+                                                                  ],
                                                                   "properties": {
                                                                     "literal": {
                                                                       "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/0/oneOf/1/oneOf/0/properties/definition/properties/allowRoleEmulationBy/anyOf/0"
@@ -260,14 +305,18 @@
                                                                 {
                                                                   "description": "Look up the Hasura claims at the specified JSON Pointer and provide a default value if the lookup fails.",
                                                                   "type": "object",
-                                                                  "required": ["path"],
+                                                                  "required": [
+                                                                    "path"
+                                                                  ],
                                                                   "properties": {
                                                                     "path": {
                                                                       "$id": "https://hasura.io/jsonschemas/metadata/JWTClaimsMappingPathEntry_for_Role",
                                                                       "title": "JWTClaimsMappingPathEntry",
                                                                       "description": "Entry to lookup the Hasura claims at the specified JSON Pointer",
                                                                       "type": "object",
-                                                                      "required": ["path"],
+                                                                      "required": [
+                                                                        "path"
+                                                                      ],
                                                                       "properties": {
                                                                         "path": {
                                                                           "description": "JSON pointer to find the particular claim in the decoded JWT token.",
@@ -305,7 +354,9 @@
                                                                 {
                                                                   "description": "Literal value of the claims mapping",
                                                                   "type": "object",
-                                                                  "required": ["literal"],
+                                                                  "required": [
+                                                                    "literal"
+                                                                  ],
                                                                   "properties": {
                                                                     "literal": {
                                                                       "type": "array",
@@ -319,14 +370,18 @@
                                                                 {
                                                                   "description": "Look up the Hasura claims at the specified JSON Pointer and provide a default value if the lookup fails.",
                                                                   "type": "object",
-                                                                  "required": ["path"],
+                                                                  "required": [
+                                                                    "path"
+                                                                  ],
                                                                   "properties": {
                                                                     "path": {
                                                                       "$id": "https://hasura.io/jsonschemas/metadata/JWTClaimsMappingPathEntry_for_Array_of_Role",
                                                                       "title": "JWTClaimsMappingPathEntry",
                                                                       "description": "Entry to lookup the Hasura claims at the specified JSON Pointer",
                                                                       "type": "object",
-                                                                      "required": ["path"],
+                                                                      "required": [
+                                                                        "path"
+                                                                      ],
                                                                       "properties": {
                                                                         "path": {
                                                                           "description": "JSON pointer to find the particular claim in the decoded JWT token.",
@@ -335,7 +390,10 @@
                                                                         },
                                                                         "default": {
                                                                           "description": "Default value to be used when no value is found when looking up the value using the `path`.",
-                                                                          "type": ["array", "null"],
+                                                                          "type": [
+                                                                            "array",
+                                                                            "null"
+                                                                          ],
                                                                           "items": {
                                                                             "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/0/oneOf/1/oneOf/0/properties/definition/properties/allowRoleEmulationBy/anyOf/0"
                                                                           }
@@ -358,7 +416,9 @@
                                                           {
                                                             "description": "Literal value of the claims mapping",
                                                             "type": "object",
-                                                            "required": ["literal"],
+                                                            "required": [
+                                                              "literal"
+                                                            ],
                                                             "properties": {
                                                               "literal": {
                                                                 "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/0/oneOf/1/oneOf/0/properties/definition/properties/mode/oneOf/2/properties/noAuth/properties/sessionVariables/additionalProperties"
@@ -369,14 +429,18 @@
                                                           {
                                                             "description": "Look up the Hasura claims at the specified JSON Pointer and provide a default value if the lookup fails.",
                                                             "type": "object",
-                                                            "required": ["path"],
+                                                            "required": [
+                                                              "path"
+                                                            ],
                                                             "properties": {
                                                               "path": {
                                                                 "$id": "https://hasura.io/jsonschemas/metadata/JWTClaimsMappingPathEntry_for_SessionVariableValue",
                                                                 "title": "JWTClaimsMappingPathEntry",
                                                                 "description": "Entry to lookup the Hasura claims at the specified JSON Pointer",
                                                                 "type": "object",
-                                                                "required": ["path"],
+                                                                "required": [
+                                                                  "path"
+                                                                ],
                                                                 "properties": {
                                                                   "path": {
                                                                     "description": "JSON pointer to find the particular claim in the decoded JWT token.",
@@ -408,14 +472,19 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["namespace"],
+                                                  "required": [
+                                                    "namespace"
+                                                  ],
                                                   "properties": {
                                                     "namespace": {
                                                       "$id": "https://hasura.io/jsonschemas/metadata/JWTClaimsNamespace",
                                                       "title": "JWTClaimsNamespace",
                                                       "description": "Used when all of the Hasura claims are present in a single object within the decoded JWT.",
                                                       "type": "object",
-                                                      "required": ["claimsFormat", "location"],
+                                                      "required": [
+                                                        "claimsFormat",
+                                                        "location"
+                                                      ],
                                                       "properties": {
                                                         "claimsFormat": {
                                                           "description": "Format in which the Hasura claims will be present.",
@@ -427,12 +496,16 @@
                                                                 {
                                                                   "description": "Claims will be in the JSON format.",
                                                                   "type": "string",
-                                                                  "enum": ["Json"]
+                                                                  "enum": [
+                                                                    "Json"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "Claims will be in the Stringified JSON format.",
                                                                   "type": "string",
-                                                                  "enum": ["StringifiedJson"]
+                                                                  "enum": [
+                                                                    "StringifiedJson"
+                                                                  ]
                                                                 }
                                                               ]
                                                             }
@@ -465,11 +538,15 @@
                                                   "title": "JWTBearerAuthorizationLocation",
                                                   "description": "Get the bearer token from the `Authorization` header.",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["BearerAuthorization"]
+                                                      "enum": [
+                                                        "BearerAuthorization"
+                                                      ]
                                                     }
                                                   },
                                                   "additionalProperties": false
@@ -478,11 +555,16 @@
                                                   "title": "JWTCookieLocation",
                                                   "description": "Get the token from the Cookie header under the specified cookie name.",
                                                   "type": "object",
-                                                  "required": ["name", "type"],
+                                                  "required": [
+                                                    "name",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["Cookie"]
+                                                      "enum": [
+                                                        "Cookie"
+                                                      ]
                                                     },
                                                     "name": {
                                                       "type": "string"
@@ -494,11 +576,16 @@
                                                   "title": "JWTHeaderLocation",
                                                   "description": "Custom header from where the header should be parsed from.",
                                                   "type": "object",
-                                                  "required": ["name", "type"],
+                                                  "required": [
+                                                    "name",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["Header"]
+                                                      "enum": [
+                                                        "Header"
+                                                      ]
                                                     },
                                                     "name": {
                                                       "type": "string"
@@ -521,14 +608,19 @@
                                                 {
                                                   "description": "JWT mode when the algorithm `type` and `key` is known",
                                                   "type": "object",
-                                                  "required": ["fixed"],
+                                                  "required": [
+                                                    "fixed"
+                                                  ],
                                                   "properties": {
                                                     "fixed": {
                                                       "$id": "https://hasura.io/jsonschemas/metadata/JWTKeyConfig",
                                                       "title": "JWTKeyConfig",
                                                       "description": "JWT Secret config according to which the incoming JWT will be decoded.",
                                                       "type": "object",
-                                                      "required": ["algorithm", "key"],
+                                                      "required": [
+                                                        "algorithm",
+                                                        "key"
+                                                      ],
                                                       "properties": {
                                                         "algorithm": {
                                                           "description": "The algorithm used to decode the JWT.",
@@ -541,62 +633,86 @@
                                                                 {
                                                                   "description": "HMAC using SHA-256",
                                                                   "type": "string",
-                                                                  "enum": ["HS256"]
+                                                                  "enum": [
+                                                                    "HS256"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "HMAC using SHA-384",
                                                                   "type": "string",
-                                                                  "enum": ["HS384"]
+                                                                  "enum": [
+                                                                    "HS384"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "HMAC using SHA-512",
                                                                   "type": "string",
-                                                                  "enum": ["HS512"]
+                                                                  "enum": [
+                                                                    "HS512"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "ECDSA using SHA-256",
                                                                   "type": "string",
-                                                                  "enum": ["ES256"]
+                                                                  "enum": [
+                                                                    "ES256"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "ECDSA using SHA-384",
                                                                   "type": "string",
-                                                                  "enum": ["ES384"]
+                                                                  "enum": [
+                                                                    "ES384"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "RSASSA-PKCS1-v1_5 using SHA-256",
                                                                   "type": "string",
-                                                                  "enum": ["RS256"]
+                                                                  "enum": [
+                                                                    "RS256"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "RSASSA-PKCS1-v1_5 using SHA-384",
                                                                   "type": "string",
-                                                                  "enum": ["RS384"]
+                                                                  "enum": [
+                                                                    "RS384"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "RSASSA-PKCS1-v1_5 using SHA-512",
                                                                   "type": "string",
-                                                                  "enum": ["RS512"]
+                                                                  "enum": [
+                                                                    "RS512"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "RSASSA-PSS using SHA-256",
                                                                   "type": "string",
-                                                                  "enum": ["PS256"]
+                                                                  "enum": [
+                                                                    "PS256"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "RSASSA-PSS using SHA-384",
                                                                   "type": "string",
-                                                                  "enum": ["PS384"]
+                                                                  "enum": [
+                                                                    "PS384"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "RSASSA-PSS using SHA-512",
                                                                   "type": "string",
-                                                                  "enum": ["PS512"]
+                                                                  "enum": [
+                                                                    "PS512"
+                                                                  ]
                                                                 },
                                                                 {
                                                                   "description": "Edwards-curve Digital Signature Algorithm (EdDSA)",
                                                                   "type": "string",
-                                                                  "enum": ["EdDSA"]
+                                                                  "enum": [
+                                                                    "EdDSA"
+                                                                  ]
                                                                 }
                                                               ]
                                                             }
@@ -619,7 +735,9 @@
                                                 {
                                                   "description": "JWT mode where the `type` and `key` parameters are obtained dynamically through JWK.",
                                                   "type": "object",
-                                                  "required": ["jwkFromUrl"],
+                                                  "required": [
+                                                    "jwkFromUrl"
+                                                  ],
                                                   "properties": {
                                                     "jwkFromUrl": {
                                                       "type": "string",
@@ -640,7 +758,9 @@
                                 },
                                 {
                                   "type": "object",
-                                  "required": ["noAuth"],
+                                  "required": [
+                                    "noAuth"
+                                  ],
                                   "properties": {
                                     "noAuth": {
                                       "$id": "https://hasura.io/jsonschemas/metadata/NoAuthConfig",
@@ -655,7 +775,10 @@
                                         }
                                       ],
                                       "type": "object",
-                                      "required": ["role", "sessionVariables"],
+                                      "required": [
+                                        "role",
+                                        "sessionVariables"
+                                      ],
                                       "properties": {
                                         "role": {
                                           "description": "role to assume whilst running the engine",
@@ -692,22 +815,32 @@
                       "title": "AuthConfigV2",
                       "description": "Definition of the authentication configuration v2, used by the API server.",
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["AuthConfig"]
+                          "enum": [
+                            "AuthConfig"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v2"]
+                          "enum": [
+                            "v2"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/AuthConfigV2",
                           "title": "AuthConfig (V2)",
                           "description": "Definition of the authentication configuration v2, used by the API server.",
                           "type": "object",
-                          "required": ["mode"],
+                          "required": [
+                            "mode"
+                          ],
                           "properties": {
                             "mode": {
                               "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/0/oneOf/1/oneOf/0/properties/definition/properties/mode"
@@ -721,22 +854,32 @@
                     {
                       "title": "AuthConfigV3",
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["AuthConfig"]
+                          "enum": [
+                            "AuthConfig"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v3"]
+                          "enum": [
+                            "v3"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/AuthConfigV3",
                           "title": "AuthConfig (V3)",
                           "description": "Definition of the authentication configuration v3, used by the API server.",
                           "type": "object",
-                          "required": ["mode"],
+                          "required": [
+                            "mode"
+                          ],
                           "properties": {
                             "mode": {
                               "$id": "https://hasura.io/jsonschemas/metadata/AuthModeConfigV3",
@@ -745,7 +888,9 @@
                               "oneOf": [
                                 {
                                   "type": "object",
-                                  "required": ["webhook"],
+                                  "required": [
+                                    "webhook"
+                                  ],
                                   "properties": {
                                     "webhook": {
                                       "$id": "https://hasura.io/jsonschemas/metadata/AuthHookConfigV3",
@@ -759,7 +904,9 @@
                                           },
                                           "customHeadersConfig": {
                                             "headers": {
-                                              "forward": ["Authorization"],
+                                              "forward": [
+                                                "Authorization"
+                                              ],
                                               "additional": {
                                                 "user-agent": "hasura-ddn"
                                               }
@@ -778,7 +925,9 @@
                                               },
                                               "customHeadersConfig": {
                                                 "headers": {
-                                                  "forward": ["Authorization"],
+                                                  "forward": [
+                                                    "Authorization"
+                                                  ],
                                                   "additional": {
                                                     "user-agent": "hasura-ddn"
                                                   }
@@ -787,11 +936,16 @@
                                             }
                                           ],
                                           "type": "object",
-                                          "required": ["method", "url"],
+                                          "required": [
+                                            "method",
+                                            "url"
+                                          ],
                                           "properties": {
                                             "method": {
                                               "type": "string",
-                                              "enum": ["GET"]
+                                              "enum": [
+                                                "GET"
+                                              ]
                                             },
                                             "url": {
                                               "description": "The URL of the GET authentication webhook.",
@@ -812,7 +966,9 @@
                                                   "examples": [
                                                     {
                                                       "headers": {
-                                                        "forward": ["Authorization"],
+                                                        "forward": [
+                                                          "Authorization"
+                                                        ],
                                                         "additional": {
                                                           "user-agent": "hasura-ddn"
                                                         }
@@ -830,7 +986,9 @@
                                                           "description": "The configuration for the headers to be sent to the auth hook.",
                                                           "examples": [
                                                             {
-                                                              "forward": ["Authorization"],
+                                                              "forward": [
+                                                                "Authorization"
+                                                              ],
                                                               "additional": {
                                                                 "user-agent": "hasura-ddn"
                                                               }
@@ -846,14 +1004,18 @@
                                                                   "$id": "https://hasura.io/jsonschemas/metadata/AllOrList_for_String",
                                                                   "title": "AllOrList",
                                                                   "description": "A list of items or a wildcard.",
-                                                                  "examples": ["*"],
+                                                                  "examples": [
+                                                                    "*"
+                                                                  ],
                                                                   "anyOf": [
                                                                     {
                                                                       "$id": "https://hasura.io/jsonschemas/metadata/All",
                                                                       "title": "All",
                                                                       "description": "Wildcard: match all items",
                                                                       "type": "string",
-                                                                      "enum": ["*"]
+                                                                      "enum": [
+                                                                        "*"
+                                                                      ]
                                                                     },
                                                                     {
                                                                       "type": "array",
@@ -910,7 +1072,9 @@
                                                 },
                                                 "body": {
                                                   "headers": {
-                                                    "forward": ["Authorization"],
+                                                    "forward": [
+                                                      "Authorization"
+                                                    ],
                                                     "additional": {}
                                                   }
                                                 }
@@ -918,11 +1082,16 @@
                                             }
                                           ],
                                           "type": "object",
-                                          "required": ["method", "url"],
+                                          "required": [
+                                            "method",
+                                            "url"
+                                          ],
                                           "properties": {
                                             "method": {
                                               "type": "string",
-                                              "enum": ["POST"]
+                                              "enum": [
+                                                "POST"
+                                              ]
                                             },
                                             "url": {
                                               "description": "The URL of the POST authentication webhook.",
@@ -950,7 +1119,9 @@
                                                       },
                                                       "body": {
                                                         "headers": {
-                                                          "forward": ["Authorization"],
+                                                          "forward": [
+                                                            "Authorization"
+                                                          ],
                                                           "additional": {}
                                                         }
                                                       }
@@ -981,7 +1152,9 @@
                                                           "examples": [
                                                             {
                                                               "headers": {
-                                                                "forward": ["Authorization"],
+                                                                "forward": [
+                                                                  "Authorization"
+                                                                ],
                                                                 "additional": {}
                                                               }
                                                             }
@@ -1026,7 +1199,9 @@
                                 },
                                 {
                                   "type": "object",
-                                  "required": ["jwt"],
+                                  "required": [
+                                    "jwt"
+                                  ],
                                   "properties": {
                                     "jwt": {
                                       "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/0/oneOf/1/oneOf/0/properties/definition/properties/mode/oneOf/1/properties/jwt"
@@ -1036,7 +1211,9 @@
                                 },
                                 {
                                   "type": "object",
-                                  "required": ["noAuth"],
+                                  "required": [
+                                    "noAuth"
+                                  ],
                                   "properties": {
                                     "noAuth": {
                                       "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/0/oneOf/1/oneOf/0/properties/definition/properties/mode/oneOf/2/properties/noAuth"
@@ -1055,34 +1232,50 @@
                     {
                       "title": "AuthConfigV4",
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["AuthConfig"]
+                          "enum": [
+                            "AuthConfig"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v4"]
+                          "enum": [
+                            "v4"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/AuthConfigV4",
                           "title": "AuthConfig (V4)",
                           "description": "Definition of the authentication configuration v4, used by the API server.",
                           "type": "object",
-                          "required": ["mode"],
+                          "required": [
+                            "mode"
+                          ],
                           "properties": {
                             "mode": {
                               "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/0/oneOf/1/oneOf/2/properties/definition/properties/mode"
                             },
                             "alternativeModes": {
-                              "type": ["array", "null"],
+                              "type": [
+                                "array",
+                                "null"
+                              ],
                               "items": {
                                 "$id": "https://hasura.io/jsonschemas/metadata/AlternativeMode",
                                 "title": "AlternativeMode",
                                 "description": "Alternative Authentication Modes",
                                 "type": "object",
-                                "required": ["config", "identifier"],
+                                "required": [
+                                  "config",
+                                  "identifier"
+                                ],
                                 "properties": {
                                   "identifier": {
                                     "type": "string"
@@ -1111,26 +1304,39 @@
                       "title": "PromptQlConfigV2",
                       "description": "Definition of the configuration of PromptQL, v2",
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["PromptQlConfig"]
+                          "enum": [
+                            "PromptQlConfig"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v2"]
+                          "enum": [
+                            "v2"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/PromptQlConfigV2",
                           "title": "PromptQlConfigV2",
                           "description": "Definition of the configuration of PromptQL for the project",
                           "type": "object",
-                          "required": ["llm"],
+                          "required": [
+                            "llm"
+                          ],
                           "properties": {
                             "systemInstructions": {
                               "description": "Custom system instructions provided to every PromptQL thread that allows tailoring of behavior to match to the project's specific needs.",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "llm": {
                               "description": "Configuration of the LLM to be used for PromptQL",
@@ -1145,11 +1351,15 @@
                                       "title": "HasuraLlmConfig",
                                       "description": "Configuration settings for the Hasura-configured LLM",
                                       "type": "object",
-                                      "required": ["provider"],
+                                      "required": [
+                                        "provider"
+                                      ],
                                       "properties": {
                                         "provider": {
                                           "type": "string",
-                                          "enum": ["hasura"]
+                                          "enum": [
+                                            "hasura"
+                                          ]
                                         },
                                         "fallback": {
                                           "description": "The fallback LLM to use if the Hasura API is unavailable",
@@ -1176,19 +1386,29 @@
                                                   "title": "HasuraLlmOpenAiConfig",
                                                   "description": "Configuration settings for an OpenAI LLM, to be used via the Hasura-configured LLM proxy",
                                                   "type": "object",
-                                                  "required": ["provider"],
+                                                  "required": [
+                                                    "provider"
+                                                  ],
                                                   "properties": {
                                                     "provider": {
                                                       "type": "string",
-                                                      "enum": ["openai"]
+                                                      "enum": [
+                                                        "openai"
+                                                      ]
                                                     },
                                                     "model": {
                                                       "description": "The specific OpenAI model to use. If not specified, the default model will be used.",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     },
                                                     "baseUrl": {
                                                       "description": "The base URL to use for the OpenAI API. If not specified, the default URL will be used.",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     }
                                                   },
                                                   "additionalProperties": false
@@ -1198,19 +1418,29 @@
                                                   "title": "HasuraLlmAnthropicConfig",
                                                   "description": "Configuration settings for an Anthropic LLM, to be used via the Hasura-configured LLM proxy",
                                                   "type": "object",
-                                                  "required": ["provider"],
+                                                  "required": [
+                                                    "provider"
+                                                  ],
                                                   "properties": {
                                                     "provider": {
                                                       "type": "string",
-                                                      "enum": ["anthropic"]
+                                                      "enum": [
+                                                        "anthropic"
+                                                      ]
                                                     },
                                                     "model": {
                                                       "description": "The specific Anthropic model to use. If not specified, the default model will be used.",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     },
                                                     "baseUrl": {
                                                       "description": "The base URL to use for the Anthropic API. If not specified, the default URL will be used.",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     }
                                                   },
                                                   "additionalProperties": false
@@ -1220,19 +1450,30 @@
                                                   "title": "HasuraLlmAzureConfig",
                                                   "description": "Configuration settings for an Azure-provided LLM, to be used via the Hasura-configured LLM proxy",
                                                   "type": "object",
-                                                  "required": ["endpoint", "provider"],
+                                                  "required": [
+                                                    "endpoint",
+                                                    "provider"
+                                                  ],
                                                   "properties": {
                                                     "provider": {
                                                       "type": "string",
-                                                      "enum": ["azure"]
+                                                      "enum": [
+                                                        "azure"
+                                                      ]
                                                     },
                                                     "apiVersion": {
                                                       "description": "The specific Azure API version to use. If not specified, the default version will be used.",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     },
                                                     "model": {
                                                       "description": "The specific Azure model to use. If not specified, the default model will be used.",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     },
                                                     "endpoint": {
                                                       "description": "The endpoint to use for the Azure LLM API",
@@ -1246,15 +1487,22 @@
                                                   "title": "HasuraLlmGeminiConfig",
                                                   "description": "Configuration settings for a Gemini LLM, to be used via the Hasura-configured LLM proxy",
                                                   "type": "object",
-                                                  "required": ["provider"],
+                                                  "required": [
+                                                    "provider"
+                                                  ],
                                                   "properties": {
                                                     "provider": {
                                                       "type": "string",
-                                                      "enum": ["gemini"]
+                                                      "enum": [
+                                                        "gemini"
+                                                      ]
                                                     },
                                                     "model": {
                                                       "description": "The specific Gemini model to use. If not specified, the default model will be used.",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     },
                                                     "safetySettings": {
                                                       "description": "Safety settings for the Gemini API",
@@ -1275,11 +1523,16 @@
                                                   "title": "HasuraLlmBedrockConfig",
                                                   "description": "Configuration settings for an AWS Bedrock-provided LLM, to be used via the Hasura-configured LLM proxy",
                                                   "type": "object",
-                                                  "required": ["modelId", "provider"],
+                                                  "required": [
+                                                    "modelId",
+                                                    "provider"
+                                                  ],
                                                   "properties": {
                                                     "provider": {
                                                       "type": "string",
-                                                      "enum": ["bedrock"]
+                                                      "enum": [
+                                                        "bedrock"
+                                                      ]
                                                     },
                                                     "modelId": {
                                                       "description": "The specific AWS Bedrock model to use.",
@@ -1287,7 +1540,10 @@
                                                     },
                                                     "regionName": {
                                                       "description": "The specific AWS Bedrock region to use. If not specified, the region configured in the Hasura LLM proxy will be used.",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     }
                                                   },
                                                   "additionalProperties": false
@@ -1297,11 +1553,16 @@
                                                   "title": "HasuraLlmVertexConfig",
                                                   "description": "Configuration settings for a Vertex LLM, to be used via the Hasura-configured LLM proxy",
                                                   "type": "object",
-                                                  "required": ["modelId", "provider"],
+                                                  "required": [
+                                                    "modelId",
+                                                    "provider"
+                                                  ],
                                                   "properties": {
                                                     "provider": {
                                                       "type": "string",
-                                                      "enum": ["vertex"]
+                                                      "enum": [
+                                                        "vertex"
+                                                      ]
                                                     },
                                                     "modelId": {
                                                       "description": "The specific Gemini/Vertex model to use",
@@ -1309,7 +1570,10 @@
                                                     },
                                                     "googleLocation": {
                                                       "description": "The Vertex AI location (e.g., us-central1)",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     },
                                                     "safetySettings": {
                                                       "description": "Safety settings for Gemini-compatible models on Vertex",
@@ -1340,19 +1604,30 @@
                                       "title": "OpenAiLlmConfig",
                                       "description": "Configuration settings for an OpenAI LLM",
                                       "type": "object",
-                                      "required": ["apiKey", "provider"],
+                                      "required": [
+                                        "apiKey",
+                                        "provider"
+                                      ],
                                       "properties": {
                                         "provider": {
                                           "type": "string",
-                                          "enum": ["openai"]
+                                          "enum": [
+                                            "openai"
+                                          ]
                                         },
                                         "model": {
                                           "description": "The specific OpenAI model to use. If not specified, the default model will be used.",
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         },
                                         "baseUrl": {
                                           "description": "The base URL to use for the OpenAI API. If not specified, the default URL will be used.",
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         },
                                         "apiKey": {
                                           "description": "The API key to use for the OpenAI API",
@@ -1382,19 +1657,30 @@
                                       "title": "AnthropicLlmConfig",
                                       "description": "Configuration settings for an Anthropic LLM",
                                       "type": "object",
-                                      "required": ["apiKey", "provider"],
+                                      "required": [
+                                        "apiKey",
+                                        "provider"
+                                      ],
                                       "properties": {
                                         "provider": {
                                           "type": "string",
-                                          "enum": ["anthropic"]
+                                          "enum": [
+                                            "anthropic"
+                                          ]
                                         },
                                         "model": {
                                           "description": "The specific Anthropic model to use. If not specified, the default model will be used.",
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         },
                                         "baseUrl": {
                                           "description": "The base URL to use for the Anthropic API. If not specified, the default URL will be used.",
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         },
                                         "apiKey": {
                                           "description": "The API key to use for the Anthropic API",
@@ -1424,19 +1710,31 @@
                                       "title": "AzureLlmConfig",
                                       "description": "Configuration settings for an Azure-provided LLM",
                                       "type": "object",
-                                      "required": ["apiKey", "endpoint", "provider"],
+                                      "required": [
+                                        "apiKey",
+                                        "endpoint",
+                                        "provider"
+                                      ],
                                       "properties": {
                                         "provider": {
                                           "type": "string",
-                                          "enum": ["azure"]
+                                          "enum": [
+                                            "azure"
+                                          ]
                                         },
                                         "apiVersion": {
                                           "description": "The specific Azure API version to use. If not specified, the default version will be used.",
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         },
                                         "model": {
                                           "description": "The specific Azure model to use. If not specified, the default model will be used.",
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         },
                                         "endpoint": {
                                           "description": "The endpoint to use for the Azure LLM API",
@@ -1470,15 +1768,23 @@
                                       "title": "GeminiLlmConfig",
                                       "description": "Configuration settings for a Gemini LLM",
                                       "type": "object",
-                                      "required": ["apiKey", "provider"],
+                                      "required": [
+                                        "apiKey",
+                                        "provider"
+                                      ],
                                       "properties": {
                                         "provider": {
                                           "type": "string",
-                                          "enum": ["gemini"]
+                                          "enum": [
+                                            "gemini"
+                                          ]
                                         },
                                         "model": {
                                           "description": "The specific Gemini model to use. If not specified, the default model will be used.",
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         },
                                         "apiKey": {
                                           "description": "The API key to use for the Gemini API",
@@ -1541,22 +1847,30 @@
                                                         {
                                                           "description": "Always show regardless of probability of unsafe content",
                                                           "type": "string",
-                                                          "enum": ["blockNone"]
+                                                          "enum": [
+                                                            "blockNone"
+                                                          ]
                                                         },
                                                         {
                                                           "description": "Block when high probability of unsafe content",
                                                           "type": "string",
-                                                          "enum": ["blockOnlyHigh"]
+                                                          "enum": [
+                                                            "blockOnlyHigh"
+                                                          ]
                                                         },
                                                         {
                                                           "description": "Block when medium or high probability of unsafe content",
                                                           "type": "string",
-                                                          "enum": ["blockMediumAndAbove"]
+                                                          "enum": [
+                                                            "blockMediumAndAbove"
+                                                          ]
                                                         },
                                                         {
                                                           "description": "Block when low, medium or high probability of unsafe content",
                                                           "type": "string",
-                                                          "enum": ["blockLowAndAbove"]
+                                                          "enum": [
+                                                            "blockLowAndAbove"
+                                                          ]
                                                         }
                                                       ]
                                                     },
@@ -1614,7 +1928,9 @@
                                       "properties": {
                                         "provider": {
                                           "type": "string",
-                                          "enum": ["vertex"]
+                                          "enum": [
+                                            "vertex"
+                                          ]
                                         },
                                         "modelId": {
                                           "description": "The specific Gemini/Vertex model to use",
@@ -1677,7 +1993,9 @@
                                       "properties": {
                                         "provider": {
                                           "type": "string",
-                                          "enum": ["bedrock"]
+                                          "enum": [
+                                            "bedrock"
+                                          ]
                                         },
                                         "modelId": {
                                           "description": "The specific AWS Bedrock model to use.",
@@ -1735,11 +2053,16 @@
                                       "title": "SchemaSelector",
                                       "description": "LLM-based schema selector configuration",
                                       "type": "object",
-                                      "required": ["llm", "type"],
+                                      "required": [
+                                        "llm",
+                                        "type"
+                                      ],
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": ["llm_selector"]
+                                          "enum": [
+                                            "llm_selector"
+                                          ]
                                         },
                                         "llm": {
                                           "description": "LLM configuration to use for schema selection",
@@ -1751,13 +2074,19 @@
                                         },
                                         "maxItems": {
                                           "description": "Maximum number of items to select",
-                                          "type": ["integer", "null"],
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
                                           "format": "uint32",
                                           "minimum": 0
                                         },
                                         "instructions": {
                                           "description": "Custom instructions for the LLM selector",
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         },
                                         "alwaysInclude": {
                                           "description": "Schema items to always include in the selection",
@@ -1803,11 +2132,16 @@
                                       "title": "FixedSchema",
                                       "description": "Fixed schema selector configuration",
                                       "type": "object",
-                                      "required": ["tables", "type"],
+                                      "required": [
+                                        "tables",
+                                        "type"
+                                      ],
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": ["fixed"]
+                                          "enum": [
+                                            "fixed"
+                                          ]
                                         },
                                         "tables": {
                                           "description": "List of tables to include with their specific columns",
@@ -1817,7 +2151,11 @@
                                             "title": "FixedSchemaTable",
                                             "description": "Configuration for a fixed schema table with specific columns",
                                             "type": "object",
-                                            "required": ["columns", "schemaName", "tableName"],
+                                            "required": [
+                                              "columns",
+                                              "schemaName",
+                                              "tableName"
+                                            ],
                                             "properties": {
                                               "schemaName": {
                                                 "description": "The name of the schema",
@@ -1846,11 +2184,15 @@
                                       "title": "AllSchema",
                                       "description": "All schema selector configuration (includes all available schemas)",
                                       "type": "object",
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": ["all"]
+                                          "enum": [
+                                            "all"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -1882,7 +2224,10 @@
                                 "title": "AiPrimitivesLlmConfig",
                                 "description": "Configure PromptQL to use a particular LLM for a specific primitive",
                                 "type": "object",
-                                "required": ["llm", "primitiveName"],
+                                "required": [
+                                  "llm",
+                                  "primitiveName"
+                                ],
                                 "properties": {
                                   "primitiveName": {
                                     "description": "The name of the operation to override",
@@ -1916,7 +2261,9 @@
                                   "title": "ThreadTitleGenerationConfig",
                                   "description": "Configure title generation for threads in the PromptQL playground",
                                   "type": "object",
-                                  "required": ["enable"],
+                                  "required": [
+                                    "enable"
+                                  ],
                                   "properties": {
                                     "enable": {
                                       "description": "Whether or not to enable thread title generation (default: true)",
@@ -1945,14 +2292,20 @@
                             "maxAssistantActions": {
                               "description": "Maximum number of assistant actions that can be performed autonomously before the process is interrupted",
                               "default": null,
-                              "type": ["integer", "null"],
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
                               "format": "uint32",
                               "minimum": 0
                             },
                             "maxTableArtifactSampleRows": {
                               "description": "Maximum number of rows to show to the LLM when sampling table artifacts",
                               "default": null,
-                              "type": ["integer", "null"],
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
                               "format": "uint32",
                               "minimum": 0
                             },
@@ -1967,19 +2320,31 @@
                                   "properties": {
                                     "enable_automations": {
                                       "description": "Enable the experimental automations feature",
-                                      "type": ["boolean", "null"]
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
                                     },
                                     "enable_visualizations": {
                                       "description": "Enable the experimental visualizations feature",
-                                      "type": ["boolean", "null"]
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
                                     },
                                     "enable_visualizations_v2": {
                                       "description": "Enable the experimental visualizations v2 feature",
-                                      "type": ["boolean", "null"]
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
                                     },
                                     "enable_visualizations_v3": {
                                       "description": "Enable the experimental visualizations v3 feature",
-                                      "type": ["boolean", "null"]
+                                      "type": [
+                                        "boolean",
+                                        "null"
+                                      ]
                                     }
                                   },
                                   "additionalProperties": true
@@ -1992,7 +2357,10 @@
                             "contextWindowLimit": {
                               "description": "Maximum number of tokens to be used for the context window for threads.",
                               "default": null,
-                              "type": ["integer", "null"],
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
                               "format": "uint32",
                               "minimum": 0
                             }
@@ -2013,22 +2381,34 @@
                       "title": "WikiPageV1",
                       "description": "Definition of a wiki page, v1",
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["WikiPage"]
+                          "enum": [
+                            "WikiPage"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/WikiPageV1",
                           "title": "WikiPageV1",
                           "description": "Definition of a wiki page",
                           "type": "object",
-                          "required": ["definition", "details", "title"],
+                          "required": [
+                            "definition",
+                            "details",
+                            "title"
+                          ],
                           "properties": {
                             "title": {
                               "description": "The title of the wiki page",
@@ -2077,7 +2457,10 @@
                                 "title": "WikiSection",
                                 "description": "Definition of a section inside a wiki page",
                                 "type": "object",
-                                "required": ["content", "title"],
+                                "required": [
+                                  "content",
+                                  "title"
+                                ],
                                 "properties": {
                                   "title": {
                                     "description": "The title of the section",
@@ -2155,22 +2538,34 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["DataConnectorLink"]
+                          "enum": [
+                            "DataConnectorLink"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/DataConnectorLinkV1",
                           "title": "DataConnectorLinkV1",
                           "description": "Definition of a data connector - version 1.",
                           "type": "object",
-                          "required": ["name", "schema", "url"],
+                          "required": [
+                            "name",
+                            "schema",
+                            "url"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name of the data connector.",
@@ -2194,7 +2589,9 @@
                                   "oneOf": [
                                     {
                                       "type": "object",
-                                      "required": ["singleUrl"],
+                                      "required": [
+                                        "singleUrl"
+                                      ],
                                       "properties": {
                                         "singleUrl": {
                                           "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/15/oneOf/0/properties/definition/oneOf/0/properties/url/allOf/0"
@@ -2204,14 +2601,19 @@
                                     },
                                     {
                                       "type": "object",
-                                      "required": ["readWriteUrls"],
+                                      "required": [
+                                        "readWriteUrls"
+                                      ],
                                       "properties": {
                                         "readWriteUrls": {
                                           "$id": "https://hasura.io/jsonschemas/metadata/ReadWriteUrls",
                                           "title": "ReadWriteUrls",
                                           "description": "A pair of URLs to access a data connector, one for reading and one for writing.",
                                           "type": "object",
-                                          "required": ["read", "write"],
+                                          "required": [
+                                            "read",
+                                            "write"
+                                          ],
                                           "properties": {
                                             "read": {
                                               "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/15/oneOf/0/properties/definition/oneOf/0/properties/url/allOf/0"
@@ -2256,11 +2658,17 @@
                                       "title": "SchemaAndCapabilitiesV01",
                                       "description": "Version 0.1 of schema and capabilities for a data connector.",
                                       "type": "object",
-                                      "required": ["capabilities", "schema", "version"],
+                                      "required": [
+                                        "capabilities",
+                                        "schema",
+                                        "version"
+                                      ],
                                       "properties": {
                                         "version": {
                                           "type": "string",
-                                          "enum": ["v0.1"]
+                                          "enum": [
+                                            "v0.1"
+                                          ]
                                         },
                                         "schema": {
                                           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -2326,7 +2734,10 @@
                                               "title": "Scalar Type",
                                               "description": "The definition of a scalar type, i.e. types that can be used as the types of columns.",
                                               "type": "object",
-                                              "required": ["aggregate_functions", "comparison_operators"],
+                                              "required": [
+                                                "aggregate_functions",
+                                                "comparison_operators"
+                                              ],
                                               "properties": {
                                                 "representation": {
                                                   "description": "A description of valid values for this scalar type. Defaults to `TypeRepresentation::JSON` if omitted",
@@ -2362,22 +2773,30 @@
                                                 {
                                                   "description": "JSON booleans",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["boolean"]
+                                                      "enum": [
+                                                        "boolean"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Any JSON string",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["string"]
+                                                      "enum": [
+                                                        "string"
+                                                      ]
                                                     }
                                                   }
                                                 },
@@ -2385,11 +2804,15 @@
                                                   "description": "Any JSON number",
                                                   "deprecated": true,
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["number"]
+                                                      "enum": [
+                                                        "number"
+                                                      ]
                                                     }
                                                   }
                                                 },
@@ -2397,198 +2820,271 @@
                                                   "description": "Any JSON number, with no decimal part",
                                                   "deprecated": true,
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["integer"]
+                                                      "enum": [
+                                                        "integer"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "A 8-bit signed integer with a minimum value of -2^7 and a maximum value of 2^7 - 1",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["int8"]
+                                                      "enum": [
+                                                        "int8"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "A 16-bit signed integer with a minimum value of -2^15 and a maximum value of 2^15 - 1",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["int16"]
+                                                      "enum": [
+                                                        "int16"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "A 32-bit signed integer with a minimum value of -2^31 and a maximum value of 2^31 - 1",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["int32"]
+                                                      "enum": [
+                                                        "int32"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "A 64-bit signed integer with a minimum value of -2^63 and a maximum value of 2^63 - 1",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["int64"]
+                                                      "enum": [
+                                                        "int64"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "An IEEE-754 single-precision floating-point number",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["float32"]
+                                                      "enum": [
+                                                        "float32"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "An IEEE-754 double-precision floating-point number",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["float64"]
+                                                      "enum": [
+                                                        "float64"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Arbitrary-precision integer string",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["biginteger"]
+                                                      "enum": [
+                                                        "biginteger"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Arbitrary-precision decimal string",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["bigdecimal"]
+                                                      "enum": [
+                                                        "bigdecimal"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "UUID string (8-4-4-4-12)",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["uuid"]
+                                                      "enum": [
+                                                        "uuid"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "ISO 8601 date",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["date"]
+                                                      "enum": [
+                                                        "date"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "ISO 8601 timestamp",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["timestamp"]
+                                                      "enum": [
+                                                        "timestamp"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "ISO 8601 timestamp-with-timezone",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["timestamptz"]
+                                                      "enum": [
+                                                        "timestamptz"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "GeoJSON, per RFC 7946",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["geography"]
+                                                      "enum": [
+                                                        "geography"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "GeoJSON Geometry object, per RFC 7946",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["geometry"]
+                                                      "enum": [
+                                                        "geometry"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Base64-encoded bytes",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["bytes"]
+                                                      "enum": [
+                                                        "bytes"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Arbitrary JSON",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["json"]
+                                                      "enum": [
+                                                        "json"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "One of the specified string values",
                                                   "type": "object",
-                                                  "required": ["one_of", "type"],
+                                                  "required": [
+                                                    "one_of",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["enum"]
+                                                      "enum": [
+                                                        "enum"
+                                                      ]
                                                     },
                                                     "one_of": {
                                                       "type": "array",
@@ -2604,7 +3100,9 @@
                                               "title": "Aggregate Function Definition",
                                               "description": "The definition of an aggregation function on a scalar type",
                                               "type": "object",
-                                              "required": ["result_type"],
+                                              "required": [
+                                                "result_type"
+                                              ],
                                               "properties": {
                                                 "result_type": {
                                                   "description": "The scalar or object type of the result of this function",
@@ -2623,11 +3121,16 @@
                                                 {
                                                   "description": "A named type",
                                                   "type": "object",
-                                                  "required": ["name", "type"],
+                                                  "required": [
+                                                    "name",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["named"]
+                                                      "enum": [
+                                                        "named"
+                                                      ]
                                                     },
                                                     "name": {
                                                       "description": "The name can refer to a scalar or object type",
@@ -2638,11 +3141,16 @@
                                                 {
                                                   "description": "A nullable type",
                                                   "type": "object",
-                                                  "required": ["type", "underlying_type"],
+                                                  "required": [
+                                                    "type",
+                                                    "underlying_type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["nullable"]
+                                                      "enum": [
+                                                        "nullable"
+                                                      ]
                                                     },
                                                     "underlying_type": {
                                                       "description": "The type of the non-null inhabitants of this type",
@@ -2657,11 +3165,16 @@
                                                 {
                                                   "description": "An array type",
                                                   "type": "object",
-                                                  "required": ["element_type", "type"],
+                                                  "required": [
+                                                    "element_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["array"]
+                                                      "enum": [
+                                                        "array"
+                                                      ]
                                                     },
                                                     "element_type": {
                                                       "description": "The type of the elements of the array",
@@ -2676,11 +3189,16 @@
                                                 {
                                                   "description": "A predicate type for a given object type",
                                                   "type": "object",
-                                                  "required": ["object_type_name", "type"],
+                                                  "required": [
+                                                    "object_type_name",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["predicate"]
+                                                      "enum": [
+                                                        "predicate"
+                                                      ]
                                                     },
                                                     "object_type_name": {
                                                       "description": "The object type name",
@@ -2696,31 +3214,44 @@
                                               "oneOf": [
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["equal"]
+                                                      "enum": [
+                                                        "equal"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["in"]
+                                                      "enum": [
+                                                        "in"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["argument_type", "type"],
+                                                  "required": [
+                                                    "argument_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["custom"]
+                                                      "enum": [
+                                                        "custom"
+                                                      ]
                                                     },
                                                     "argument_type": {
                                                       "description": "The type of the argument to this operator",
@@ -2738,11 +3269,16 @@
                                               "title": "Object Type",
                                               "description": "The definition of an object type",
                                               "type": "object",
-                                              "required": ["fields"],
+                                              "required": [
+                                                "fields"
+                                              ],
                                               "properties": {
                                                 "description": {
                                                   "description": "Description of this type",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "fields": {
                                                   "description": "Fields defined on this object type",
@@ -2757,11 +3293,16 @@
                                               "title": "Object Field",
                                               "description": "The definition of an object field",
                                               "type": "object",
-                                              "required": ["type"],
+                                              "required": [
+                                                "type"
+                                              ],
                                               "properties": {
                                                 "description": {
                                                   "description": "Description of this field",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "type": {
                                                   "description": "The type of this field",
@@ -2783,11 +3324,16 @@
                                             "ArgumentInfo": {
                                               "title": "Argument Info",
                                               "type": "object",
-                                              "required": ["type"],
+                                              "required": [
+                                                "type"
+                                              ],
                                               "properties": {
                                                 "description": {
                                                   "description": "Argument description",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "type": {
                                                   "description": "The name of the type of this argument",
@@ -2816,7 +3362,10 @@
                                                 },
                                                 "description": {
                                                   "description": "Description of the collection",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "arguments": {
                                                   "description": "Any arguments that this collection requires",
@@ -2848,7 +3397,9 @@
                                             "UniquenessConstraint": {
                                               "title": "Uniqueness Constraint",
                                               "type": "object",
-                                              "required": ["unique_columns"],
+                                              "required": [
+                                                "unique_columns"
+                                              ],
                                               "properties": {
                                                 "unique_columns": {
                                                   "description": "A list of columns which this constraint requires to be unique",
@@ -2862,7 +3413,10 @@
                                             "ForeignKeyConstraint": {
                                               "title": "Foreign Key Constraint",
                                               "type": "object",
-                                              "required": ["column_mapping", "foreign_collection"],
+                                              "required": [
+                                                "column_mapping",
+                                                "foreign_collection"
+                                              ],
                                               "properties": {
                                                 "column_mapping": {
                                                   "description": "The columns on which you want want to define the foreign key.",
@@ -2880,7 +3434,11 @@
                                             "FunctionInfo": {
                                               "title": "Function Info",
                                               "type": "object",
-                                              "required": ["arguments", "name", "result_type"],
+                                              "required": [
+                                                "arguments",
+                                                "name",
+                                                "result_type"
+                                              ],
                                               "properties": {
                                                 "name": {
                                                   "description": "The name of the function",
@@ -2888,7 +3446,10 @@
                                                 },
                                                 "description": {
                                                   "description": "Description of the function",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "arguments": {
                                                   "description": "Any arguments that this collection requires",
@@ -2910,7 +3471,11 @@
                                             "ProcedureInfo": {
                                               "title": "Procedure Info",
                                               "type": "object",
-                                              "required": ["arguments", "name", "result_type"],
+                                              "required": [
+                                                "arguments",
+                                                "name",
+                                                "result_type"
+                                              ],
                                               "properties": {
                                                 "name": {
                                                   "description": "The name of the procedure",
@@ -2918,7 +3483,10 @@
                                                 },
                                                 "description": {
                                                   "description": "Column description",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "arguments": {
                                                   "description": "Any arguments that this collection requires",
@@ -2940,7 +3508,10 @@
                                             "RequestLevelArguments": {
                                               "title": "Request Level Arguments",
                                               "type": "object",
-                                              "required": ["mutation_arguments", "query_arguments"],
+                                              "required": [
+                                                "mutation_arguments",
+                                                "query_arguments"
+                                              ],
                                               "properties": {
                                                 "query_arguments": {
                                                   "description": "Any arguments that all Query requests require",
@@ -2964,7 +3535,10 @@
                                           "$schema": "http://json-schema.org/draft-07/schema#",
                                           "title": "Capabilities Response",
                                           "type": "object",
-                                          "required": ["capabilities", "version"],
+                                          "required": [
+                                            "capabilities",
+                                            "version"
+                                          ],
                                           "properties": {
                                             "version": {
                                               "type": "string"
@@ -2978,7 +3552,10 @@
                                               "title": "Capabilities",
                                               "description": "Describes the features of the specification which a data connector implements.",
                                               "type": "object",
-                                              "required": ["mutation", "query"],
+                                              "required": [
+                                                "mutation",
+                                                "query"
+                                              ],
                                               "properties": {
                                                 "query": {
                                                   "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/0/oneOf/0/properties/definition/properties/schema/allOf/0/oneOf/0/properties/capabilities/definitions/QueryCapabilities"
@@ -3180,11 +3757,17 @@
                                       "title": "SchemaAndCapabilitiesV02",
                                       "description": "Version 0.2 of schema and capabilities for a data connector.",
                                       "type": "object",
-                                      "required": ["capabilities", "schema", "version"],
+                                      "required": [
+                                        "capabilities",
+                                        "schema",
+                                        "version"
+                                      ],
                                       "properties": {
                                         "version": {
                                           "type": "string",
-                                          "enum": ["v0.2"]
+                                          "enum": [
+                                            "v0.2"
+                                          ]
                                         },
                                         "schema": {
                                           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -3260,7 +3843,9 @@
                                             "AggregateCapabilitiesSchemaInfo": {
                                               "title": "Aggregate Capabilities Schema Info",
                                               "type": "object",
-                                              "required": ["count_scalar_type"],
+                                              "required": [
+                                                "count_scalar_type"
+                                              ],
                                               "properties": {
                                                 "count_scalar_type": {
                                                   "description": "The scalar type which should be used for the return type of count (star_count and column_count) operations.",
@@ -3274,31 +3859,44 @@
                                               "oneOf": [
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["min"]
+                                                      "enum": [
+                                                        "min"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["max"]
+                                                      "enum": [
+                                                        "max"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["sum"]
+                                                      "enum": [
+                                                        "sum"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The scalar type of the result of this function, which should have one of the type representations Int64 or Float64, depending on whether this function is defined on a scalar type with an integer or floating-point representation, respectively.",
@@ -3308,11 +3906,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["average"]
+                                                      "enum": [
+                                                        "average"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The scalar type of the result of this function, which should have the type representation Float64",
@@ -3322,11 +3925,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["custom"]
+                                                      "enum": [
+                                                        "custom"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The scalar or object type of the result of this function",
@@ -3343,11 +3951,16 @@
                                             "ArgumentInfo": {
                                               "title": "Argument Info",
                                               "type": "object",
-                                              "required": ["type"],
+                                              "required": [
+                                                "type"
+                                              ],
                                               "properties": {
                                                 "description": {
                                                   "description": "Argument description",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "type": {
                                                   "description": "The name of the type of this argument",
@@ -3379,7 +3992,12 @@
                                             "CollectionInfo": {
                                               "title": "Collection Info",
                                               "type": "object",
-                                              "required": ["arguments", "name", "type", "uniqueness_constraints"],
+                                              "required": [
+                                                "arguments",
+                                                "name",
+                                                "type",
+                                                "uniqueness_constraints"
+                                              ],
                                               "properties": {
                                                 "name": {
                                                   "description": "The name of the collection\n\nNote: these names are abstract - there is no requirement that this name correspond to the name of an actual collection in the database.",
@@ -3387,7 +4005,10 @@
                                                 },
                                                 "description": {
                                                   "description": "Description of the collection",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "arguments": {
                                                   "description": "Any arguments that this collection requires",
@@ -3426,131 +4047,184 @@
                                               "oneOf": [
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["equal"]
+                                                      "enum": [
+                                                        "equal"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["in"]
+                                                      "enum": [
+                                                        "in"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["less_than"]
+                                                      "enum": [
+                                                        "less_than"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["less_than_or_equal"]
+                                                      "enum": [
+                                                        "less_than_or_equal"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["greater_than"]
+                                                      "enum": [
+                                                        "greater_than"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["greater_than_or_equal"]
+                                                      "enum": [
+                                                        "greater_than_or_equal"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["contains"]
+                                                      "enum": [
+                                                        "contains"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["contains_insensitive"]
+                                                      "enum": [
+                                                        "contains_insensitive"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["starts_with"]
+                                                      "enum": [
+                                                        "starts_with"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["starts_with_insensitive"]
+                                                      "enum": [
+                                                        "starts_with_insensitive"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["ends_with"]
+                                                      "enum": [
+                                                        "ends_with"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["ends_with_insensitive"]
+                                                      "enum": [
+                                                        "ends_with_insensitive"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["argument_type", "type"],
+                                                  "required": [
+                                                    "argument_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["custom"]
+                                                      "enum": [
+                                                        "custom"
+                                                      ]
                                                     },
                                                     "argument_type": {
                                                       "description": "The type of the argument to this operator",
@@ -3570,11 +4244,16 @@
                                               "oneOf": [
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["nanosecond"]
+                                                      "enum": [
+                                                        "nanosecond"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3584,11 +4263,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["microsecond"]
+                                                      "enum": [
+                                                        "microsecond"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3598,11 +4282,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["millisecond"]
+                                                      "enum": [
+                                                        "millisecond"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3612,11 +4301,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["second"]
+                                                      "enum": [
+                                                        "second"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3626,11 +4320,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["minute"]
+                                                      "enum": [
+                                                        "minute"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3640,11 +4339,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["hour"]
+                                                      "enum": [
+                                                        "hour"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3654,11 +4358,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["day"]
+                                                      "enum": [
+                                                        "day"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3668,11 +4377,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["week"]
+                                                      "enum": [
+                                                        "week"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3682,11 +4396,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["month"]
+                                                      "enum": [
+                                                        "month"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3696,11 +4415,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["quarter"]
+                                                      "enum": [
+                                                        "quarter"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3710,11 +4434,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["year"]
+                                                      "enum": [
+                                                        "year"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3724,11 +4453,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["day_of_week"]
+                                                      "enum": [
+                                                        "day_of_week"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3738,11 +4472,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["day_of_year"]
+                                                      "enum": [
+                                                        "day_of_year"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The result type, which must be a defined scalar type in the schema response.",
@@ -3752,11 +4491,16 @@
                                                 },
                                                 {
                                                   "type": "object",
-                                                  "required": ["result_type", "type"],
+                                                  "required": [
+                                                    "result_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["custom"]
+                                                      "enum": [
+                                                        "custom"
+                                                      ]
                                                     },
                                                     "result_type": {
                                                       "description": "The scalar or object type of the result of this function",
@@ -3773,7 +4517,10 @@
                                             "ForeignKeyConstraint": {
                                               "title": "Foreign Key Constraint",
                                               "type": "object",
-                                              "required": ["column_mapping", "foreign_collection"],
+                                              "required": [
+                                                "column_mapping",
+                                                "foreign_collection"
+                                              ],
                                               "properties": {
                                                 "column_mapping": {
                                                   "description": "The columns on which you want want to define the foreign key. This is a mapping between fields on object type to columns on the foreign collection. The column on the foreign collection is specified via a field path (ie. an array of field names that descend through nested object fields). The field path must only contain a single item, meaning a column on the foreign collection's type, unless the 'relationships.nested' capability is supported, in which case multiple items can be used to denote a nested object field.",
@@ -3794,7 +4541,11 @@
                                             "FunctionInfo": {
                                               "title": "Function Info",
                                               "type": "object",
-                                              "required": ["arguments", "name", "result_type"],
+                                              "required": [
+                                                "arguments",
+                                                "name",
+                                                "result_type"
+                                              ],
                                               "properties": {
                                                 "name": {
                                                   "description": "The name of the function",
@@ -3802,7 +4553,10 @@
                                                 },
                                                 "description": {
                                                   "description": "Description of the function",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "arguments": {
                                                   "description": "Any arguments that this collection requires",
@@ -3825,11 +4579,16 @@
                                               "title": "Object Field",
                                               "description": "The definition of an object field",
                                               "type": "object",
-                                              "required": ["type"],
+                                              "required": [
+                                                "type"
+                                              ],
                                               "properties": {
                                                 "description": {
                                                   "description": "Description of this field",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "type": {
                                                   "description": "The type of this field",
@@ -3852,11 +4611,17 @@
                                               "title": "Object Type",
                                               "description": "The definition of an object type",
                                               "type": "object",
-                                              "required": ["fields", "foreign_keys"],
+                                              "required": [
+                                                "fields",
+                                                "foreign_keys"
+                                              ],
                                               "properties": {
                                                 "description": {
                                                   "description": "Description of this type",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "fields": {
                                                   "description": "Fields defined on this object type",
@@ -3877,7 +4642,11 @@
                                             "ProcedureInfo": {
                                               "title": "Procedure Info",
                                               "type": "object",
-                                              "required": ["arguments", "name", "result_type"],
+                                              "required": [
+                                                "arguments",
+                                                "name",
+                                                "result_type"
+                                              ],
                                               "properties": {
                                                 "name": {
                                                   "description": "The name of the procedure",
@@ -3885,7 +4654,10 @@
                                                 },
                                                 "description": {
                                                   "description": "Column description",
-                                                  "type": ["string", "null"]
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
                                                 },
                                                 "arguments": {
                                                   "description": "Any arguments that this collection requires",
@@ -3924,7 +4696,11 @@
                                             "RelationalMutationInfo": {
                                               "title": "Relational Mutation Info",
                                               "type": "object",
-                                              "required": ["deletable", "insertable", "updatable"],
+                                              "required": [
+                                                "deletable",
+                                                "insertable",
+                                                "updatable"
+                                              ],
                                               "properties": {
                                                 "insertable": {
                                                   "description": "Whether inserts are supported for this collection",
@@ -4021,11 +4797,16 @@
                                                 {
                                                   "description": "A named type",
                                                   "type": "object",
-                                                  "required": ["name", "type"],
+                                                  "required": [
+                                                    "name",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["named"]
+                                                      "enum": [
+                                                        "named"
+                                                      ]
                                                     },
                                                     "name": {
                                                       "description": "The name can refer to a scalar or object type",
@@ -4036,11 +4817,16 @@
                                                 {
                                                   "description": "A nullable type",
                                                   "type": "object",
-                                                  "required": ["type", "underlying_type"],
+                                                  "required": [
+                                                    "type",
+                                                    "underlying_type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["nullable"]
+                                                      "enum": [
+                                                        "nullable"
+                                                      ]
                                                     },
                                                     "underlying_type": {
                                                       "description": "The type of the non-null inhabitants of this type",
@@ -4055,11 +4841,16 @@
                                                 {
                                                   "description": "An array type",
                                                   "type": "object",
-                                                  "required": ["element_type", "type"],
+                                                  "required": [
+                                                    "element_type",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["array"]
+                                                      "enum": [
+                                                        "array"
+                                                      ]
                                                     },
                                                     "element_type": {
                                                       "description": "The type of the elements of the array",
@@ -4074,11 +4865,16 @@
                                                 {
                                                   "description": "A predicate type for a given object type",
                                                   "type": "object",
-                                                  "required": ["object_type_name", "type"],
+                                                  "required": [
+                                                    "object_type_name",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["predicate"]
+                                                      "enum": [
+                                                        "predicate"
+                                                      ]
                                                     },
                                                     "object_type_name": {
                                                       "description": "The object type name",
@@ -4095,209 +4891,286 @@
                                                 {
                                                   "description": "JSON booleans",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["boolean"]
+                                                      "enum": [
+                                                        "boolean"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Any JSON string",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["string"]
+                                                      "enum": [
+                                                        "string"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "A 8-bit signed integer with a minimum value of -2^7 and a maximum value of 2^7 - 1",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["int8"]
+                                                      "enum": [
+                                                        "int8"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "A 16-bit signed integer with a minimum value of -2^15 and a maximum value of 2^15 - 1",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["int16"]
+                                                      "enum": [
+                                                        "int16"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "A 32-bit signed integer with a minimum value of -2^31 and a maximum value of 2^31 - 1",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["int32"]
+                                                      "enum": [
+                                                        "int32"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "A 64-bit signed integer with a minimum value of -2^63 and a maximum value of 2^63 - 1",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["int64"]
+                                                      "enum": [
+                                                        "int64"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "An IEEE-754 single-precision floating-point number",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["float32"]
+                                                      "enum": [
+                                                        "float32"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "An IEEE-754 double-precision floating-point number",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["float64"]
+                                                      "enum": [
+                                                        "float64"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Arbitrary-precision integer string",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["biginteger"]
+                                                      "enum": [
+                                                        "biginteger"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Arbitrary-precision decimal string",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["bigdecimal"]
+                                                      "enum": [
+                                                        "bigdecimal"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "UUID string (8-4-4-4-12)",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["uuid"]
+                                                      "enum": [
+                                                        "uuid"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "ISO 8601 date",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["date"]
+                                                      "enum": [
+                                                        "date"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "ISO 8601 timestamp",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["timestamp"]
+                                                      "enum": [
+                                                        "timestamp"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "ISO 8601 timestamp-with-timezone",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["timestamptz"]
+                                                      "enum": [
+                                                        "timestamptz"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "GeoJSON, per RFC 7946",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["geography"]
+                                                      "enum": [
+                                                        "geography"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "GeoJSON Geometry object, per RFC 7946",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["geometry"]
+                                                      "enum": [
+                                                        "geometry"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Base64-encoded bytes",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["bytes"]
+                                                      "enum": [
+                                                        "bytes"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "Arbitrary JSON",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["json"]
+                                                      "enum": [
+                                                        "json"
+                                                      ]
                                                     }
                                                   }
                                                 },
                                                 {
                                                   "description": "One of the specified string values",
                                                   "type": "object",
-                                                  "required": ["one_of", "type"],
+                                                  "required": [
+                                                    "one_of",
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["enum"]
+                                                      "enum": [
+                                                        "enum"
+                                                      ]
                                                     },
                                                     "one_of": {
                                                       "type": "array",
@@ -4312,7 +5185,9 @@
                                             "UniquenessConstraint": {
                                               "title": "Uniqueness Constraint",
                                               "type": "object",
-                                              "required": ["unique_columns"],
+                                              "required": [
+                                                "unique_columns"
+                                              ],
                                               "properties": {
                                                 "unique_columns": {
                                                   "description": "A list of columns which this constraint requires to be unique",
@@ -4329,7 +5204,10 @@
                                           "$schema": "http://json-schema.org/draft-07/schema#",
                                           "title": "Capabilities Response",
                                           "type": "object",
-                                          "required": ["capabilities", "version"],
+                                          "required": [
+                                            "capabilities",
+                                            "version"
+                                          ],
                                           "properties": {
                                             "version": {
                                               "type": "string"
@@ -4371,7 +5249,10 @@
                                               "title": "Capabilities",
                                               "description": "Describes the features of the specification which a data connector implements.",
                                               "type": "object",
-                                              "required": ["mutation", "query"],
+                                              "required": [
+                                                "mutation",
+                                                "query"
+                                              ],
                                               "properties": {
                                                 "query": {
                                                   "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/0/oneOf/0/properties/definition/properties/schema/allOf/0/oneOf/1/properties/capabilities/definitions/QueryCapabilities"
@@ -4874,7 +5755,9 @@
                                             "RelationalAggregateCapabilities": {
                                               "title": "Relational Aggregate Capabilities",
                                               "type": "object",
-                                              "required": ["expression"],
+                                              "required": [
+                                                "expression"
+                                              ],
                                               "properties": {
                                                 "expression": {
                                                   "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/0/oneOf/0/properties/definition/properties/schema/allOf/0/oneOf/1/properties/capabilities/definitions/RelationalExpressionCapabilities"
@@ -5332,7 +6215,10 @@
                                             "RelationalJoinCapabilities": {
                                               "title": "Relational Join Capabilities",
                                               "type": "object",
-                                              "required": ["expression", "join_types"],
+                                              "required": [
+                                                "expression",
+                                                "join_types"
+                                              ],
                                               "properties": {
                                                 "expression": {
                                                   "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/0/oneOf/0/properties/definition/properties/schema/allOf/0/oneOf/1/properties/capabilities/definitions/RelationalExpressionCapabilities"
@@ -5494,7 +6380,9 @@
                                             "RelationalProjectionCapabilities": {
                                               "title": "Relational Projection Capabilities",
                                               "type": "object",
-                                              "required": ["expression"],
+                                              "required": [
+                                                "expression"
+                                              ],
                                               "properties": {
                                                 "expression": {
                                                   "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/0/oneOf/0/properties/definition/properties/schema/allOf/0/oneOf/1/properties/capabilities/definitions/RelationalExpressionCapabilities"
@@ -5505,7 +6393,9 @@
                                               "title": "Relational Query Capabilities",
                                               "description": "Describes which features of the relational query API are supported by the connector. This feature is experimental and subject to breaking changes within minor versions.",
                                               "type": "object",
-                                              "required": ["project"],
+                                              "required": [
+                                                "project"
+                                              ],
                                               "properties": {
                                                 "project": {
                                                   "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/0/oneOf/0/properties/definition/properties/schema/allOf/0/oneOf/1/properties/capabilities/definitions/RelationalProjectionCapabilities"
@@ -6159,7 +7049,9 @@
                                             "RelationalSortCapabilities": {
                                               "title": "Relational Sort Capabilities",
                                               "type": "object",
-                                              "required": ["expression"],
+                                              "required": [
+                                                "expression"
+                                              ],
                                               "properties": {
                                                 "expression": {
                                                   "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/0/oneOf/0/properties/definition/properties/schema/allOf/0/oneOf/1/properties/capabilities/definitions/RelationalExpressionCapabilities"
@@ -6169,7 +7061,9 @@
                                             "RelationalWindowCapabilities": {
                                               "title": "Relational Window Capabilities",
                                               "type": "object",
-                                              "required": ["expression"],
+                                              "required": [
+                                                "expression"
+                                              ],
                                               "properties": {
                                                 "expression": {
                                                   "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/0/oneOf/0/properties/definition/properties/schema/allOf/0/oneOf/1/properties/capabilities/definitions/RelationalExpressionCapabilities"
@@ -6299,7 +7193,10 @@
                                 "title": "DataConnectorArgumentPreset",
                                 "description": "An argument preset that can be applied to all functions/procedures of a connector",
                                 "type": "object",
-                                "required": ["argument", "value"],
+                                "required": [
+                                  "argument",
+                                  "value"
+                                ],
                                 "properties": {
                                   "argument": {
                                     "$id": "https://hasura.io/jsonschemas/metadata/DataConnectorArgumentName",
@@ -6312,7 +7209,9 @@
                                     "title": "DataConnectorArgumentPresetValue",
                                     "description": "The value of a data connector argument preset.",
                                     "type": "object",
-                                    "required": ["httpHeaders"],
+                                    "required": [
+                                      "httpHeaders"
+                                    ],
                                     "properties": {
                                       "httpHeaders": {
                                         "description": "HTTP headers that can be preset from request",
@@ -6322,7 +7221,10 @@
                                             "title": "HttpHeadersPreset",
                                             "description": "Configuration of what HTTP request headers should be forwarded to a data connector.",
                                             "type": "object",
-                                            "required": ["additional", "forward"],
+                                            "required": [
+                                              "additional",
+                                              "forward"
+                                            ],
                                             "properties": {
                                               "forward": {
                                                 "description": "List of HTTP headers that should be forwarded from HTTP requests",
@@ -6365,7 +7267,11 @@
                                   "title": "ResponseHeaders",
                                   "description": "Configuration of what HTTP response headers should be forwarded from a data connector to the client in HTTP response.",
                                   "type": "object",
-                                  "required": ["forwardHeaders", "headersField", "resultField"],
+                                  "required": [
+                                    "forwardHeaders",
+                                    "headersField",
+                                    "resultField"
+                                  ],
                                   "properties": {
                                     "headersField": {
                                       "description": "Name of the field in the NDC function/procedure's result which contains the response headers",
@@ -6416,29 +7322,42 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["GraphqlConfig"]
+                          "enum": [
+                            "GraphqlConfig"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/GraphqlConfigV1",
                           "title": "GraphqlConfigV1",
                           "description": "GraphqlConfig object tells us two things:\n\n1. How the Graphql schema should look like for the features (`where`, `order_by` etc) Hasura provides 2. What features should be enabled/disabled across the subgraphs",
                           "type": "object",
-                          "required": ["mutation", "query"],
+                          "required": [
+                            "mutation",
+                            "query"
+                          ],
                           "properties": {
                             "query": {
                               "$id": "https://hasura.io/jsonschemas/metadata/QueryGraphqlConfig",
                               "title": "QueryGraphqlConfig",
                               "description": "Configuration for the GraphQL schema of Hasura features for queries. `None` means disable the feature.",
                               "type": "object",
-                              "required": ["rootOperationTypeName"],
+                              "required": [
+                                "rootOperationTypeName"
+                              ],
                               "properties": {
                                 "rootOperationTypeName": {
                                   "description": "The name of the root operation type name for queries. Usually `query`.",
@@ -6456,7 +7375,9 @@
                                       "title": "ArgumentsInputGraphqlConfig",
                                       "description": "Configuration for the arguments input.",
                                       "type": "object",
-                                      "required": ["fieldName"],
+                                      "required": [
+                                        "fieldName"
+                                      ],
                                       "properties": {
                                         "fieldName": {
                                           "description": "The name of arguments passing field. Usually `args`.",
@@ -6482,7 +7403,9 @@
                                       "title": "LimitInputGraphqlConfig",
                                       "description": "Configuration for the limit operation.",
                                       "type": "object",
-                                      "required": ["fieldName"],
+                                      "required": [
+                                        "fieldName"
+                                      ],
                                       "properties": {
                                         "fieldName": {
                                           "description": "The name of the limit operation field. Usually `limit`.",
@@ -6508,7 +7431,9 @@
                                       "title": "OffsetInputGraphqlConfig",
                                       "description": "Configuration for the offset operation.",
                                       "type": "object",
-                                      "required": ["fieldName"],
+                                      "required": [
+                                        "fieldName"
+                                      ],
                                       "properties": {
                                         "fieldName": {
                                           "description": "The name of the offset operation field. Usually `offset`.",
@@ -6534,7 +7459,10 @@
                                       "title": "FilterInputGraphqlConfig",
                                       "description": "Configuration for the filter operation.",
                                       "type": "object",
-                                      "required": ["fieldName", "operatorNames"],
+                                      "required": [
+                                        "fieldName",
+                                        "operatorNames"
+                                      ],
                                       "properties": {
                                         "fieldName": {
                                           "description": "The name of the filter operation field. Usually `where`.",
@@ -6552,7 +7480,12 @@
                                               "title": "FilterInputOperatorNames",
                                               "description": "The names of built-in filter operators.",
                                               "type": "object",
-                                              "required": ["and", "isNull", "not", "or"],
+                                              "required": [
+                                                "and",
+                                                "isNull",
+                                                "not",
+                                                "or"
+                                              ],
                                               "properties": {
                                                 "and": {
                                                   "description": "The name of the `and` operator. Usually `_and`.",
@@ -6607,7 +7540,11 @@
                                       "title": "OrderByInputGraphqlConfig",
                                       "description": "Configuration for the sort operation.",
                                       "type": "object",
-                                      "required": ["enumDirectionValues", "enumTypeNames", "fieldName"],
+                                      "required": [
+                                        "enumDirectionValues",
+                                        "enumTypeNames",
+                                        "fieldName"
+                                      ],
                                       "properties": {
                                         "fieldName": {
                                           "description": "The name of the filter operation field. Usually `order_by`.",
@@ -6625,7 +7562,10 @@
                                               "title": "OrderByDirectionValues",
                                               "description": "The names of the direction parameters.",
                                               "type": "object",
-                                              "required": ["asc", "desc"],
+                                              "required": [
+                                                "asc",
+                                                "desc"
+                                              ],
                                               "properties": {
                                                 "asc": {
                                                   "description": "The name of the ascending parameter. Usually `Asc`.",
@@ -6655,7 +7595,10 @@
                                             "title": "OrderByEnumTypeName",
                                             "description": "Type name for a sort directions enum, with the given set of possible directions.",
                                             "type": "object",
-                                            "required": ["directions", "typeName"],
+                                            "required": [
+                                              "directions",
+                                              "typeName"
+                                            ],
                                             "properties": {
                                               "directions": {
                                                 "type": "array",
@@ -6667,12 +7610,16 @@
                                                     {
                                                       "description": "Ascending.",
                                                       "type": "string",
-                                                      "enum": ["Asc"]
+                                                      "enum": [
+                                                        "Asc"
+                                                      ]
                                                     },
                                                     {
                                                       "description": "Descending.",
                                                       "type": "string",
-                                                      "enum": ["Desc"]
+                                                      "enum": [
+                                                        "Desc"
+                                                      ]
                                                     }
                                                   ]
                                                 }
@@ -6700,7 +7647,11 @@
                                       "title": "AggregateGraphqlConfig",
                                       "description": "Configuration for the GraphQL schema for aggregates.",
                                       "type": "object",
-                                      "required": ["countDistinctFieldName", "countFieldName", "filterInputFieldName"],
+                                      "required": [
+                                        "countDistinctFieldName",
+                                        "countFieldName",
+                                        "filterInputFieldName"
+                                      ],
                                       "properties": {
                                         "filterInputFieldName": {
                                           "description": "The name of the filter input parameter of aggregate fields and field name in predicates",
@@ -6742,7 +7693,9 @@
                               "title": "MutationGraphqlConfig",
                               "description": "Configuration for the GraphQL schema of Hasura features for mutations.",
                               "type": "object",
-                              "required": ["rootOperationTypeName"],
+                              "required": [
+                                "rootOperationTypeName"
+                              ],
                               "properties": {
                                 "rootOperationTypeName": {
                                   "description": "The name of the root operation type name for mutations. Usually `mutation`.",
@@ -6762,7 +7715,9 @@
                                   "title": "SubscriptionGraphqlConfig",
                                   "description": "Configuration for the GraphQL schema of Hasura features for subscriptions.",
                                   "type": "object",
-                                  "required": ["rootOperationTypeName"],
+                                  "required": [
+                                    "rootOperationTypeName"
+                                  ],
                                   "properties": {
                                     "rootOperationTypeName": {
                                       "description": "The name of the root operation type name for subscriptions. Usually `subscription`.",
@@ -6787,7 +7742,9 @@
                                   "title": "GraphqlApolloFederationConfig",
                                   "description": "Configuration for the GraphQL schema of Hasura features for Apollo Federation.",
                                   "type": "object",
-                                  "required": ["enableRootFields"],
+                                  "required": [
+                                    "enableRootFields"
+                                  ],
                                   "properties": {
                                     "enableRootFields": {
                                       "description": "Adds the `_entities` and `_services` root fields required for Apollo Federation.",
@@ -6849,7 +7806,9 @@
                           }
                         ],
                         "description": "An author of a book",
-                        "globalIdFields": ["author_id"],
+                        "globalIdFields": [
+                          "author_id"
+                        ],
                         "graphql": {
                           "typeName": "Author"
                         },
@@ -6886,22 +7845,33 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["ObjectType"]
+                          "enum": [
+                            "ObjectType"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/ObjectTypeV1",
                           "title": "ObjectTypeV1",
                           "description": "Definition of a user-defined Open DD object type.",
                           "type": "object",
-                          "required": ["fields", "name"],
+                          "required": [
+                            "fields",
+                            "name"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name to give this object type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph.",
@@ -6923,7 +7893,10 @@
                                 "title": "ObjectFieldDefinition",
                                 "description": "The definition of a field in a user-defined object type.",
                                 "type": "object",
-                                "required": ["name", "type"],
+                                "required": [
+                                  "name",
+                                  "type"
+                                ],
                                 "properties": {
                                   "name": {
                                     "description": "The name of the field. This name is used both when referring to the field elsewhere in the metadata and when creating the corresponding GraphQl type.",
@@ -6943,7 +7916,10 @@
                                   },
                                   "description": {
                                     "description": "The description of this field. Gets added to the description of the field's definition in the graphql schema.",
-                                    "type": ["string", "null"]
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
                                   },
                                   "deprecated": {
                                     "description": "Whether this field is deprecated. If set, the deprecation status is added to the field's graphql schema.",
@@ -6965,7 +7941,10 @@
                                       "title": "FieldArgumentDefinition",
                                       "description": "The definition of an argument for a field in a user-defined object type.",
                                       "type": "object",
-                                      "required": ["argumentType", "name"],
+                                      "required": [
+                                        "argumentType",
+                                        "name"
+                                      ],
                                       "properties": {
                                         "name": {
                                           "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/9/oneOf/0/properties/definition/properties/arguments/items/properties/name"
@@ -6974,7 +7953,10 @@
                                           "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/10/oneOf/0/properties/definition/properties/outputType/allOf/0"
                                         },
                                         "description": {
-                                          "type": ["string", "null"]
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -6986,7 +7968,10 @@
                             },
                             "globalIdFields": {
                               "description": "The subset of fields that uniquely identify this object in the domain. Setting this property will automatically implement the GraphQL Relay Node interface for this object type and add an `id` global ID field. If setting this property, there must not be a field named `id` already present.",
-                              "type": ["array", "null"],
+                              "type": [
+                                "array",
+                                "null"
+                              ],
                               "items": {
                                 "$id": "https://hasura.io/jsonschemas/metadata/FieldName",
                                 "title": "FieldName",
@@ -7034,7 +8019,9 @@
                                           "title": "ObjectApolloFederationConfig",
                                           "description": "Configuration for apollo federation related types and directives.",
                                           "type": "object",
-                                          "required": ["keys"],
+                                          "required": [
+                                            "keys"
+                                          ],
                                           "properties": {
                                             "keys": {
                                               "type": "array",
@@ -7043,7 +8030,9 @@
                                                 "title": "ApolloFederationObjectKey",
                                                 "description": "The definition of a key for an apollo federation object.",
                                                 "type": "object",
-                                                "required": ["fields"],
+                                                "required": [
+                                                  "fields"
+                                                ],
                                                 "properties": {
                                                   "fields": {
                                                     "type": "array",
@@ -7073,7 +8062,10 @@
                             },
                             "description": {
                               "description": "The description of the object. Gets added to the description of the object's definition in the graphql schema.",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "dataConnectorTypeMapping": {
                               "description": "Mapping of this object type to corresponding object types in various data connectors.",
@@ -7084,7 +8076,10 @@
                                 "title": "DataConnectorTypeMapping",
                                 "description": "This defines the mapping of the fields of an object type to the corresponding columns of an object type in a data connector.",
                                 "type": "object",
-                                "required": ["dataConnectorName", "dataConnectorObjectType"],
+                                "required": [
+                                  "dataConnectorName",
+                                  "dataConnectorObjectType"
+                                ],
                                 "properties": {
                                   "dataConnectorName": {
                                     "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/0/oneOf/0/properties/definition/properties/name/allOf/0"
@@ -7107,14 +8102,18 @@
                                             {
                                               "description": "Source field directly maps to some column in the data connector.",
                                               "type": "object",
-                                              "required": ["column"],
+                                              "required": [
+                                                "column"
+                                              ],
                                               "properties": {
                                                 "column": {
                                                   "$id": "https://hasura.io/jsonschemas/metadata/ColumnFieldMapping",
                                                   "title": "ColumnFieldMapping",
                                                   "description": "The target column in a data connector object that a source field maps to.",
                                                   "type": "object",
-                                                  "required": ["name"],
+                                                  "required": [
+                                                    "name"
+                                                  ],
                                                   "properties": {
                                                     "name": {
                                                       "description": "The name of the target column",
@@ -7176,22 +8175,32 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["ScalarType"]
+                          "enum": [
+                            "ScalarType"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/ScalarTypeV1",
                           "title": "ScalarTypeV1",
                           "description": "Definition of a user-defined scalar type that that has opaque semantics.",
                           "type": "object",
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name to give this scalar type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph.",
@@ -7209,7 +8218,9 @@
                                   "title": "ScalarTypeGraphQLConfiguration",
                                   "description": "GraphQL configuration of an Open DD scalar type",
                                   "type": "object",
-                                  "required": ["typeName"],
+                                  "required": [
+                                    "typeName"
+                                  ],
                                   "properties": {
                                     "typeName": {
                                       "description": "The name of the GraphQl type to use for this scalar.",
@@ -7229,7 +8240,10 @@
                             },
                             "description": {
                               "description": "The description of this scalar. Gets added to the description of the scalar's definition in the graphql schema.",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             }
                           },
                           "additionalProperties": false
@@ -7281,15 +8295,23 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["ObjectBooleanExpressionType"]
+                          "enum": [
+                            "ObjectBooleanExpressionType"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/ObjectBooleanExpressionTypeV1",
@@ -7347,7 +8369,10 @@
                                 "title": "ComparableField",
                                 "description": "A field of an object type that can be used for comparison when evaluating a boolean expression.",
                                 "type": "object",
-                                "required": ["fieldName", "operators"],
+                                "required": [
+                                  "fieldName",
+                                  "operators"
+                                ],
                                 "properties": {
                                   "fieldName": {
                                     "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/2/oneOf/0/properties/definition/properties/globalIdFields/items"
@@ -7359,7 +8384,9 @@
                                     "oneOf": [
                                       {
                                         "type": "object",
-                                        "required": ["enableAll"],
+                                        "required": [
+                                          "enableAll"
+                                        ],
                                         "properties": {
                                           "enableAll": {
                                             "type": "boolean"
@@ -7369,7 +8396,9 @@
                                       },
                                       {
                                         "type": "object",
-                                        "required": ["enableSpecific"],
+                                        "required": [
+                                          "enableSpecific"
+                                        ],
                                         "properties": {
                                           "enableSpecific": {
                                             "type": "array",
@@ -7397,7 +8426,9 @@
                                   "title": "ObjectBooleanExpressionTypeGraphQlConfiguration",
                                   "description": "GraphQL configuration of an Open DD boolean expression type.",
                                   "type": "object",
-                                  "required": ["typeName"],
+                                  "required": [
+                                    "typeName"
+                                  ],
                                   "properties": {
                                     "typeName": {
                                       "description": "The name to use for the GraphQL type representation of this boolean expression type.",
@@ -7473,22 +8504,35 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["BooleanExpressionType"]
+                          "enum": [
+                            "BooleanExpressionType"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/BooleanExpressionTypeV1",
                           "title": "BooleanExpressionTypeV1",
                           "description": "Definition of a type representing a boolean expression on an OpenDD object type.",
                           "type": "object",
-                          "required": ["isNull", "logicalOperators", "name", "operand"],
+                          "required": [
+                            "isNull",
+                            "logicalOperators",
+                            "name",
+                            "operand"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name to give this boolean expression type, used to refer to it elsewhere in the metadata. Must be unique across all types defined in this subgraph.",
@@ -7510,14 +8554,20 @@
                                       "title": "Object",
                                       "description": "Definition of a boolean expression on an OpenDD object type",
                                       "type": "object",
-                                      "required": ["object"],
+                                      "required": [
+                                        "object"
+                                      ],
                                       "properties": {
                                         "object": {
                                           "$id": "https://hasura.io/jsonschemas/metadata/BooleanExpressionObjectOperand",
                                           "title": "BooleanExpressionObjectOperand",
                                           "description": "Definition of an object type representing a boolean expression on an OpenDD object type.",
                                           "type": "object",
-                                          "required": ["comparableFields", "comparableRelationships", "type"],
+                                          "required": [
+                                            "comparableFields",
+                                            "comparableRelationships",
+                                            "type"
+                                          ],
                                           "properties": {
                                             "type": {
                                               "description": "The name of the object type that this boolean expression applies to.",
@@ -7535,7 +8585,10 @@
                                                 "title": "BooleanExpressionComparableField",
                                                 "description": "Comparison configuration definition for a field that can be used for a comparison",
                                                 "type": "object",
-                                                "required": ["booleanExpressionType", "fieldName"],
+                                                "required": [
+                                                  "booleanExpressionType",
+                                                  "fieldName"
+                                                ],
                                                 "properties": {
                                                   "fieldName": {
                                                     "description": "The name of the field that can be compared.",
@@ -7565,7 +8618,9 @@
                                                 "title": "BooleanExpressionComparableRelationship",
                                                 "description": "Definition of a relationship that can be used for a comparison",
                                                 "type": "object",
-                                                "required": ["relationshipName"],
+                                                "required": [
+                                                  "relationshipName"
+                                                ],
                                                 "properties": {
                                                   "relationshipName": {
                                                     "description": "The name of the relationship to use for comparison",
@@ -7600,14 +8655,20 @@
                                       "title": "Scalar",
                                       "description": "Definition of a boolean expression on a scalar tyoe",
                                       "type": "object",
-                                      "required": ["scalar"],
+                                      "required": [
+                                        "scalar"
+                                      ],
                                       "properties": {
                                         "scalar": {
                                           "$id": "https://hasura.io/jsonschemas/metadata/BooleanExpressionScalarOperand",
                                           "title": "BooleanExpressionScalarOperand",
                                           "description": "Definition of a scalar type representing a boolean expression on an OpenDD scalar type.",
                                           "type": "object",
-                                          "required": ["comparisonOperators", "dataConnectorOperatorMapping", "type"],
+                                          "required": [
+                                            "comparisonOperators",
+                                            "dataConnectorOperatorMapping",
+                                            "type"
+                                          ],
                                           "properties": {
                                             "type": {
                                               "description": "The OpenDD type name of the scalar type that this boolean expression applies to.",
@@ -7625,7 +8686,10 @@
                                                 "title": "ComparisonOperator",
                                                 "description": "Definition of a comparison operator for a scalar type",
                                                 "type": "object",
-                                                "required": ["argumentType", "name"],
+                                                "required": [
+                                                  "argumentType",
+                                                  "name"
+                                                ],
                                                 "properties": {
                                                   "name": {
                                                     "description": "Name you want to give the operator in OpenDD / GraphQL",
@@ -7710,7 +8774,9 @@
                                   "title": "BooleanExpressionLogicalOperators",
                                   "description": "Configuration for logical operators in boolean expressions",
                                   "type": "object",
-                                  "required": ["enable"],
+                                  "required": [
+                                    "enable"
+                                  ],
                                   "properties": {
                                     "enable": {
                                       "type": "boolean"
@@ -7728,7 +8794,9 @@
                                   "title": "BooleanExpressionIsNull",
                                   "description": "Configuration for is_null in boolean expressions",
                                   "type": "object",
-                                  "required": ["enable"],
+                                  "required": [
+                                    "enable"
+                                  ],
                                   "properties": {
                                     "enable": {
                                       "type": "boolean"
@@ -7746,7 +8814,9 @@
                                   "title": "BooleanExpressionTypeGraphQlConfiguration",
                                   "description": "GraphQL configuration of an OpenDD boolean expression type.",
                                   "type": "object",
-                                  "required": ["typeName"],
+                                  "required": [
+                                    "typeName"
+                                  ],
                                   "properties": {
                                     "typeName": {
                                       "description": "The name to use for the GraphQL type representation of this boolean expression type.",
@@ -7836,22 +8906,33 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["OrderByExpression"]
+                          "enum": [
+                            "OrderByExpression"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/OrderByExpressionV1",
                           "title": "OrderByExpressionV1",
                           "description": "Definition of a type representing an order by expression on an OpenDD type.",
                           "type": "object",
-                          "required": ["name", "operand"],
+                          "required": [
+                            "name",
+                            "operand"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name used to refer to this expression. This name is unique only in the context of the `orderedType`",
@@ -7877,14 +8958,20 @@
                                       "title": "Object",
                                       "description": "Definition of an order by expression on an OpenDD object type",
                                       "type": "object",
-                                      "required": ["object"],
+                                      "required": [
+                                        "object"
+                                      ],
                                       "properties": {
                                         "object": {
                                           "$id": "https://hasura.io/jsonschemas/metadata/OrderByExpressionObjectOperand",
                                           "title": "OrderByExpressionObjectOperand",
                                           "description": "Definition of an type representing an order by expression on an OpenDD object type.",
                                           "type": "object",
-                                          "required": ["orderableFields", "orderableRelationships", "orderedType"],
+                                          "required": [
+                                            "orderableFields",
+                                            "orderableRelationships",
+                                            "orderedType"
+                                          ],
                                           "properties": {
                                             "orderedType": {
                                               "description": "The type that this expression applies to.",
@@ -7902,7 +8989,10 @@
                                                 "title": "OrderByExpressionOrderableField",
                                                 "description": "Definition of a field in a type representing an order by expression on an OpenDD type.",
                                                 "type": "object",
-                                                "required": ["fieldName", "orderByExpression"],
+                                                "required": [
+                                                  "fieldName",
+                                                  "orderByExpression"
+                                                ],
                                                 "properties": {
                                                   "fieldName": {
                                                     "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/2/oneOf/0/properties/definition/properties/globalIdFields/items"
@@ -7927,7 +9017,9 @@
                                                 "title": "OrderByExpressionOrderableRelationship",
                                                 "description": "Definition of a relationship in a type representing an order by expression on an OpenDD type.",
                                                 "type": "object",
-                                                "required": ["relationshipName"],
+                                                "required": [
+                                                  "relationshipName"
+                                                ],
                                                 "properties": {
                                                   "relationshipName": {
                                                     "description": "The name of the relationship.",
@@ -7962,14 +9054,19 @@
                                       "title": "Scalar",
                                       "description": "Definition of an order by expression on an OpenDD scalar type",
                                       "type": "object",
-                                      "required": ["scalar"],
+                                      "required": [
+                                        "scalar"
+                                      ],
                                       "properties": {
                                         "scalar": {
                                           "$id": "https://hasura.io/jsonschemas/metadata/OrderByExpressionScalarOperand",
                                           "title": "OrderByExpressionScalarOperand",
                                           "description": "Definition of a type representing an order by expression on an OpenDD scalar type.",
                                           "type": "object",
-                                          "required": ["enableOrderByDirections", "orderedType"],
+                                          "required": [
+                                            "enableOrderByDirections",
+                                            "orderedType"
+                                          ],
                                           "properties": {
                                             "orderedType": {
                                               "description": "The type that this expression applies to.",
@@ -8005,7 +9102,9 @@
                                   "title": "OrderByExpressionGraphQlConfiguration",
                                   "description": "GraphQL configuration settings for a type representing an order by expression on an OpenDD type.",
                                   "type": "object",
-                                  "required": ["expressionTypeName"],
+                                  "required": [
+                                    "expressionTypeName"
+                                  ],
                                   "properties": {
                                     "expressionTypeName": {
                                       "$id": "https://hasura.io/jsonschemas/metadata/GraphQlTypeName",
@@ -8023,7 +9122,10 @@
                             },
                             "description": {
                               "description": "The description of the order by expression.",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             }
                           },
                           "additionalProperties": false
@@ -8040,15 +9142,23 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["DataConnectorScalarRepresentation"]
+                          "enum": [
+                            "DataConnectorScalarRepresentation"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/DataConnectorScalarRepresentationV1",
@@ -8065,7 +9175,11 @@
                             }
                           ],
                           "type": "object",
-                          "required": ["dataConnectorName", "dataConnectorScalarType", "representation"],
+                          "required": [
+                            "dataConnectorName",
+                            "dataConnectorScalarType",
+                            "representation"
+                          ],
                           "properties": {
                             "dataConnectorName": {
                               "description": "The name of the data connector that this scalar type comes from.",
@@ -8098,7 +9212,13 @@
                                       "title": "InbuiltType",
                                       "description": "An inbuilt primitive OpenDD type.",
                                       "type": "string",
-                                      "enum": ["ID", "Int", "Float", "Boolean", "String"]
+                                      "enum": [
+                                        "ID",
+                                        "Int",
+                                        "Float",
+                                        "Boolean",
+                                        "String"
+                                      ]
                                     },
                                     {
                                       "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/2/oneOf/0/properties/definition/properties/name/allOf/0"
@@ -8173,22 +9293,33 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["AggregateExpression"]
+                          "enum": [
+                            "AggregateExpression"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/AggregateExpressionV1",
                           "title": "AggregateExpressionV1",
                           "description": "Definition of how to aggregate over a particular operand type",
                           "type": "object",
-                          "required": ["name", "operand"],
+                          "required": [
+                            "name",
+                            "operand"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name of the aggregate expression.",
@@ -8214,14 +9345,19 @@
                                       "title": "Object",
                                       "description": "If the operand is an object type",
                                       "type": "object",
-                                      "required": ["object"],
+                                      "required": [
+                                        "object"
+                                      ],
                                       "properties": {
                                         "object": {
                                           "$id": "https://hasura.io/jsonschemas/metadata/ObjectAggregateOperand",
                                           "title": "ObjectAggregateOperand",
                                           "description": "Definition of an aggregate over an object-typed operand",
                                           "type": "object",
-                                          "required": ["aggregatableFields", "aggregatedType"],
+                                          "required": [
+                                            "aggregatableFields",
+                                            "aggregatedType"
+                                          ],
                                           "properties": {
                                             "aggregatedType": {
                                               "description": "The name of the object type the aggregate expression is aggregating",
@@ -8239,7 +9375,10 @@
                                                 "title": "AggregatableFieldDefinition",
                                                 "description": "Definition of an aggregatable field on an object type",
                                                 "type": "object",
-                                                "required": ["aggregateExpression", "fieldName"],
+                                                "required": [
+                                                  "aggregateExpression",
+                                                  "fieldName"
+                                                ],
                                                 "properties": {
                                                   "fieldName": {
                                                     "description": "The name of the field on the operand aggregated type that is aggregatable",
@@ -8251,7 +9390,10 @@
                                                   },
                                                   "description": {
                                                     "description": "A description of the aggregatable field. Gets added to the description of the field in the GraphQL schema.",
-                                                    "type": ["string", "null"]
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
                                                   },
                                                   "aggregateExpression": {
                                                     "description": "The aggregate expression used to aggregate the type of the field",
@@ -8275,7 +9417,9 @@
                                       "title": "Scalar",
                                       "description": "If the operand is a scalar type",
                                       "type": "object",
-                                      "required": ["scalar"],
+                                      "required": [
+                                        "scalar"
+                                      ],
                                       "properties": {
                                         "scalar": {
                                           "$id": "https://hasura.io/jsonschemas/metadata/ScalarAggregateOperand",
@@ -8304,7 +9448,10 @@
                                                 "title": "AggregationFunctionDefinition",
                                                 "description": "Definition of an aggregation function",
                                                 "type": "object",
-                                                "required": ["name", "returnType"],
+                                                "required": [
+                                                  "name",
+                                                  "returnType"
+                                                ],
                                                 "properties": {
                                                   "name": {
                                                     "description": "The name of the aggregation function",
@@ -8320,7 +9467,10 @@
                                                   },
                                                   "description": {
                                                     "description": "A description of the aggregation function. Gets added to the description of the field in the GraphQL schema.",
-                                                    "type": ["string", "null"]
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
                                                   },
                                                   "returnType": {
                                                     "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/10/oneOf/0/properties/definition/properties/outputType/allOf/0"
@@ -8372,7 +9522,9 @@
                                                           "title": "AggregateFunctionMapping",
                                                           "description": "Definition of how to map the aggregation function to a function in the data connector",
                                                           "type": "object",
-                                                          "required": ["name"],
+                                                          "required": [
+                                                            "name"
+                                                          ],
                                                           "properties": {
                                                             "name": {
                                                               "description": "The name of the aggregation function in the data connector",
@@ -8413,7 +9565,9 @@
                                   "title": "AggregateCountDefinition",
                                   "description": "Definition of a count aggregation function",
                                   "type": "object",
-                                  "required": ["enable"],
+                                  "required": [
+                                    "enable"
+                                  ],
                                   "properties": {
                                     "enable": {
                                       "description": "Whether or not the aggregate function is available for use or not",
@@ -8421,7 +9575,10 @@
                                     },
                                     "description": {
                                       "description": "A description of the aggregation function. Gets added to the description of the field in the GraphQL schema.",
-                                      "type": ["string", "null"]
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
                                     },
                                     "returnType": {
                                       "description": "The scalar type that the count aggregation function returns. Must be an integer type. If omitted, Int is used as the default.",
@@ -8466,7 +9623,9 @@
                                     }
                                   ],
                                   "type": "object",
-                                  "required": ["selectTypeName"],
+                                  "required": [
+                                    "selectTypeName"
+                                  ],
                                   "properties": {
                                     "selectTypeName": {
                                       "description": "The type name to use for the aggregate selection type",
@@ -8497,7 +9656,10 @@
                             },
                             "description": {
                               "description": "The description of the aggregate expression. Gets added to the description of the command's root field in the GraphQL schema.",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             }
                           },
                           "additionalProperties": false
@@ -8550,7 +9712,9 @@
                           "selectUniques": [
                             {
                               "queryRootField": "ArticleByID",
-                              "uniqueIdentifier": ["article_id"],
+                              "uniqueIdentifier": [
+                                "article_id"
+                              ],
                               "description": "Description for the select unique ArticleByID"
                             }
                           ],
@@ -8570,22 +9734,34 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["Model"]
+                          "enum": [
+                            "Model"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/ModelV1",
                           "title": "ModelV1",
                           "description": "The definition of a data model. A data model is a collection of objects of a particular type. Models can support one or more CRUD operations.",
                           "type": "object",
-                          "required": ["name", "objectType", "orderableFields"],
+                          "required": [
+                            "name",
+                            "objectType",
+                            "orderableFields"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name of the data model.",
@@ -8621,7 +9797,10 @@
                                 "title": "ArgumentDefinition",
                                 "description": "The definition of an argument for a field, command, or model.",
                                 "type": "object",
-                                "required": ["name", "type"],
+                                "required": [
+                                  "name",
+                                  "type"
+                                ],
                                 "properties": {
                                   "name": {
                                     "$id": "https://hasura.io/jsonschemas/metadata/ArgumentName",
@@ -8634,7 +9813,10 @@
                                     "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/10/oneOf/0/properties/definition/properties/outputType/allOf/0"
                                   },
                                   "description": {
-                                    "type": ["string", "null"]
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -8654,7 +9836,10 @@
                                     }
                                   ],
                                   "type": "object",
-                                  "required": ["collection", "dataConnectorName"],
+                                  "required": [
+                                    "collection",
+                                    "dataConnectorName"
+                                  ],
                                   "properties": {
                                     "dataConnectorName": {
                                       "description": "The name of the data connector backing this model.",
@@ -8717,7 +9902,10 @@
                                 "title": "OrderableField",
                                 "description": "A field that can be used to order the objects in a model.",
                                 "type": "object",
-                                "required": ["fieldName", "orderByDirections"],
+                                "required": [
+                                  "fieldName",
+                                  "orderByDirections"
+                                ],
                                 "properties": {
                                   "fieldName": {
                                     "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/2/oneOf/0/properties/definition/properties/globalIdFields/items"
@@ -8729,7 +9917,9 @@
                                     "oneOf": [
                                       {
                                         "type": "object",
-                                        "required": ["enableAll"],
+                                        "required": [
+                                          "enableAll"
+                                        ],
                                         "properties": {
                                           "enableAll": {
                                             "type": "boolean"
@@ -8739,7 +9929,9 @@
                                       },
                                       {
                                         "type": "object",
-                                        "required": ["enableSpecific"],
+                                        "required": [
+                                          "enableSpecific"
+                                        ],
                                         "properties": {
                                           "enableSpecific": {
                                             "type": "array",
@@ -8747,7 +9939,10 @@
                                               "$id": "https://hasura.io/jsonschemas/metadata/OrderByDirection2",
                                               "title": "OrderByDirection",
                                               "type": "string",
-                                              "enum": ["Asc", "Desc"]
+                                              "enum": [
+                                                "Asc",
+                                                "Desc"
+                                              ]
                                             }
                                           }
                                         },
@@ -8782,7 +9977,9 @@
                                       "selectUniques": [
                                         {
                                           "queryRootField": "ArticleByID",
-                                          "uniqueIdentifier": ["article_id"],
+                                          "uniqueIdentifier": [
+                                            "article_id"
+                                          ],
                                           "description": "Description for the select unique ArticleByID"
                                         }
                                       ],
@@ -8798,7 +9995,9 @@
                                     }
                                   ],
                                   "type": "object",
-                                  "required": ["selectUniques"],
+                                  "required": [
+                                    "selectUniques"
+                                  ],
                                   "properties": {
                                     "selectUniques": {
                                       "description": "For each select unique defined here, a query root field is added to the GraphQL API that can be used to select a unique object from the model.",
@@ -8808,7 +10007,10 @@
                                         "title": "SelectUniqueGraphQlDefinition",
                                         "description": "The definition of the GraphQL API for selecting a unique row/object from a model.",
                                         "type": "object",
-                                        "required": ["queryRootField", "uniqueIdentifier"],
+                                        "required": [
+                                          "queryRootField",
+                                          "uniqueIdentifier"
+                                        ],
                                         "properties": {
                                           "queryRootField": {
                                             "description": "The name of the query root field for this API.",
@@ -8827,7 +10029,10 @@
                                           },
                                           "description": {
                                             "description": "The description of the select unique graphql definition of the model. Gets added to the description of the select unique root field of the model in the graphql schema.",
-                                            "type": ["string", "null"]
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
                                           },
                                           "deprecated": {
                                             "description": "Whether this select unique query field is deprecated. If set, the deprecation status is added to the select unique root field's graphql schema.",
@@ -8848,7 +10053,9 @@
                                                 "title": "SubscriptionGraphQlDefinition",
                                                 "description": "The definition of the GraphQL API for enabling subscription on query root fields.",
                                                 "type": "object",
-                                                "required": ["rootField"],
+                                                "required": [
+                                                  "rootField"
+                                                ],
                                                 "properties": {
                                                   "rootField": {
                                                     "description": "The name of the subscription root field.",
@@ -8860,7 +10067,10 @@
                                                   },
                                                   "description": {
                                                     "description": "The description of the subscription graphql definition. Gets added to the description of the subscription root field in the graphql schema.",
-                                                    "type": ["string", "null"]
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
                                                   },
                                                   "deprecated": {
                                                     "description": "Whether this subscription root field is deprecated. If set, the deprecation status is added to the subscription root field's graphql schema.",
@@ -8900,7 +10110,9 @@
                                           "title": "SelectManyGraphQlDefinition",
                                           "description": "The definition of the GraphQL API for selecting rows from a model.",
                                           "type": "object",
-                                          "required": ["queryRootField"],
+                                          "required": [
+                                            "queryRootField"
+                                          ],
                                           "properties": {
                                             "queryRootField": {
                                               "description": "The name of the query root field for this API.",
@@ -8912,7 +10124,10 @@
                                             },
                                             "description": {
                                               "description": "The description of the select many graphql definition of the model. Gets added to the description of the select many root field of the model in the graphql schema.",
-                                              "type": ["string", "null"]
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
                                             },
                                             "deprecated": {
                                               "description": "Whether this select many query field is deprecated. If set, the deprecation status is added to the select many root field's graphql schema.",
@@ -8974,7 +10189,9 @@
                                           "title": "ModelApolloFederationConfiguration",
                                           "description": "Apollo Federation configuration for a model.",
                                           "type": "object",
-                                          "required": ["entitySource"],
+                                          "required": [
+                                            "entitySource"
+                                          ],
                                           "properties": {
                                             "entitySource": {
                                               "description": "Whether this model should be used as the source for fetching _entity for object of its type.",
@@ -9007,7 +10224,9 @@
                                           "title": "ModelAggregateGraphQlDefinition",
                                           "description": "The definition of the GraphQL API for aggregating over a model.",
                                           "type": "object",
-                                          "required": ["queryRootField"],
+                                          "required": [
+                                            "queryRootField"
+                                          ],
                                           "properties": {
                                             "queryRootField": {
                                               "description": "The name of the query root field for this API.",
@@ -9019,7 +10238,10 @@
                                             },
                                             "description": {
                                               "description": "The description of the aggregate graphql definition of the model. Gets added to the description of the aggregate root field of the model in the graphql schema.",
-                                              "type": ["string", "null"]
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
                                             },
                                             "deprecated": {
                                               "description": "Whether this aggregate query field is deprecated. If set, the deprecation status is added to the aggregate root field's graphql schema.",
@@ -9061,7 +10283,10 @@
                             },
                             "description": {
                               "description": "The description of the model. Gets added to the description of the model in the graphql schema.",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             }
                           },
                           "additionalProperties": false
@@ -9071,22 +10296,33 @@
                     },
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["Model"]
+                          "enum": [
+                            "Model"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v2"]
+                          "enum": [
+                            "v2"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/ModelV2",
                           "title": "ModelV2",
                           "description": "The definition of a data model. A data model is a collection of objects of a particular type. Models can support one or more CRUD operations. ModelV2 implements the changes described in rfcs/open-dd-expression-type-changes.md.",
                           "type": "object",
-                          "required": ["name", "objectType"],
+                          "required": [
+                            "name",
+                            "objectType"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name of the data model.",
@@ -9173,7 +10409,9 @@
                                       "selectUniques": [
                                         {
                                           "queryRootField": "ArticleByID",
-                                          "uniqueIdentifier": ["article_id"],
+                                          "uniqueIdentifier": [
+                                            "article_id"
+                                          ],
                                           "description": "Description for the select unique ArticleByID"
                                         }
                                       ],
@@ -9188,7 +10426,9 @@
                                     }
                                   ],
                                   "type": "object",
-                                  "required": ["selectUniques"],
+                                  "required": [
+                                    "selectUniques"
+                                  ],
                                   "properties": {
                                     "selectUniques": {
                                       "description": "For each select unique defined here, a query root field is added to the GraphQL API that can be used to select a unique object from the model.",
@@ -9262,7 +10502,10 @@
                             },
                             "description": {
                               "description": "The description of the model. Gets added to the description of the model in the graphql schema.",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             }
                           },
                           "additionalProperties": false
@@ -9302,22 +10545,33 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["Command"]
+                          "enum": [
+                            "Command"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/CommandV1",
                           "title": "CommandV1",
                           "description": "Definition of an OpenDD Command, which is a custom operation that can take arguments and returns an output. The semantics of a command are opaque to OpenDD.",
                           "type": "object",
-                          "required": ["name", "outputType"],
+                          "required": [
+                            "name",
+                            "outputType"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name of the command.",
@@ -9367,7 +10621,10 @@
                                     }
                                   ],
                                   "type": "object",
-                                  "required": ["dataConnectorCommand", "dataConnectorName"],
+                                  "required": [
+                                    "dataConnectorCommand",
+                                    "dataConnectorName"
+                                  ],
                                   "properties": {
                                     "dataConnectorName": {
                                       "description": "The name of the data connector backing this command.",
@@ -9388,7 +10645,9 @@
                                               "title": "Function",
                                               "description": "A function as data connector command.",
                                               "type": "object",
-                                              "required": ["function"],
+                                              "required": [
+                                                "function"
+                                              ],
                                               "properties": {
                                                 "function": {
                                                   "$id": "https://hasura.io/jsonschemas/metadata/FunctionName",
@@ -9403,7 +10662,9 @@
                                               "title": "Procedure",
                                               "description": "A procedure as data connector command.",
                                               "type": "object",
-                                              "required": ["procedure"],
+                                              "required": [
+                                                "procedure"
+                                              ],
                                               "properties": {
                                                 "procedure": {
                                                   "$id": "https://hasura.io/jsonschemas/metadata/ProcedureName",
@@ -9449,7 +10710,10 @@
                                     }
                                   ],
                                   "type": "object",
-                                  "required": ["rootFieldKind", "rootFieldName"],
+                                  "required": [
+                                    "rootFieldKind",
+                                    "rootFieldName"
+                                  ],
                                   "properties": {
                                     "rootFieldName": {
                                       "description": "The name of the graphql root field to use for this command.",
@@ -9469,7 +10733,10 @@
                                           "$id": "https://hasura.io/jsonschemas/metadata/GraphQlRootFieldKind",
                                           "title": "GraphQlRootFieldKind",
                                           "type": "string",
-                                          "enum": ["Query", "Mutation"]
+                                          "enum": [
+                                            "Query",
+                                            "Mutation"
+                                          ]
                                         }
                                       ]
                                     },
@@ -9494,7 +10761,10 @@
                             },
                             "description": {
                               "description": "The description of the command. Gets added to the description of the command's root field in the GraphQL schema.",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             }
                           },
                           "additionalProperties": false
@@ -9547,22 +10817,35 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["Relationship"]
+                          "enum": [
+                            "Relationship"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/RelationshipV1",
                           "title": "RelationshipV1",
                           "description": "Definition of a relationship on an OpenDD type which allows it to be extended with related models or commands.",
                           "type": "object",
-                          "required": ["mapping", "name", "sourceType", "target"],
+                          "required": [
+                            "mapping",
+                            "name",
+                            "sourceType",
+                            "target"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name of the relationship.",
@@ -9603,14 +10886,19 @@
                                   "oneOf": [
                                     {
                                       "type": "object",
-                                      "required": ["model"],
+                                      "required": [
+                                        "model"
+                                      ],
                                       "properties": {
                                         "model": {
                                           "$id": "https://hasura.io/jsonschemas/metadata/ModelRelationshipTarget",
                                           "title": "ModelRelationshipTarget",
                                           "description": "The target model for a relationship.",
                                           "type": "object",
-                                          "required": ["name", "relationshipType"],
+                                          "required": [
+                                            "name",
+                                            "relationshipType"
+                                          ],
                                           "properties": {
                                             "name": {
                                               "description": "The name of the data model.",
@@ -9622,7 +10910,10 @@
                                             },
                                             "subgraph": {
                                               "description": "The subgraph of the target model. Defaults to the current subgraph.",
-                                              "type": ["string", "null"],
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ],
                                               "pattern": "^(?!__)[_a-zA-Z][_a-zA-Z0-9]*$"
                                             },
                                             "relationshipType": {
@@ -9636,12 +10927,16 @@
                                                     {
                                                       "description": "Select one related object from the target.",
                                                       "type": "string",
-                                                      "enum": ["Object"]
+                                                      "enum": [
+                                                        "Object"
+                                                      ]
                                                     },
                                                     {
                                                       "description": "Select multiple related objects from the target.",
                                                       "type": "string",
-                                                      "enum": ["Array"]
+                                                      "enum": [
+                                                        "Array"
+                                                      ]
                                                     }
                                                   ]
                                                 }
@@ -9655,7 +10950,9 @@
                                                   "title": "ModelRelationshipTargetAggregate",
                                                   "description": "Which aggregate expression to use to aggregate the array relationship.",
                                                   "type": "object",
-                                                  "required": ["aggregateExpression"],
+                                                  "required": [
+                                                    "aggregateExpression"
+                                                  ],
                                                   "properties": {
                                                     "aggregateExpression": {
                                                       "description": "The name of the aggregate expression that defines how to aggregate across the relationship.",
@@ -9667,7 +10964,10 @@
                                                     },
                                                     "description": {
                                                       "description": "The description of the relationship aggregate. Gets added to the description of the aggregate field in the GraphQL schema",
-                                                      "type": ["string", "null"]
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     }
                                                   },
                                                   "additionalProperties": false
@@ -9685,14 +10985,18 @@
                                     },
                                     {
                                       "type": "object",
-                                      "required": ["command"],
+                                      "required": [
+                                        "command"
+                                      ],
                                       "properties": {
                                         "command": {
                                           "$id": "https://hasura.io/jsonschemas/metadata/CommandRelationshipTarget",
                                           "title": "CommandRelationshipTarget",
                                           "description": "The target command for a relationship.",
                                           "type": "object",
-                                          "required": ["name"],
+                                          "required": [
+                                            "name"
+                                          ],
                                           "properties": {
                                             "name": {
                                               "description": "The name of the command.",
@@ -9704,7 +11008,10 @@
                                             },
                                             "subgraph": {
                                               "description": "The subgraph of the target command. Defaults to the current subgraph.",
-                                              "type": ["string", "null"],
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ],
                                               "pattern": "^(?!__)[_a-zA-Z][_a-zA-Z0-9]*$"
                                             }
                                           },
@@ -9743,7 +11050,10 @@
                                   }
                                 ],
                                 "type": "object",
-                                "required": ["source", "target"],
+                                "required": [
+                                  "source",
+                                  "target"
+                                ],
                                 "properties": {
                                   "source": {
                                     "description": "The source configuration for this relationship mapping.",
@@ -9756,7 +11066,9 @@
                                           {
                                             "title": "SourceValue",
                                             "type": "object",
-                                            "required": ["value"],
+                                            "required": [
+                                              "value"
+                                            ],
                                             "properties": {
                                               "value": {
                                                 "$id": "https://hasura.io/jsonschemas/metadata/ValueExpression",
@@ -9766,7 +11078,9 @@
                                                   {
                                                     "title": "Literal",
                                                     "type": "object",
-                                                    "required": ["literal"],
+                                                    "required": [
+                                                      "literal"
+                                                    ],
                                                     "properties": {
                                                       "literal": true
                                                     },
@@ -9775,7 +11089,9 @@
                                                   {
                                                     "title": "SessionVariable",
                                                     "type": "object",
-                                                    "required": ["sessionVariable"],
+                                                    "required": [
+                                                      "sessionVariable"
+                                                    ],
                                                     "properties": {
                                                       "sessionVariable": {
                                                         "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/14/oneOf/0/properties/definition/properties/permissions/items/properties/argumentPresets/items/properties/value/allOf/0/oneOf/1/properties/sessionVariable"
@@ -9786,7 +11102,9 @@
                                                   {
                                                     "title": "ValueFromEnv",
                                                     "type": "object",
-                                                    "required": ["valueFromEnv"],
+                                                    "required": [
+                                                      "valueFromEnv"
+                                                    ],
                                                     "properties": {
                                                       "valueFromEnv": {
                                                         "type": "string"
@@ -9802,7 +11120,9 @@
                                           {
                                             "title": "SourceField",
                                             "type": "object",
-                                            "required": ["fieldPath"],
+                                            "required": [
+                                              "fieldPath"
+                                            ],
                                             "properties": {
                                               "fieldPath": {
                                                 "type": "array",
@@ -9811,7 +11131,9 @@
                                                   "title": "RelationshipSourceFieldAccess",
                                                   "description": "A field access in a relationship mapping.",
                                                   "type": "object",
-                                                  "required": ["fieldName"],
+                                                  "required": [
+                                                    "fieldName"
+                                                  ],
                                                   "properties": {
                                                     "fieldName": {
                                                       "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/2/oneOf/0/properties/definition/properties/globalIdFields/items"
@@ -9838,14 +11160,18 @@
                                           {
                                             "title": "TargetArgument",
                                             "type": "object",
-                                            "required": ["argument"],
+                                            "required": [
+                                              "argument"
+                                            ],
                                             "properties": {
                                               "argument": {
                                                 "$id": "https://hasura.io/jsonschemas/metadata/ArgumentMappingTarget",
                                                 "title": "ArgumentMappingTarget",
                                                 "description": "An argument target for a relationship mapping.",
                                                 "type": "object",
-                                                "required": ["argumentName"],
+                                                "required": [
+                                                  "argumentName"
+                                                ],
                                                 "properties": {
                                                   "argumentName": {
                                                     "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/9/oneOf/0/properties/definition/properties/arguments/items/properties/name"
@@ -9859,7 +11185,9 @@
                                           {
                                             "title": "TargetModelField",
                                             "type": "object",
-                                            "required": ["modelField"],
+                                            "required": [
+                                              "modelField"
+                                            ],
                                             "properties": {
                                               "modelField": {
                                                 "type": "array",
@@ -9880,7 +11208,10 @@
                             },
                             "description": {
                               "description": "The description of the relationship. Gets added to the description of the relationship in the graphql schema.",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             },
                             "deprecated": {
                               "description": "Whether this relationship is deprecated. If set, the deprecation status is added to the relationship field's graphql schema.",
@@ -9893,7 +11224,10 @@
                                   "properties": {
                                     "reason": {
                                       "description": "The reason for deprecation.",
-                                      "type": ["string", "null"]
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
                                     }
                                   },
                                   "additionalProperties": false
@@ -9953,13 +11287,20 @@
                           {
                             "role": "admin",
                             "output": {
-                              "allowedFields": ["article_id", "author_id", "title"]
+                              "allowedFields": [
+                                "article_id",
+                                "author_id",
+                                "title"
+                              ]
                             }
                           },
                           {
                             "role": "user",
                             "output": {
-                              "allowedFields": ["article_id", "author_id"]
+                              "allowedFields": [
+                                "article_id",
+                                "author_id"
+                              ]
                             }
                           }
                         ]
@@ -9975,61 +11316,20 @@
                             {
                               "role": "admin",
                               "output": {
-                                "allowedFields": ["article_id", "author_id", "title"]
+                                "allowedFields": [
+                                  "article_id",
+                                  "author_id",
+                                  "title"
+                                ]
                               }
                             },
                             {
                               "role": "user",
                               "output": {
-                                "allowedFields": ["article_id", "author_id"]
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "kind": "TypePermissions",
-                      "version": "v2",
-                      "definition": {
-                        "typeName": "movie",
-                        "permissions": {
-                          "rulesBased": [
-                            {
-                              "allowFields": {
-                                "condition": {
-                                  "contains": {
-                                    "left": {
-                                      "sessionVariable": "x-hasura-role"
-                                    },
-                                    "right": {
-                                      "literal": [
-                                        "admin",
-                                        "user",
-                                        "user_not",
-                                        "user_and",
-                                        "user_or",
-                                        "limited_fields_user"
-                                      ]
-                                    }
-                                  }
-                                },
-                                "fields": ["movie_id", "rating", "title", "release_date"]
-                              }
-                            },
-                            {
-                              "denyFields": {
-                                "condition": {
-                                  "contains": {
-                                    "left": {
-                                      "sessionVariable": "x-hasura-role"
-                                    },
-                                    "right": {
-                                      "literal": ["limited_fields_user"]
-                                    }
-                                  }
-                                },
-                                "fields": ["rating"]
+                                "allowedFields": [
+                                  "article_id",
+                                  "author_id"
+                                ]
                               }
                             }
                           ]
@@ -10040,22 +11340,33 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["TypePermissions"]
+                          "enum": [
+                            "TypePermissions"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/TypePermissionsV1",
                           "title": "TypePermissionsV1",
                           "description": "Definition of permissions for an OpenDD type.",
                           "type": "object",
-                          "required": ["permissions", "typeName"],
+                          "required": [
+                            "permissions",
+                            "typeName"
+                          ],
                           "properties": {
                             "typeName": {
                               "description": "The name of the type for which permissions are being defined. Must be an object type.",
@@ -10076,7 +11387,10 @@
                                   {
                                     "role": "user",
                                     "output": {
-                                      "allowedFields": ["article_id", "author_id"]
+                                      "allowedFields": [
+                                        "article_id",
+                                        "author_id"
+                                      ]
                                     },
                                     "input": {
                                       "fieldPresets": [
@@ -10091,7 +11405,9 @@
                                   }
                                 ],
                                 "type": "object",
-                                "required": ["role"],
+                                "required": [
+                                  "role"
+                                ],
                                 "properties": {
                                   "role": {
                                     "description": "The role for which permissions are being defined.",
@@ -10109,7 +11425,9 @@
                                         "title": "TypeOutputPermission",
                                         "description": "Permissions for a type for a particular role when used in an output context.",
                                         "type": "object",
-                                        "required": ["allowedFields"],
+                                        "required": [
+                                          "allowedFields"
+                                        ],
                                         "properties": {
                                           "allowedFields": {
                                             "description": "Fields of the type that are accessible for a role",
@@ -10145,7 +11463,10 @@
                                               "title": "FieldPreset",
                                               "description": "Preset value for a field",
                                               "type": "object",
-                                              "required": ["field", "value"],
+                                              "required": [
+                                                "field",
+                                                "value"
+                                              ],
                                               "properties": {
                                                 "field": {
                                                   "description": "Field name for preset",
@@ -10187,22 +11508,33 @@
                     },
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["TypePermissions"]
+                          "enum": [
+                            "TypePermissions"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v2"]
+                          "enum": [
+                            "v2"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/TypePermissionsV2",
                           "title": "TypePermissionsV1",
                           "description": "Definition of permissions for an OpenDD type.",
                           "type": "object",
-                          "required": ["permissions", "typeName"],
+                          "required": [
+                            "permissions",
+                            "typeName"
+                          ],
                           "properties": {
                             "typeName": {
                               "description": "The name of the type for which permissions are being defined. Must be an object type.",
@@ -10224,107 +11556,14 @@
                                       "title": "RoleBased",
                                       "description": "Definition of role-based type permissions on an OpenDD object type",
                                       "type": "object",
-                                      "required": ["roleBased"],
+                                      "required": [
+                                        "roleBased"
+                                      ],
                                       "properties": {
                                         "roleBased": {
                                           "type": "array",
                                           "items": {
                                             "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/12/oneOf/0/properties/definition/properties/permissions/items"
-                                          }
-                                        }
-                                      },
-                                      "additionalProperties": false
-                                    },
-                                    {
-                                      "title": "RulesBased",
-                                      "description": "Definition of rules-based type permissions on an OpenDD object type",
-                                      "type": "object",
-                                      "required": ["rulesBased"],
-                                      "properties": {
-                                        "rulesBased": {
-                                          "type": "array",
-                                          "items": {
-                                            "$id": "https://hasura.io/jsonschemas/metadata/TypeAuthorizationRule",
-                                            "title": "TypeAuthorizationRule",
-                                            "description": "A rule that determines which fields of a type are available to a user",
-                                            "oneOf": [
-                                              {
-                                                "type": "object",
-                                                "required": ["allowFields"],
-                                                "properties": {
-                                                  "allowFields": {
-                                                    "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/12/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/denyFields"
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["denyFields"],
-                                                "properties": {
-                                                  "denyFields": {
-                                                    "$id": "https://hasura.io/jsonschemas/metadata/Fields",
-                                                    "title": "Fields",
-                                                    "description": "A list of fields to allow/deny when the condition evaluates to `true`",
-                                                    "type": "object",
-                                                    "required": ["fields"],
-                                                    "properties": {
-                                                      "fields": {
-                                                        "type": "array",
-                                                        "items": {
-                                                          "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/2/oneOf/0/properties/definition/properties/globalIdFields/items"
-                                                        }
-                                                      },
-                                                      "condition": {
-                                                        "anyOf": [
-                                                          {
-                                                            "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                          },
-                                                          {
-                                                            "type": "null"
-                                                          }
-                                                        ]
-                                                      }
-                                                    },
-                                                    "additionalProperties": false
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["fieldPreset"],
-                                                "properties": {
-                                                  "fieldPreset": {
-                                                    "$id": "https://hasura.io/jsonschemas/metadata/InputTypeFieldPreset",
-                                                    "title": "InputTypeFieldPreset",
-                                                    "description": "A preset value for a field that applies when the condition evaluates to `true`",
-                                                    "type": "object",
-                                                    "required": ["fieldName", "value"],
-                                                    "properties": {
-                                                      "condition": {
-                                                        "anyOf": [
-                                                          {
-                                                            "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                          },
-                                                          {
-                                                            "type": "null"
-                                                          }
-                                                        ]
-                                                      },
-                                                      "fieldName": {
-                                                        "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/2/oneOf/0/properties/definition/properties/globalIdFields/items"
-                                                      },
-                                                      "value": {
-                                                        "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/11/oneOf/0/properties/definition/properties/mapping/items/properties/source/allOf/0/oneOf/0/properties/value"
-                                                      }
-                                                    },
-                                                    "additionalProperties": false
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              }
-                                            ]
                                           }
                                         }
                                       },
@@ -10409,123 +11648,38 @@
                           }
                         ]
                       }
-                    },
-                    {
-                      "kind": "ModelPermissions",
-                      "version": "v2",
-                      "definition": {
-                        "modelName": "actors_by_movie",
-                        "permissions": {
-                          "rulesBased": [
-                            {
-                              "allow": {
-                                "condition": {
-                                  "contains": {
-                                    "left": {
-                                      "sessionVariable": "x-hasura-role"
-                                    },
-                                    "right": {
-                                      "literal": ["admin", "user_with_preset_movie_id"]
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "presetArgument": {
-                                "condition": {
-                                  "equal": {
-                                    "left": {
-                                      "sessionVariable": "x-hasura-role"
-                                    },
-                                    "right": {
-                                      "literal": "user_with_preset_movie_id"
-                                    }
-                                  }
-                                },
-                                "argumentName": "movie_id",
-                                "value": {
-                                  "literal": 1
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "kind": "ModelPermissions",
-                      "version": "v2",
-                      "definition": {
-                        "modelName": "actors",
-                        "permissions": {
-                          "rulesBased": [
-                            {
-                              "allow": {
-                                "condition": {
-                                  "contains": {
-                                    "left": {
-                                      "sessionVariable": "x-hasura-role"
-                                    },
-                                    "right": {
-                                      "literal": ["admin", "object_relationship_user"]
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "filter": {
-                                "condition": {
-                                  "equal": {
-                                    "left": {
-                                      "sessionVariable": "x-hasura-role"
-                                    },
-                                    "right": {
-                                      "literal": "object_relationship_user"
-                                    }
-                                  }
-                                },
-                                "predicate": {
-                                  "relationship": {
-                                    "name": "Country",
-                                    "predicate": {
-                                      "fieldComparison": {
-                                        "field": "name",
-                                        "operator": "_eq",
-                                        "value": {
-                                          "literal": "UK"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
                     }
                   ],
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["ModelPermissions"]
+                          "enum": [
+                            "ModelPermissions"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/ModelPermissionsV1",
                           "title": "ModelPermissionsV1",
                           "description": "Definition of permissions for an OpenDD model.",
                           "type": "object",
-                          "required": ["modelName", "permissions"],
+                          "required": [
+                            "modelName",
+                            "permissions"
+                          ],
                           "properties": {
                             "modelName": {
                               "description": "The name of the model for which permissions are being defined.",
@@ -10567,7 +11721,9 @@
                                   }
                                 ],
                                 "type": "object",
-                                "required": ["role"],
+                                "required": [
+                                  "role"
+                                ],
                                 "properties": {
                                   "role": {
                                     "description": "The role for which permissions are being defined.",
@@ -10585,7 +11741,9 @@
                                         "title": "SelectPermission",
                                         "description": "Defines the permissions for selecting a model for a role.",
                                         "type": "object",
-                                        "required": ["filter"],
+                                        "required": [
+                                          "filter"
+                                        ],
                                         "properties": {
                                           "filter": {
                                             "description": "Filter expression when selecting rows for this model. Null filter implies all rows are selectable.",
@@ -10661,14 +11819,20 @@
                                                       {
                                                         "description": "Filters objects based on a field value.",
                                                         "type": "object",
-                                                        "required": ["fieldComparison"],
+                                                        "required": [
+                                                          "fieldComparison"
+                                                        ],
                                                         "properties": {
                                                           "fieldComparison": {
                                                             "$id": "https://hasura.io/jsonschemas/metadata/FieldComparisonPredicate",
                                                             "title": "FieldComparisonPredicate",
                                                             "description": "Field comparison predicate filters objects based on a field value.",
                                                             "type": "object",
-                                                            "required": ["field", "operator", "value"],
+                                                            "required": [
+                                                              "field",
+                                                              "operator",
+                                                              "value"
+                                                            ],
                                                             "properties": {
                                                               "field": {
                                                                 "description": "The field name of the object type of the model to compare.",
@@ -10702,14 +11866,18 @@
                                                       },
                                                       {
                                                         "type": "object",
-                                                        "required": ["fieldIsNull"],
+                                                        "required": [
+                                                          "fieldIsNull"
+                                                        ],
                                                         "properties": {
                                                           "fieldIsNull": {
                                                             "$id": "https://hasura.io/jsonschemas/metadata/FieldIsNullPredicate",
                                                             "title": "FieldIsNullPredicate",
                                                             "description": "Predicate to check if the given field is null.",
                                                             "type": "object",
-                                                            "required": ["field"],
+                                                            "required": [
+                                                              "field"
+                                                            ],
                                                             "properties": {
                                                               "field": {
                                                                 "description": "The name of the field that should be checked for a null value.",
@@ -10728,14 +11896,19 @@
                                                       {
                                                         "description": "Filters objects based on the nested field of a model.",
                                                         "type": "object",
-                                                        "required": ["nestedField"],
+                                                        "required": [
+                                                          "nestedField"
+                                                        ],
                                                         "properties": {
                                                           "nestedField": {
                                                             "$id": "https://hasura.io/jsonschemas/metadata/NestedFieldPredicate",
                                                             "title": "NestedFieldPredicate",
                                                             "description": "Nested field predicate filters objects of a source model based on a predicate on the nested field.",
                                                             "type": "object",
-                                                            "required": ["fieldName", "predicate"],
+                                                            "required": [
+                                                              "fieldName",
+                                                              "predicate"
+                                                            ],
                                                             "properties": {
                                                               "fieldName": {
                                                                 "description": "The name of the field in the object type of the model to follow.",
@@ -10762,14 +11935,18 @@
                                                       {
                                                         "description": "Filters objects based on the relationship of a model.",
                                                         "type": "object",
-                                                        "required": ["relationship"],
+                                                        "required": [
+                                                          "relationship"
+                                                        ],
                                                         "properties": {
                                                           "relationship": {
                                                             "$id": "https://hasura.io/jsonschemas/metadata/RelationshipPredicate",
                                                             "title": "RelationshipPredicate",
                                                             "description": "Relationship predicate filters objects of a source model based on a predicate on the related model.",
                                                             "type": "object",
-                                                            "required": ["name"],
+                                                            "required": [
+                                                              "name"
+                                                            ],
                                                             "properties": {
                                                               "name": {
                                                                 "description": "The name of the relationship of the object type of the model to follow.",
@@ -10800,7 +11977,9 @@
                                                         "title": "And",
                                                         "description": "Evaluates to true if all sub-predicates evaluate to true.",
                                                         "type": "object",
-                                                        "required": ["and"],
+                                                        "required": [
+                                                          "and"
+                                                        ],
                                                         "properties": {
                                                           "and": {
                                                             "type": "array",
@@ -10815,7 +11994,9 @@
                                                         "title": "Or",
                                                         "description": "Evaluates to true if any of the sub-predicates evaluate to true.",
                                                         "type": "object",
-                                                        "required": ["or"],
+                                                        "required": [
+                                                          "or"
+                                                        ],
                                                         "properties": {
                                                           "or": {
                                                             "type": "array",
@@ -10830,7 +12011,9 @@
                                                         "title": "Not",
                                                         "description": "Evaluates to true if the sub-predicate evaluates to false.",
                                                         "type": "object",
-                                                        "required": ["not"],
+                                                        "required": [
+                                                          "not"
+                                                        ],
                                                         "properties": {
                                                           "not": {
                                                             "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/0/properties/definition/properties/permissions/items/properties/select/anyOf/0/properties/filter/allOf/0/anyOf/1"
@@ -10922,22 +12105,33 @@
                     },
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["ModelPermissions"]
+                          "enum": [
+                            "ModelPermissions"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v2"]
+                          "enum": [
+                            "v2"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/ModelPermissionsV2",
                           "title": "ModelPermissionsV2",
                           "description": "Definition of permissions for an OpenDD model.",
                           "type": "object",
-                          "required": ["modelName", "permissions"],
+                          "required": [
+                            "modelName",
+                            "permissions"
+                          ],
                           "properties": {
                             "modelName": {
                               "description": "The name of the model for which permissions are being defined.",
@@ -10959,336 +12153,14 @@
                                       "title": "RoleBased",
                                       "description": "Definition of role-based type permissions on an OpenDD model",
                                       "type": "object",
-                                      "required": ["roleBased"],
+                                      "required": [
+                                        "roleBased"
+                                      ],
                                       "properties": {
                                         "roleBased": {
                                           "type": "array",
                                           "items": {
                                             "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/0/properties/definition/properties/permissions/items"
-                                          }
-                                        }
-                                      },
-                                      "additionalProperties": false
-                                    },
-                                    {
-                                      "title": "RulesBased",
-                                      "description": "Definition of rules-based type permissions on an OpenDD model",
-                                      "type": "object",
-                                      "required": ["rulesBased"],
-                                      "properties": {
-                                        "rulesBased": {
-                                          "type": "array",
-                                          "items": {
-                                            "$id": "https://hasura.io/jsonschemas/metadata/ModelAuthorizationRule",
-                                            "title": "ModelAuthorizationRule",
-                                            "description": "A rule that determines which model and argument presets are available to a user",
-                                            "oneOf": [
-                                              {
-                                                "type": "object",
-                                                "required": ["allow"],
-                                                "properties": {
-                                                  "allow": {
-                                                    "$id": "https://hasura.io/jsonschemas/metadata/Allow",
-                                                    "title": "Allow",
-                                                    "description": "Allow access if the condition evaluates to `true`",
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "condition": {
-                                                        "anyOf": [
-                                                          {
-                                                            "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                          },
-                                                          {
-                                                            "type": "null"
-                                                          }
-                                                        ]
-                                                      }
-                                                    },
-                                                    "additionalProperties": false
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["deny"],
-                                                "properties": {
-                                                  "deny": {
-                                                    "$id": "https://hasura.io/jsonschemas/metadata/Deny",
-                                                    "title": "Deny",
-                                                    "description": "Deny access if the condition evaluates to `true`",
-                                                    "type": "object",
-                                                    "required": ["condition"],
-                                                    "properties": {
-                                                      "condition": {
-                                                        "$id": "https://hasura.io/jsonschemas/metadata/Condition",
-                                                        "title": "Condition",
-                                                        "description": "A boolean expression used to determine if a rules-based permission should be applied.",
-                                                        "oneOf": [
-                                                          {
-                                                            "description": "Combine multiple Conditions with `&&`",
-                                                            "type": "object",
-                                                            "required": ["and"],
-                                                            "properties": {
-                                                              "and": {
-                                                                "type": "array",
-                                                                "items": {
-                                                                  "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                                }
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          },
-                                                          {
-                                                            "description": "Combine multiple Conditions with `||`",
-                                                            "type": "object",
-                                                            "required": ["or"],
-                                                            "properties": {
-                                                              "or": {
-                                                                "type": "array",
-                                                                "items": {
-                                                                  "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                                }
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          },
-                                                          {
-                                                            "description": "Negate a Condition",
-                                                            "type": "object",
-                                                            "required": ["not"],
-                                                            "properties": {
-                                                              "not": {
-                                                                "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          },
-                                                          {
-                                                            "description": "Compare two ValueExpressions for equality",
-                                                            "type": "object",
-                                                            "required": ["equal"],
-                                                            "properties": {
-                                                              "equal": {
-                                                                "$id": "https://hasura.io/jsonschemas/metadata/Comparison",
-                                                                "title": "Comparison",
-                                                                "description": "A left and right value for comparison",
-                                                                "type": "object",
-                                                                "required": ["left", "right"],
-                                                                "properties": {
-                                                                  "left": {
-                                                                    "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/11/oneOf/0/properties/definition/properties/mapping/items/properties/source/allOf/0/oneOf/0/properties/value"
-                                                                  },
-                                                                  "right": {
-                                                                    "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/11/oneOf/0/properties/definition/properties/mapping/items/properties/source/allOf/0/oneOf/0/properties/value"
-                                                                  }
-                                                                },
-                                                                "additionalProperties": false
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          },
-                                                          {
-                                                            "description": "Is the left value contained in the right value? The right value must be an array type.",
-                                                            "type": "object",
-                                                            "required": ["contains"],
-                                                            "properties": {
-                                                              "contains": {
-                                                                "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition/oneOf/3/properties/equal"
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          },
-                                                          {
-                                                            "description": "Is the left value greater than the right value?",
-                                                            "type": "object",
-                                                            "required": ["greaterThan"],
-                                                            "properties": {
-                                                              "greaterThan": {
-                                                                "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition/oneOf/3/properties/equal"
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          },
-                                                          {
-                                                            "description": "Is the left value less than the right value?",
-                                                            "type": "object",
-                                                            "required": ["lessThan"],
-                                                            "properties": {
-                                                              "lessThan": {
-                                                                "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition/oneOf/3/properties/equal"
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          },
-                                                          {
-                                                            "description": "Is the left value greater than or equal to the right value?",
-                                                            "type": "object",
-                                                            "required": ["greaterThanOrEqual"],
-                                                            "properties": {
-                                                              "greaterThanOrEqual": {
-                                                                "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition/oneOf/3/properties/equal"
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          },
-                                                          {
-                                                            "description": "Is the left value less than or equal to the right value?",
-                                                            "type": "object",
-                                                            "required": ["lessThanOrEqual"],
-                                                            "properties": {
-                                                              "lessThanOrEqual": {
-                                                                "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition/oneOf/3/properties/equal"
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          },
-                                                          {
-                                                            "description": "Is the value null?",
-                                                            "type": "object",
-                                                            "required": ["isNull"],
-                                                            "properties": {
-                                                              "isNull": {
-                                                                "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/11/oneOf/0/properties/definition/properties/mapping/items/properties/source/allOf/0/oneOf/0/properties/value"
-                                                              }
-                                                            },
-                                                            "additionalProperties": false
-                                                          }
-                                                        ]
-                                                      }
-                                                    },
-                                                    "additionalProperties": false
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["presetArgument"],
-                                                "properties": {
-                                                  "presetArgument": {
-                                                    "$id": "https://hasura.io/jsonschemas/metadata/PresetArgument",
-                                                    "title": "PresetArgument",
-                                                    "description": "A preset value for an argument that applies when the condition evaluates to `true`",
-                                                    "type": "object",
-                                                    "required": ["argumentName", "value"],
-                                                    "properties": {
-                                                      "argumentName": {
-                                                        "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/9/oneOf/0/properties/definition/properties/arguments/items/properties/name"
-                                                      },
-                                                      "condition": {
-                                                        "anyOf": [
-                                                          {
-                                                            "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                          },
-                                                          {
-                                                            "type": "null"
-                                                          }
-                                                        ]
-                                                      },
-                                                      "value": {
-                                                        "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/14/oneOf/0/properties/definition/properties/permissions/items/properties/argumentPresets/items/properties/value/allOf/0"
-                                                      }
-                                                    },
-                                                    "additionalProperties": false
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["filter"],
-                                                "properties": {
-                                                  "filter": {
-                                                    "$id": "https://hasura.io/jsonschemas/metadata/Filter",
-                                                    "title": "Filter",
-                                                    "description": "A filter that applies when the condition evaluates to `true`",
-                                                    "type": "object",
-                                                    "required": ["predicate"],
-                                                    "properties": {
-                                                      "condition": {
-                                                        "anyOf": [
-                                                          {
-                                                            "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                          },
-                                                          {
-                                                            "type": "null"
-                                                          }
-                                                        ]
-                                                      },
-                                                      "predicate": {
-                                                        "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/0/properties/definition/properties/permissions/items/properties/select/anyOf/0/properties/filter/allOf/0/anyOf/1"
-                                                      }
-                                                    },
-                                                    "additionalProperties": false
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["allowRelationalOperations"],
-                                                "properties": {
-                                                  "allowRelationalOperations": {
-                                                    "$id": "https://hasura.io/jsonschemas/metadata/AllowRelationalOperations",
-                                                    "title": "AllowRelationalOperations",
-                                                    "description": "Allow these relational operations if the condition evaluates to `true`",
-                                                    "type": "object",
-                                                    "required": ["operations"],
-                                                    "properties": {
-                                                      "condition": {
-                                                        "anyOf": [
-                                                          {
-                                                            "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                          },
-                                                          {
-                                                            "type": "null"
-                                                          }
-                                                        ]
-                                                      },
-                                                      "operations": {
-                                                        "type": "array",
-                                                        "items": {
-                                                          "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/5/properties/denyRelationalOperations/properties/operations/items"
-                                                        }
-                                                      }
-                                                    },
-                                                    "additionalProperties": false
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["denyRelationalOperations"],
-                                                "properties": {
-                                                  "denyRelationalOperations": {
-                                                    "$id": "https://hasura.io/jsonschemas/metadata/DenyRelationalOperations",
-                                                    "title": "DenyRelationalOperations",
-                                                    "description": "Deny these relational operations if the condition evaluates to `true`",
-                                                    "type": "object",
-                                                    "required": ["condition", "operations"],
-                                                    "properties": {
-                                                      "condition": {
-                                                        "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny/properties/condition"
-                                                      },
-                                                      "operations": {
-                                                        "type": "array",
-                                                        "items": {
-                                                          "$id": "https://hasura.io/jsonschemas/metadata/RelationalOperation",
-                                                          "title": "RelationalOperation",
-                                                          "description": "An operation on a model",
-                                                          "type": "string",
-                                                          "enum": ["insert", "update", "delete"]
-                                                        }
-                                                      }
-                                                    },
-                                                    "additionalProperties": false
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              }
-                                            ]
                                           }
                                         }
                                       },
@@ -11327,78 +12199,38 @@
                           }
                         ]
                       }
-                    },
-                    {
-                      "kind": "CommandPermissions",
-                      "version": "v2",
-                      "definition": {
-                        "commandName": "get_actors_with_filter",
-                        "permissions": {
-                          "rulesBased": [
-                            {
-                              "allow": {
-                                "condition": {
-                                  "contains": {
-                                    "left": {
-                                      "sessionVariable": "x-hasura-role"
-                                    },
-                                    "right": {
-                                      "literal": ["filter_user"]
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "presetArgument": {
-                                "condition": {
-                                  "equal": {
-                                    "left": {
-                                      "sessionVariable": "x-hasura-role"
-                                    },
-                                    "right": {
-                                      "literal": "filter_user"
-                                    }
-                                  }
-                                },
-                                "argumentName": "actor_bool_exp",
-                                "value": {
-                                  "booleanExpression": {
-                                    "fieldComparison": {
-                                      "field": "actor_id",
-                                      "operator": "_eq",
-                                      "value": {
-                                        "literal": 4
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
                     }
                   ],
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["CommandPermissions"]
+                          "enum": [
+                            "CommandPermissions"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/CommandPermissionsV1",
                           "title": "CommandPermissionsV1",
                           "description": "Definition of permissions for an OpenDD command.",
                           "type": "object",
-                          "required": ["commandName", "permissions"],
+                          "required": [
+                            "commandName",
+                            "permissions"
+                          ],
                           "properties": {
                             "commandName": {
                               "description": "The name of the command for which permissions are being defined.",
@@ -11430,7 +12262,10 @@
                                   }
                                 ],
                                 "type": "object",
-                                "required": ["allowExecution", "role"],
+                                "required": [
+                                  "allowExecution",
+                                  "role"
+                                ],
                                 "properties": {
                                   "role": {
                                     "description": "The role for which permissions are being defined.",
@@ -11453,7 +12288,10 @@
                                       "title": "ArgumentPreset",
                                       "description": "Preset value for an argument",
                                       "type": "object",
-                                      "required": ["argument", "value"],
+                                      "required": [
+                                        "argument",
+                                        "value"
+                                      ],
                                       "properties": {
                                         "argument": {
                                           "description": "Argument name for preset",
@@ -11474,7 +12312,9 @@
                                                 {
                                                   "title": "Literal",
                                                   "type": "object",
-                                                  "required": ["literal"],
+                                                  "required": [
+                                                    "literal"
+                                                  ],
                                                   "properties": {
                                                     "literal": true
                                                   },
@@ -11483,7 +12323,9 @@
                                                 {
                                                   "title": "SessionVariable",
                                                   "type": "object",
-                                                  "required": ["sessionVariable"],
+                                                  "required": [
+                                                    "sessionVariable"
+                                                  ],
                                                   "properties": {
                                                     "sessionVariable": {
                                                       "$id": "https://hasura.io/jsonschemas/metadata/OpenDdSessionVariable",
@@ -11497,7 +12339,9 @@
                                                 {
                                                   "title": "BooleanExpression",
                                                   "type": "object",
-                                                  "required": ["booleanExpression"],
+                                                  "required": [
+                                                    "booleanExpression"
+                                                  ],
                                                   "properties": {
                                                     "booleanExpression": {
                                                       "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/0/properties/definition/properties/permissions/items/properties/select/anyOf/0/properties/filter/allOf/0/anyOf/1"
@@ -11508,7 +12352,9 @@
                                                 {
                                                   "title": "ValueFromEnv",
                                                   "type": "object",
-                                                  "required": ["valueFromEnv"],
+                                                  "required": [
+                                                    "valueFromEnv"
+                                                  ],
                                                   "properties": {
                                                     "valueFromEnv": {
                                                       "type": "string"
@@ -11536,22 +12382,33 @@
                     },
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["CommandPermissions"]
+                          "enum": [
+                            "CommandPermissions"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v2"]
+                          "enum": [
+                            "v2"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/CommandPermissionsV2",
                           "title": "CommandPermissionsV2",
                           "description": "Definition of permissions for an OpenDD command.",
                           "type": "object",
-                          "required": ["commandName", "permissions"],
+                          "required": [
+                            "commandName",
+                            "permissions"
+                          ],
                           "properties": {
                             "commandName": {
                               "description": "The name of the command for which permissions are being defined.",
@@ -11573,61 +12430,14 @@
                                       "title": "RoleBased",
                                       "description": "Definition of role-based permissions on an OpenDD command",
                                       "type": "object",
-                                      "required": ["roleBased"],
+                                      "required": [
+                                        "roleBased"
+                                      ],
                                       "properties": {
                                         "roleBased": {
                                           "type": "array",
                                           "items": {
                                             "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/14/oneOf/0/properties/definition/properties/permissions/items"
-                                          }
-                                        }
-                                      },
-                                      "additionalProperties": false
-                                    },
-                                    {
-                                      "title": "RulesBased",
-                                      "description": "Definition of a rules-based permissions on an OpenDD command",
-                                      "type": "object",
-                                      "required": ["rulesBased"],
-                                      "properties": {
-                                        "rulesBased": {
-                                          "type": "array",
-                                          "items": {
-                                            "$id": "https://hasura.io/jsonschemas/metadata/CommandAuthorizationRule",
-                                            "title": "CommandAuthorizationRule",
-                                            "description": "A rule that determines which commands and argument presets are available to a user",
-                                            "oneOf": [
-                                              {
-                                                "type": "object",
-                                                "required": ["allow"],
-                                                "properties": {
-                                                  "allow": {
-                                                    "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/0/properties/allow"
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["deny"],
-                                                "properties": {
-                                                  "deny": {
-                                                    "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny"
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["presetArgument"],
-                                                "properties": {
-                                                  "presetArgument": {
-                                                    "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/2/properties/presetArgument"
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              }
-                                            ]
                                           }
                                         }
                                       },
@@ -11681,15 +12491,23 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["LifecyclePluginHook"]
+                          "enum": [
+                            "LifecyclePluginHook"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/LifecyclePluginHookV1",
@@ -11700,11 +12518,18 @@
                               "title": "LifecyclePreParsePluginHook",
                               "description": "Definition of a lifecycle plugin hook for the pre-parse stage.",
                               "type": "object",
-                              "required": ["config", "name", "pre", "url"],
+                              "required": [
+                                "config",
+                                "name",
+                                "pre",
+                                "url"
+                              ],
                               "properties": {
                                 "pre": {
                                   "type": "string",
-                                  "enum": ["parse"]
+                                  "enum": [
+                                    "parse"
+                                  ]
                                 },
                                 "name": {
                                   "description": "The name of the lifecycle plugin hook.",
@@ -11720,7 +12545,9 @@
                                       "oneOf": [
                                         {
                                           "type": "object",
-                                          "required": ["value"],
+                                          "required": [
+                                            "value"
+                                          ],
                                           "properties": {
                                             "value": {
                                               "type": "string"
@@ -11730,7 +12557,9 @@
                                         },
                                         {
                                           "type": "object",
-                                          "required": ["valueFromEnv"],
+                                          "required": [
+                                            "valueFromEnv"
+                                          ],
                                           "properties": {
                                             "valueFromEnv": {
                                               "type": "string"
@@ -11750,7 +12579,9 @@
                                       "title": "LifecyclePreParsePluginHookConfig",
                                       "description": "Configuration for a lifecycle plugin hook.",
                                       "type": "object",
-                                      "required": ["request"],
+                                      "required": [
+                                        "request"
+                                      ],
                                       "properties": {
                                         "request": {
                                           "description": "Configuration for the request to the lifecycle plugin hook.",
@@ -11760,7 +12591,9 @@
                                               "title": "LifecyclePreParsePluginHookConfigRequest",
                                               "description": "Configuration for a lifecycle plugin hook request.",
                                               "type": "object",
-                                              "required": ["rawRequest"],
+                                              "required": [
+                                                "rawRequest"
+                                              ],
                                               "properties": {
                                                 "headers": {
                                                   "description": "Configuration for the headers.",
@@ -11866,11 +12699,18 @@
                               "title": "LifecyclePreResponsePluginHook",
                               "description": "Definition of a lifecycle plugin hook for the pre-response stage.",
                               "type": "object",
-                              "required": ["config", "name", "pre", "url"],
+                              "required": [
+                                "config",
+                                "name",
+                                "pre",
+                                "url"
+                              ],
                               "properties": {
                                 "pre": {
                                   "type": "string",
-                                  "enum": ["response"]
+                                  "enum": [
+                                    "response"
+                                  ]
                                 },
                                 "name": {
                                   "description": "The name of the lifecycle plugin hook.",
@@ -11892,7 +12732,9 @@
                                       "title": "LifecyclePreResponsePluginHookConfig",
                                       "description": "Configuration for a lifecycle plugin hook.",
                                       "type": "object",
-                                      "required": ["request"],
+                                      "required": [
+                                        "request"
+                                      ],
                                       "properties": {
                                         "request": {
                                           "description": "Configuration for the request to the lifecycle plugin hook.",
@@ -11902,7 +12744,9 @@
                                               "title": "LifecyclePreResponsePluginHookConfigRequest",
                                               "description": "Configuration for a lifecycle plugin hook request.",
                                               "type": "object",
-                                              "required": ["rawRequest"],
+                                              "required": [
+                                                "rawRequest"
+                                              ],
                                               "properties": {
                                                 "headers": {
                                                   "description": "Configuration for the headers.",
@@ -11963,11 +12807,15 @@
                                                   "title": "LifecyclePreResponsePluginHookSynchronousModeConfig",
                                                   "description": "Synchronous mode. The engine will wait for the plugin hook to respond before continuing.",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["synchronous"]
+                                                      "enum": [
+                                                        "synchronous"
+                                                      ]
                                                     },
                                                     "onPluginFailure": {
                                                       "description": "Configuration for the on-plugin-failure behavior of the plugin hook (default: fail).",
@@ -11981,12 +12829,16 @@
                                                             {
                                                               "description": "Fail the request if the plugin hook fails.",
                                                               "type": "string",
-                                                              "enum": ["fail"]
+                                                              "enum": [
+                                                                "fail"
+                                                              ]
                                                             },
                                                             {
                                                               "description": "Continue with the request if the plugin hook fails.",
                                                               "type": "string",
-                                                              "enum": ["continue"]
+                                                              "enum": [
+                                                                "continue"
+                                                              ]
                                                             }
                                                           ]
                                                         }
@@ -11999,11 +12851,15 @@
                                                   "title": "LifecyclePreResponsePluginHookAsynchronousModeConfig",
                                                   "description": "Asynchronous mode. The engine will not wait for the plugin hook to respond before continuing.",
                                                   "type": "object",
-                                                  "required": ["type"],
+                                                  "required": [
+                                                    "type"
+                                                  ],
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": ["asynchronous"]
+                                                      "enum": [
+                                                        "asynchronous"
+                                                      ]
                                                     }
                                                   },
                                                   "additionalProperties": false
@@ -12027,11 +12883,18 @@
                               "title": "LifecyclePreRoutePluginHook",
                               "description": "Definition of a lifecycle plugin hook for the pre-route stage.",
                               "type": "object",
-                              "required": ["config", "name", "pre", "url"],
+                              "required": [
+                                "config",
+                                "name",
+                                "pre",
+                                "url"
+                              ],
                               "properties": {
                                 "pre": {
                                   "type": "string",
-                                  "enum": ["route"]
+                                  "enum": [
+                                    "route"
+                                  ]
                                 },
                                 "name": {
                                   "description": "The name of the lifecycle plugin hook.",
@@ -12053,7 +12916,11 @@
                                       "title": "LifecyclePreRoutePluginHookConfig",
                                       "description": "Configuration for a lifecycle plugin hook.",
                                       "type": "object",
-                                      "required": ["matchMethods", "matchPath", "request"],
+                                      "required": [
+                                        "matchMethods",
+                                        "matchPath",
+                                        "request"
+                                      ],
                                       "properties": {
                                         "matchPath": {
                                           "description": "Regex to match the request path",
@@ -12067,7 +12934,13 @@
                                             "title": "RequestMethod",
                                             "description": "Possible HTTP Request Methods for the incoming requests handled by the pre-route plugin hook.",
                                             "type": "string",
-                                            "enum": ["GET", "POST", "PUT", "DELETE", "PATCH"]
+                                            "enum": [
+                                              "GET",
+                                              "POST",
+                                              "PUT",
+                                              "DELETE",
+                                              "PATCH"
+                                            ]
                                           }
                                         },
                                         "request": {
@@ -12078,7 +12951,10 @@
                                               "title": "LifecyclePreRoutePluginHookConfigRequest",
                                               "description": "Configuration for a lifecycle plugin hook request.",
                                               "type": "object",
-                                              "required": ["method", "rawRequest"],
+                                              "required": [
+                                                "method",
+                                                "rawRequest"
+                                              ],
                                               "properties": {
                                                 "headers": {
                                                   "description": "Configuration for the headers in the pre-route plugin hook HTTP requests.",
@@ -12099,7 +12975,10 @@
                                                       "title": "LifecyclePreRoutePluginHookConfigRequestMethods",
                                                       "description": "Configuration for the method for the pre-route plugin hook HTTP requests.",
                                                       "type": "string",
-                                                      "enum": ["GET", "POST"]
+                                                      "enum": [
+                                                        "GET",
+                                                        "POST"
+                                                      ]
                                                     }
                                                   ]
                                                 },
@@ -12202,11 +13081,19 @@
                               "title": "LifecyclePreNdcRequestPluginHook",
                               "description": "Definition of a lifecycle plugin hook for the pre-ndc-request stage.",
                               "type": "object",
-                              "required": ["config", "connectors", "name", "pre", "url"],
+                              "required": [
+                                "config",
+                                "connectors",
+                                "name",
+                                "pre",
+                                "url"
+                              ],
                               "properties": {
                                 "pre": {
                                   "type": "string",
-                                  "enum": ["ndcRequest"]
+                                  "enum": [
+                                    "ndcRequest"
+                                  ]
                                 },
                                 "name": {
                                   "description": "The name of the lifecycle plugin hook.",
@@ -12235,7 +13122,9 @@
                                       "title": "LifecyclePreNdcRequestPluginHookConfig",
                                       "description": "config for pre-ndc-request hook Configuration for a lifecycle plugin hook.",
                                       "type": "object",
-                                      "required": ["request"],
+                                      "required": [
+                                        "request"
+                                      ],
                                       "properties": {
                                         "request": {
                                           "description": "Configuration for the request to the lifecycle plugin hook.",
@@ -12281,7 +13170,10 @@
                                                 },
                                                 "forwardHeaders": {
                                                   "description": "Headers to be forwarded from the incoming request.",
-                                                  "type": ["array", "null"],
+                                                  "type": [
+                                                    "array",
+                                                    "null"
+                                                  ],
                                                   "items": {
                                                     "type": "string"
                                                   }
@@ -12303,11 +13195,19 @@
                               "title": "LifecyclePreNdcResponsePluginHook",
                               "description": "Definition of a lifecycle plugin hook for the pre-ndc-response stage.",
                               "type": "object",
-                              "required": ["config", "connectors", "name", "pre", "url"],
+                              "required": [
+                                "config",
+                                "connectors",
+                                "name",
+                                "pre",
+                                "url"
+                              ],
                               "properties": {
                                 "pre": {
                                   "type": "string",
-                                  "enum": ["ndcResponse"]
+                                  "enum": [
+                                    "ndcResponse"
+                                  ]
                                 },
                                 "name": {
                                   "description": "The name of the lifecycle plugin hook.",
@@ -12336,7 +13236,9 @@
                                       "title": "LifecyclePreNdcResponsePluginHookConfig",
                                       "description": "Configuration for a lifecycle plugin hook.",
                                       "type": "object",
-                                      "required": ["request"],
+                                      "required": [
+                                        "request"
+                                      ],
                                       "properties": {
                                         "request": {
                                           "description": "Configuration for the request to the lifecycle plugin hook.",
@@ -12429,22 +13331,33 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["View"]
+                          "enum": [
+                            "View"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/ViewV1",
                           "title": "ViewV1",
                           "description": "Definition of a SQL view that can be created in the data layer",
                           "type": "object",
-                          "required": ["name", "sqlExpression"],
+                          "required": [
+                            "name",
+                            "sqlExpression"
+                          ],
                           "properties": {
                             "name": {
                               "description": "The name of the view",
@@ -12464,7 +13377,10 @@
                             },
                             "description": {
                               "description": "Optional description",
-                              "type": ["string", "null"]
+                              "type": [
+                                "string",
+                                "null"
+                              ]
                             }
                           },
                           "additionalProperties": false
@@ -12481,22 +13397,33 @@
                   "oneOf": [
                     {
                       "type": "object",
-                      "required": ["definition", "kind", "version"],
+                      "required": [
+                        "definition",
+                        "kind",
+                        "version"
+                      ],
                       "properties": {
                         "kind": {
                           "type": "string",
-                          "enum": ["ViewPermissions"]
+                          "enum": [
+                            "ViewPermissions"
+                          ]
                         },
                         "version": {
                           "type": "string",
-                          "enum": ["v1"]
+                          "enum": [
+                            "v1"
+                          ]
                         },
                         "definition": {
                           "$id": "https://hasura.io/jsonschemas/metadata/ViewPermissionsV1",
                           "title": "ViewPermissionsV1",
                           "description": "Definition of permissions for an OpenDD view.",
                           "type": "object",
-                          "required": ["permissions", "viewName"],
+                          "required": [
+                            "permissions",
+                            "viewName"
+                          ],
                           "properties": {
                             "viewName": {
                               "description": "The name of the view for which permissions are being defined.",
@@ -12518,7 +13445,9 @@
                                       "title": "RoleBased",
                                       "description": "Definition of role-based view permissions on an OpenDD view",
                                       "type": "object",
-                                      "required": ["roleBased"],
+                                      "required": [
+                                        "roleBased"
+                                      ],
                                       "properties": {
                                         "roleBased": {
                                           "type": "array",
@@ -12527,7 +13456,10 @@
                                             "title": "ViewPermission",
                                             "description": "Defines the permissions for a view for a role.",
                                             "type": "object",
-                                            "required": ["allow", "role"],
+                                            "required": [
+                                              "allow",
+                                              "role"
+                                            ],
                                             "properties": {
                                               "role": {
                                                 "description": "The role for which permissions are being defined.",
@@ -12543,45 +13475,6 @@
                                               }
                                             },
                                             "additionalProperties": false
-                                          }
-                                        }
-                                      },
-                                      "additionalProperties": false
-                                    },
-                                    {
-                                      "title": "RulesBased",
-                                      "description": "Definition of rules-based view permissions on an OpenDD view",
-                                      "type": "object",
-                                      "required": ["rulesBased"],
-                                      "properties": {
-                                        "rulesBased": {
-                                          "type": "array",
-                                          "items": {
-                                            "$id": "https://hasura.io/jsonschemas/metadata/ViewAuthorizationRule",
-                                            "title": "ViewAuthorizationRule",
-                                            "description": "A rule that determines whether a view is accessible to a user",
-                                            "oneOf": [
-                                              {
-                                                "type": "object",
-                                                "required": ["allow"],
-                                                "properties": {
-                                                  "allow": {
-                                                    "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/0/properties/allow"
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              },
-                                              {
-                                                "type": "object",
-                                                "required": ["deny"],
-                                                "properties": {
-                                                  "deny": {
-                                                    "$ref": "#/definitions/SubgraphObject/anyOf/0/anyOf/1/oneOf/13/oneOf/1/properties/definition/properties/permissions/allOf/0/oneOf/1/properties/rulesBased/items/oneOf/1/properties/deny"
-                                                  }
-                                                },
-                                                "additionalProperties": false
-                                              }
-                                            ]
                                           }
                                         }
                                       },

--- a/utilities/generate-metadata-docs/package.json
+++ b/utilities/generate-metadata-docs/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc --outDir dist",
-    "start": "npx ts-node src/index.ts",
+    "filter-schema": "node filter-rules-based.js",
+    "start": "npm run filter-schema && npx ts-node src/index.ts",
     "watch": "tsc -w & nodemon --ignore auto-generated.json --no-deprecation dist/index.js",
     "test": "jest --watchAll --verbose --silent",
     "format": "npx prettier . --write"

--- a/utilities/one-click-llm/package-lock.json
+++ b/utilities/one-click-llm/package-lock.json
@@ -68,6 +68,7 @@
       "integrity": "sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1669,6 +1670,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -2611,6 +2613,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4271,6 +4274,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Description 📝

Bifurcates the metadata sync bewteen LSP and DDN Docs/PromptQL Docs.

Going forward, the DDN Docs will not receive updates from LSP to ensure what's documented in this repository reflects DDN's capabilities specifically. Additionally, a small script is added that removes rules-based permissions documentation from DDN; this can be extended if anything else is lingering.