### PR TITLE
chore(images): migrate base images to private -stable aliases

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/ubuntu:22.04-stable
 
 RUN yes | unminimize
 


### PR DESCRIPTION
## Summary

Re-homes base images used in this repo to Hasura's private Artifact Registry `us-docker.pkg.dev/hasura-container-images/external-images`, using floating `-stable` aliases. These aliases are auto-advanced to the latest patched digest of the same version line, so patching happens automatically without a version bump.

Per Hasura policy, every container deployed in Hasura infra must be pulled from this private registry rather than upstream registries (Docker Hub, ghcr.io, gcr.io, quay.io, mirror.gcr.io, registry.k8s.io, public.ecr.aws). Upstream images are vendored there using a `preserve-source` path layout.

## Exact FROM swaps

### `Dockerfile.dev`
- `FROM ubuntu:22.04` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/ubuntu:22.04-stable`

## Notes

- This is part of an org-wide **Phase 1** migration: exact-match swaps only — same version/tag, no version bumps, no reformatting, no other lines touched.
- `git diff` shows only the single listed FROM line changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)