### PR TITLE
fix(security): prevent Pwn Request vulnerability in DRI reviewer workflow

### DIFF
--- a/.github/workflows/connector-dri-pr-reviewer.yml
+++ b/.github/workflows/connector-dri-pr-reviewer.yml
@@ -25,6 +25,12 @@ on:
 jobs:
   connector-docs-dri-reviewer:
     runs-on: ubuntu-latest
+    # SECURITY: Only run for PRs from the same repository to prevent Pwn Request attacks.
+    # This workflow uses `pull_request_target` (runs with base repo secrets) and checks out
+    # the PR HEAD from the fork. Without this guard, an attacker could open a PR from a fork
+    # with malicious code (e.g. a postinstall script in package.json) that would execute with
+    # access to DOCS_GITHUB_TOKEN. External fork PRs will need manual reviewer assignment.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
## Summary

Fixes a **Pwn Request** vulnerability in `.github/workflows/connector-dri-pr-reviewer.yml`. This is the same vulnerability class exploited in **CVE-2026-45321** (the TanStack supply chain attack on 2026-05-11).

## The Vulnerability

The workflow combined two ingredients that, together, allow arbitrary code execution from a fork PR with access to base-repo secrets:

1. **`pull_request_target` trigger** — runs with the base repo's secrets (`DOCS_GITHUB_TOKEN`) and write permissions.
2. **Checks out fork HEAD** — pulls in attacker-controlled code:

```yaml
- uses: actions/checkout@v4
  with:
    ref: ${{github.event.pull_request.head.ref}}
    repository: ${{github.event.pull_request.head.repo.full_name}}
```

3. **Subsequent step runs code from the fork** — `npm install js-yaml` runs after checkout, which executes any `postinstall` (or other lifecycle) scripts in a fork-controlled `package.json`.

### Attack scenario

1. Attacker forks `hasura/ddn-docs`.
2. Adds a malicious `package.json` with a `postinstall` script (e.g. exfiltrate `$DOCS_GITHUB_TOKEN` to an external endpoint).
3. Opens a PR touching any file under `docs/**/*.mdx` to trigger the workflow.
4. Workflow runs on the base repo, checks out attacker code, runs `npm install`, postinstall executes with the secret in scope.
5. Attacker now holds a token with `pull-requests: write` on the repo — and depending on `DOCS_GITHUB_TOKEN`'s broader scopes, potentially more.

This is exactly the pattern abused in CVE-2026-45321.

## The Fix

Add a job-level guard so the job only runs for PRs from the same repository (not forks):

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

External fork PRs will silently skip the job and will need manual DRI reviewer assignment, which is the correct tradeoff: untrusted code must not be executed in a context that holds repo secrets.

## Why this fix (vs alternatives)

- **Checking out base SHA instead of fork HEAD**: would defeat the purpose — the workflow needs to read the PR's changed MDX files to extract connector IDs.
- **Splitting into a `pull_request` + artifact pattern**: works but is a larger refactor. The `if:` guard is the minimal, well-understood mitigation documented by GitHub Security Lab for this class.
- **Removing `pull_request_target`**: would lose the ability to request reviewers from forks, but reviewer requests on fork PRs already weren't safely achievable without trusting fork code.

## References

- CVE-2026-45321 — TanStack supply chain attack (2026-05-11), same Pwn Request pattern
- GitHub Security Lab: "Keeping your GitHub Actions and workflows secure: Preventing pwn requests"
- PromptQL audit thread: https://console.hasura.io/project/hasuraql/promptql-playground/thread/756572bc-4187-4521-9fa2-90ca17fc498d

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: confirm a dummy fork PR shows the job as Skipped rather than executing
- [ ] After merge: confirm same-repo PRs touching `docs/**/*.mdx` still get DRIs assigned as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)