### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/calibre-image-compression.yml
+++ b/.github/workflows/calibre-image-compression.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Compress images
         uses: calibreapp/image-actions@6ae3e76c0d85ea2ade996fa739c566668068cf42

--- a/.github/workflows/check-for-redirects.yml
+++ b/.github/workflows/check-for-redirects.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Delete comment if no redirects needed
         if: steps.check-renamed.outputs.diff-status == 'false'
-        uses: hasura/comment-progress@v2.3.0
+        uses: hasura/comment-progress@d8d9320638e445492ea219e1079074c1c0c66f34 # v2.3.0
         with:
           github-token: ${{secrets.DOCS_GITHUB_TOKEN}}
           repository: 'hasura/ddn-docs'
@@ -67,7 +67,7 @@ jobs:
 
       - name: Add comment
         if: steps.check-renamed.outputs.diff-status == 'true'
-        uses: hasura/comment-progress@v2.3.0
+        uses: hasura/comment-progress@d8d9320638e445492ea219e1079074c1c0c66f34 # v2.3.0
         with:
           github-token: ${{secrets.DOCS_GITHUB_TOKEN}}
           repository: 'hasura/ddn-docs'

--- a/.github/workflows/connector-dri-pr-reviewer.yml
+++ b/.github/workflows/connector-dri-pr-reviewer.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get changed MDX files
         id: changed_mdx_files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44
         with:
           files: docs/**/*.mdx
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Assign DRI based on connector IDs in frontmatter
         if: steps.changed_mdx_files.outputs.all_modified_files != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{secrets.DOCS_GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/create-docs-pdf.yml
+++ b/.github/workflows/create-docs-pdf.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '18'
 
@@ -20,7 +20,7 @@ jobs:
         run: npx docusaurus-to-pdf
 
       - name: Upload PDF as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: pdf-output
           path: ./pdf_output/reference-docs.pdf

--- a/.github/workflows/create-docs-ticket.yml
+++ b/.github/workflows/create-docs-ticket.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '20'
 

--- a/.github/workflows/dx-assertion-test.yml
+++ b/.github/workflows/dx-assertion-test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Docs Assertion Tester
         id: docs_test
-        uses: hasura/docs-assertion-tester@v1.0.2
+        uses: hasura/docs-assertion-tester@5da2eab6ff03e22f1829e6020872af56ea4ebcc3 # v1.0.2
         with:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.DOCS_GITHUB_TOKEN }}
@@ -19,7 +19,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.number }}
       - name: Add comment
-        uses: hasura/comment-progress@v2.3.0
+        uses: hasura/comment-progress@d8d9320638e445492ea219e1079074c1c0c66f34 # v2.3.0
         with:
           github-token: ${{secrets.DOCS_GITHUB_TOKEN}}
           repository: ${{ github.repository }}

--- a/.github/workflows/merge-main-into-pr-and-test.yml
+++ b/.github/workflows/merge-main-into-pr-and-test.yml
@@ -17,10 +17,10 @@ jobs:
         run: echo "::set-output name=branch::${{ github.event.pull_request.head.ref }}"
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set up Node.js and Yarn
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '20'
 

--- a/.github/workflows/merge-main-to-staging.yml
+++ b/.github/workflows/merge-main-to-staging.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/merge-staging-to-prod.yml
+++ b/.github/workflows/merge-staging-to-prod.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/open-redirects-pr.yml
+++ b/.github/workflows/open-redirects-pr.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Checkout the hasura.io repository
         if: steps.grab-renamed.outputs.diff-status == 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: hasura/hasura.io
           path: hasura.io
@@ -82,7 +82,7 @@ jobs:
 
       - name: create pull request
         if: steps.grab-renamed.outputs.diff-status == 'true'
-        uses: peter-evans/create-pull-request@v5.0.2
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           path: hasura.io
           token: ${{ secrets.DOCS_GITHUB_TOKEN }}

--- a/.github/workflows/trigger-prod-algolia-crawl.yml
+++ b/.github/workflows/trigger-prod-algolia-crawl.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Trigger Algolia Crawler Crawl
         env:


### PR DESCRIPTION
## Summary
- Pin all public GitHub Action references to their immutable commit SHAs
- Original version tags preserved as inline comments for maintainability
- Prevents supply chain attacks via mutable tag references

## Test plan
- [ ] Verify CI workflows still trigger and run correctly
- [ ] Spot-check a few pinned SHAs match their expected tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)