### PR TITLE
docs: Add sessionVariableToTraceAttributeMap documentation for AuthConfig V4

### DIFF
--- a/docs/auth/jwt/jwt-configuration.mdx
+++ b/docs/auth/jwt/jwt-configuration.mdx
@@ -764,3 +764,29 @@ Hasura with Clerk.
 
 By default, Keycloak uses the `RSA-OAEP` algorithm, which the Hasura DDN engine doesn't support. Remove the algorithm in
 the `Realm Settings -> Keys -> Add Providers` tab.
+
+## Propagating claims to traces
+
+You can forward selected session variables (derived from JWT claims) into OpenTelemetry trace attributes using the
+`sessionVariableToTraceAttributeMap` field in your `AuthConfigV4`.
+
+This is useful for correlating traces by tenant, user, or organization in multi-tenant setups.
+
+```yaml
+kind: AuthConfig
+version: v4
+definition:
+  mode:
+    jwt:
+      # ... your JWT config ...
+  sessionVariableToTraceAttributeMap:
+    - sessionVariable: x-hasura-tenant-id
+      traceAttribute: tenant-id
+    - sessionVariable: x-hasura-org-id
+      traceAttribute: org-id
+```
+
+The mapped values will appear as attributes on every span and be propagated via the `baggage` HTTP header to all
+downstream services (NDC connectors, webhooks, plugins).
+
+For more details, see the [AuthConfig reference](/reference/metadata-reference/auth-config).

--- a/docs/auth/webhook/webhook-mode.mdx
+++ b/docs/auth/webhook/webhook-mode.mdx
@@ -212,6 +212,17 @@ Content-Type: application/json
 }
 ```
 
+:::info Session Variables as Trace Attributes
+
+When `sessionVariableToTraceAttributeMap` is configured on `AuthConfigV4`, session variable values returned by the
+webhook are also mapped to OpenTelemetry trace attributes and propagated as baggage to downstream services.
+
+If your webhook response includes explicit baggage values, these take precedence over values derived from the same
+session variable via `sessionVariableToTraceAttributeMap`.
+
+For more details, see the [AuthConfig reference](/reference/metadata-reference/auth-config).
+:::
+
 ## Step 3. Define permissions
 
 Let's add some example `TypePermissions` so that an admin role can access all fields in the Orders type, but we restrict

--- a/docs/reference/metadata-reference/auth-config.mdx
+++ b/docs/reference/metadata-reference/auth-config.mdx
@@ -83,6 +83,10 @@ definition:
           algorithm: HS256
           key:
             valueFromEnv: AUTH_SECRET
+  # Optional: propagate session vars as trace attributes
+  sessionVariableToTraceAttributeMap:
+    - sessionVariable: x-hasura-tenant-id
+      traceAttribute: tenant-id
 ```
 
 | **Field**       | **Description**                                                                                                                                                                                                                                                                     | **Reference**                                    |
@@ -158,6 +162,7 @@ Definition of the authentication configuration v4, used by the API server.
 |-----|-----|-----|-----|
 | `mode` | [AuthModeConfigV3](#authconfig-authmodeconfigv3) | true |  |
 | `alternativeModes` | [[AlternativeMode](#authconfig-alternativemode)] / null | false |  |
+| `sessionVariableToTraceAttributeMap` | [[SessionVariableToTraceAttributeMapping](#authconfig-sessionvariabletotraceattributemapping)] / null | false | Maps session variable values from the authenticated identity to OpenTelemetry trace attributes. Propagated as baggage to all downstream services. Works with all auth modes. |
 
 
 
@@ -169,6 +174,17 @@ Alternative Authentication Modes
 |-----|-----|-----|-----|
 | `identifier` | string | true |  |
 | `config` | [AuthModeConfigV3](#authconfig-authmodeconfigv3) | true |  |
+
+
+
+#### SessionVariableToTraceAttributeMapping {#authconfig-sessionvariabletotraceattributemapping}
+
+Mapping of a session variable to an OpenTelemetry trace attribute.
+
+| Key | Value | Required | Description |
+|-----|-----|-----|-----|
+| `sessionVariable` | string | true | The session variable name (e.g. `x-hasura-tenant-id`). |
+| `traceAttribute` | string | true | The trace attribute key under which the value will appear on spans and be propagated downstream (e.g. `tenant-id`). |
 
 
 

--- a/docs/reference/metadata-reference/auth-config.mdx
+++ b/docs/reference/metadata-reference/auth-config.mdx
@@ -115,6 +115,9 @@ definition:
         headers:
           additional:
             user-agent: "Hasura DDN"
+  sessionVariableToTraceAttributeMap:
+    - sessionVariable: x-hasura-tenant-id
+      traceAttribute: tenant-id
 ```
 
 | **Field**             | **Description**                                                                                                                                                           | **Reference**                                                          |


### PR DESCRIPTION
Documents the new `sessionVariableToTraceAttributeMap` field added in hasura/v3-engine#2465

This feature allows mapping session variable values to OpenTelemetry trace attributes.

## Changes
- `docs/reference/metadata-reference/auth-config.mdx`: Added new field and type definition
- `docs/auth/jwt/jwt-configuration.mdx`: Added "Propagating claims to traces" section
- `docs/auth/webhook/webhook-mode.mdx`: Added info about webhook baggage precedence