### PR TITLE
Exclude V2 permissions (PromptQL-only)

### DIFF
--- a/docs/reference/metadata-reference/permissions.mdx
+++ b/docs/reference/metadata-reference/permissions.mdx
@@ -221,7 +221,6 @@ Definition of permissions for an OpenDD type.
 | Value | Description |
 |-----|-----|
 | [TypePermissions (v1)](#typepermissions-typepermissions-(v1)) |  |
-| [TypePermissions (v2)](#typepermissions-typepermissions-(v2)) |  |
 
  **Examples:**
 
@@ -304,16 +303,6 @@ definition:
           fields:
             - rating
 ```
-
-
-#### TypePermissions (v2) {#typepermissions-typepermissions-(v2)}
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `TypePermissions` | true |  |
-| `version` | `v2` | true |  |
-| `definition` | [TypePermissionsV1](#typepermissions-typepermissionsv1) | true | Definition of permissions for an OpenDD type. |
-
 
 
 #### TypePermissions (v1) {#typepermissions-typepermissions-(v1)}
@@ -449,7 +438,6 @@ Definition of permissions for an OpenDD model.
 | Value | Description |
 |-----|-----|
 | [ModelPermissions (v1)](#modelpermissions-modelpermissions-(v1)) |  |
-| [ModelPermissions (v2)](#modelpermissions-modelpermissions-(v2)) |  |
 
  **Examples:**
 
@@ -561,165 +549,6 @@ definition:
                   value:
                     literal: UK
 ```
-
-
-#### ModelPermissions (v2) {#modelpermissions-modelpermissions-(v2)}
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `ModelPermissions` | true |  |
-| `version` | `v2` | true |  |
-| `definition` | [ModelPermissionsV2](#modelpermissions-modelpermissionsv2) | true | Definition of permissions for an OpenDD model. |
-
-
-
-#### ModelPermissionsV2 {#modelpermissions-modelpermissionsv2}
-
-Definition of permissions for an OpenDD model.
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `modelName` | [ModelName](#modelpermissions-modelname) | true | The name of the model for which permissions are being defined. |
-| `permissions` | [ModelPermissionOperand](#modelpermissions-modelpermissionoperand) | true | Permissions for this model |
-
-
-
-#### ModelPermissionOperand {#modelpermissions-modelpermissionoperand}
-
-Configuration for role-based model permissions
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `roleBased` | [[ModelPermission](#modelpermissions-modelpermission)] | false |  |
-| `rulesBased` | [[ModelAuthorizationRule](#modelpermissions-modelauthorizationrule)] | false |  |
-
-
-
-#### ModelAuthorizationRule {#modelpermissions-modelauthorizationrule}
-
-A rule that determines which model and argument presets are available to a user
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `allow` | [Allow](#modelpermissions-allow) | false | Allow access if the condition evaluates to `true` |
-| `deny` | [Deny](#modelpermissions-deny) | false | Deny access if the condition evaluates to `true` |
-| `presetArgument` | [PresetArgument](#modelpermissions-presetargument) | false | A preset value for an argument that applies when the condition evaluates to `true` |
-| `filter` | [Filter](#modelpermissions-filter) | false | A filter that applies when the condition evaluates to `true` |
-| `allowRelationalOperations` | [AllowRelationalOperations](#modelpermissions-allowrelationaloperations) | false | Allow these relational operations if the condition evaluates to `true` |
-| `denyRelationalOperations` | [DenyRelationalOperations](#modelpermissions-denyrelationaloperations) | false | Deny these relational operations if the condition evaluates to `true` |
-
-
-
-#### DenyRelationalOperations {#modelpermissions-denyrelationaloperations}
-
-Deny these relational operations if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) | true |  |
-| `operations` | [[RelationalOperation](#modelpermissions-relationaloperation)] | true |  |
-
-
-
-#### AllowRelationalOperations {#modelpermissions-allowrelationaloperations}
-
-Allow these relational operations if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) / null | false |  |
-| `operations` | [[RelationalOperation](#modelpermissions-relationaloperation)] | true |  |
-
-
-
-#### RelationalOperation {#modelpermissions-relationaloperation}
-
-An operation on a model
-
-
-**Value:** `insert` / `update` / `delete`
-
-
-#### Filter {#modelpermissions-filter}
-
-A filter that applies when the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) / null | false |  |
-| `predicate` | [ModelPredicate](#modelpermissions-modelpredicate) | true |  |
-
-
-
-#### PresetArgument {#modelpermissions-presetargument}
-
-A preset value for an argument that applies when the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argumentName` | [ArgumentName](#modelpermissions-argumentname) | true |  |
-| `condition` | [Condition](#modelpermissions-condition) / null | false |  |
-| `value` | [ValueExpressionOrPredicate](#modelpermissions-valueexpressionorpredicate) | true |  |
-
-
-
-#### Deny {#modelpermissions-deny}
-
-Deny access if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) | true | A boolean expression used to determine if a rules-based permission should be applied. |
-
-
-
-#### Allow {#modelpermissions-allow}
-
-Allow access if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#modelpermissions-condition) / null | false |  |
-
-
-
-#### Condition {#modelpermissions-condition}
-
-A boolean expression used to determine if a rules-based permission should be applied.
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `and` | [[Condition](#modelpermissions-condition)] | false |  |
-| `or` | [[Condition](#modelpermissions-condition)] | false |  |
-| `not` | [Condition](#modelpermissions-condition) | false |  |
-| `equal` | [Comparison](#modelpermissions-comparison) | false | A left and right value for comparison |
-| `contains` | [Comparison](#modelpermissions-comparison) | false |  |
-| `greaterThan` | [Comparison](#modelpermissions-comparison) | false |  |
-| `lessThan` | [Comparison](#modelpermissions-comparison) | false |  |
-| `greaterThanOrEqual` | [Comparison](#modelpermissions-comparison) | false |  |
-| `lessThanOrEqual` | [Comparison](#modelpermissions-comparison) | false |  |
-| `isNull` | [ValueExpression](#modelpermissions-valueexpression) | false |  |
-
-
-
-#### Comparison {#modelpermissions-comparison}
-
-A left and right value for comparison
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `left` | [ValueExpression](#modelpermissions-valueexpression) | true |  |
-| `right` | [ValueExpression](#modelpermissions-valueexpression) | true |  |
-
 
 
 #### ModelPermissions (v1) {#modelpermissions-modelpermissions-(v1)}
@@ -1030,7 +859,6 @@ Definition of permissions for an OpenDD command.
 | Value | Description |
 |-----|-----|
 | [CommandPermissions (v1)](#commandpermissions-commandpermissions-(v1)) |  |
-| [CommandPermissions (v2)](#commandpermissions-commandpermissions-(v2)) |  |
 
  **Examples:**
 
@@ -1079,121 +907,6 @@ definition:
                 value:
                   literal: 4
 ```
-
-
-#### CommandPermissions (v2) {#commandpermissions-commandpermissions-(v2)}
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `kind` | `CommandPermissions` | true |  |
-| `version` | `v2` | true |  |
-| `definition` | [CommandPermissionsV2](#commandpermissions-commandpermissionsv2) | true | Definition of permissions for an OpenDD command. |
-
-
-
-#### CommandPermissionsV2 {#commandpermissions-commandpermissionsv2}
-
-Definition of permissions for an OpenDD command.
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `commandName` | [CommandName](#commandpermissions-commandname) | true | The name of the command for which permissions are being defined. |
-| `permissions` | [CommandPermissionOperand](#commandpermissions-commandpermissionoperand) | true | The permissions for the command. |
-
-
-
-#### CommandPermissionOperand {#commandpermissions-commandpermissionoperand}
-
-Configuration for role-based command permissions
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `roleBased` | [[CommandPermission](#commandpermissions-commandpermission)] | false |  |
-| `rulesBased` | [[CommandAuthorizationRule](#commandpermissions-commandauthorizationrule)] | false |  |
-
-
-
-#### CommandAuthorizationRule {#commandpermissions-commandauthorizationrule}
-
-A rule that determines which commands and argument presets are available to a user
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `allow` | [Allow](#commandpermissions-allow) | false |  |
-| `deny` | [Deny](#commandpermissions-deny) | false |  |
-| `presetArgument` | [PresetArgument](#commandpermissions-presetargument) | false |  |
-
-
-
-#### PresetArgument {#commandpermissions-presetargument}
-
-A preset value for an argument that applies when the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `argumentName` | [ArgumentName](#commandpermissions-argumentname) | true |  |
-| `condition` | [Condition](#commandpermissions-condition) / null | false |  |
-| `value` | [ValueExpressionOrPredicate](#commandpermissions-valueexpressionorpredicate) | true |  |
-
-
-
-#### Deny {#commandpermissions-deny}
-
-Deny access if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#commandpermissions-condition) | true | A boolean expression used to determine if a rules-based permission should be applied. |
-
-
-
-#### Allow {#commandpermissions-allow}
-
-Allow access if the condition evaluates to `true`
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `condition` | [Condition](#commandpermissions-condition) / null | false |  |
-
-
-
-#### Condition {#commandpermissions-condition}
-
-A boolean expression used to determine if a rules-based permission should be applied.
-
-
-**Must have exactly one of the following fields:**
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `and` | [[Condition](#commandpermissions-condition)] | false |  |
-| `or` | [[Condition](#commandpermissions-condition)] | false |  |
-| `not` | [Condition](#commandpermissions-condition) | false |  |
-| `equal` | [Comparison](#commandpermissions-comparison) | false | A left and right value for comparison |
-| `contains` | [Comparison](#commandpermissions-comparison) | false |  |
-| `greaterThan` | [Comparison](#commandpermissions-comparison) | false |  |
-| `lessThan` | [Comparison](#commandpermissions-comparison) | false |  |
-| `greaterThanOrEqual` | [Comparison](#commandpermissions-comparison) | false |  |
-| `lessThanOrEqual` | [Comparison](#commandpermissions-comparison) | false |  |
-| `isNull` | [ValueExpression](#commandpermissions-valueexpression) | false |  |
-
-
-
-#### Comparison {#commandpermissions-comparison}
-
-A left and right value for comparison
-
-| Key | Value | Required | Description |
-|-----|-----|-----|-----|
-| `left` | [ValueExpression](#commandpermissions-valueexpression) | true |  |
-| `right` | [ValueExpression](#commandpermissions-valueexpression) | true |  |
-
 
 
 #### CommandPermissions (v1) {#commandpermissions-commandpermissions-(v1)}

--- a/utilities/generate-metadata-docs/src/logic/walker.ts
+++ b/utilities/generate-metadata-docs/src/logic/walker.ts
@@ -225,7 +225,10 @@ export function getSchemaMarkdown(metadataObject: JSONSchema7Definition): string
     markdownValue += `| Value | Description |\n|-----|-----|\n`;
     (metadataObject.allOf || metadataObject.anyOf || metadataObject.oneOf).forEach(option => {
       const valueType = handleSchemaDefinition(option);
-      markdownValue += `| ${valueType} | ${getDescription(option)} |\n`;
+      // Skip empty rows for excluded entities
+      if (valueType) {
+        markdownValue += `| ${valueType} | ${getDescription(option)} |\n`;
+      }
     });
 
     const markdown = generateSchemaObjectMarkdown(metadataObject, markdownValue, rootTitle);

--- a/utilities/generate-metadata-docs/src/logic/walker.ts
+++ b/utilities/generate-metadata-docs/src/logic/walker.ts
@@ -17,6 +17,32 @@ import {
 } from './helpers';
 import { externalMetadataRefs, topLevelMetadataRefs } from '../entities/objects';
 
+/**
+ * Entities to exclude from documentation generation.
+ * These entities and their child types will be hidden from the docs.
+ *
+ * Note: The actual schema uses versioned entities like "TypePermissions (v2)"
+ * based on the kind and version properties in the schema.
+ */
+const EXCLUDED_ENTITIES = [
+  'TypePermissionsV2',
+  'TypePermissions (v2)',
+  'ModelPermissionsV2',
+  'ModelPermissions (v2)',
+  'CommandPermissionsV2',
+  'CommandPermissions (v2)'
+];
+
+/**
+ * Check if a title should be excluded from documentation.
+ */
+function shouldExcludeEntity(title: string | undefined): boolean {
+  if (!title) return false;
+
+  // Check if the title matches any excluded entity exactly
+  return EXCLUDED_ENTITIES.includes(title);
+}
+
 export function getSchemaMarkdown(metadataObject: JSONSchema7Definition): string {
   const markdownArray = [];
   const visitedRefs = {
@@ -24,8 +50,16 @@ export function getSchemaMarkdown(metadataObject: JSONSchema7Definition): string
     ...externalMetadataRefs,
   };
 
+  // Track excluded entities to skip their child types
+  const excludedRefs = new Set<string>();
+
   // needed to generate uniq anchor tags
   const rootTitle = getTitle(metadataObject);
+
+  // Check if the root entity should be excluded
+  if (shouldExcludeEntity(rootTitle)) {
+    return ''; // Return empty string for excluded entities
+  }
 
   // generate Schema markdownArray and return reference of Schema
   function handleSchemaDefinition(metadataObject: JSONSchema7Definition, isSource: boolean = false): string {
@@ -42,6 +76,17 @@ export function getSchemaMarkdown(metadataObject: JSONSchema7Definition): string
     let typeDefinition = ``;
 
     const refTitle = getTitle(metadataObject);
+
+    // Skip excluded entities and their children
+    if (shouldExcludeEntity(refTitle)) {
+      excludedRefs.add(refTitle);
+      return ''; // Return empty string for excluded entities
+    }
+
+    // Skip if this is a child of an excluded entity
+    if (refTitle && excludedRefs.has(refTitle)) {
+      return '';
+    }
 
     if (refTitle && Object.keys(visitedRefs).includes(refTitle) && !isSource) {
       return visitedRefs[refTitle];


### PR DESCRIPTION
## Description 📝

`ModelPermissionsV2`, `CommandPermissionsV2` and `TypePermissionsV2` don't work in DDN GraphQL, so let's filter them out of the docs to remove confusion.

## Quick Links 🚀

 <!-- Links to the relevant place(s) in the CloudFlare Pages build. Wait for CF comment for link. -->

## Assertion Tests 🤖

<!-- Add assertions between the comments below to have ChatGPT check the quality of your docs contribution (Diff) and 
how well it integrates with existing docs. E.g., A user should be able to easily understand how to make a simple 
query. -->

<!-- For more info, see the Action's docs in the marketplace: https://github.com/marketplace/actions/docs-assertion-tester#usage -->

<!-- DX:Assertion-start -->
<!-- DX:Assertion-end -->